### PR TITLE
feat(ci): add script to ci

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,9 @@
+## Describe your changes
+
+
+## Checklist before requesting a review
+- Repo forked and branch created from `next` according to naming convention.
+- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
+- Relevant issues are linked in the PR description.
+- Tests added for new functionality.
+- Documentation/comments updated according to changes.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,66 @@
+name: CI
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, repoened, synchronize]
+
+jobs:
+  test:
+    name: Test Rust ${{matrix.toolchain}} on ${{matrix.os}}
+    runs-on: ${{matrix.os}}-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        toolchain: [stable, nightly]
+        os: [ubuntu]
+    steps:
+      - uses: actions/checkout@main
+      - name: Install rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{matrix.toolchain}}
+          override: true
+      - name: Test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@main
+      - name: Install minimal stable with clippy
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          components: clippy
+          override: true
+
+      - name: Clippy
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --all -- -D clippy::all -D warnings
+
+  rustfmt:
+    name: rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@main
+      - name: Install minimal stable with rustfmt
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          components: rustfmt
+          override: true
+
+      - name: rustfmt
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,108 @@
+# Contributing to Crypto
+
+#### First off, thanks for taking the time to contribute!
+
+We want to make contributing to this project as easy and transparent as possible, whether it's:
+
+- Reporting a [bug](https://github.com/0xPolygonMiden/crypto/issues/new)
+- Taking part in [discussions](https://github.com/0xPolygonMiden/crypto/discussions)
+- Submitting a [fix](https://github.com/0xPolygonMiden/crypto/pulls)
+- Proposing new [features](https://github.com/0xPolygonMiden/crypto/issues/new)
+
+&nbsp;
+
+## Flow
+We are using [Github Flow](https://docs.github.com/en/get-started/quickstart/github-flow), so all code changes happen through pull requests from a [forked repo](https://docs.github.com/en/get-started/quickstart/fork-a-repo).
+
+### Branching
+- The current active branch is `next`. Every branch with a fix/feature must be forked from `next`.
+
+- The branch name should contain a short issue/feature description separated with hyphens [(kebab-case)](https://en.wikipedia.org/wiki/Letter_case#Kebab_case). 
+
+    For example, if the issue title is `Fix functionality X in component Y` then the branch name will be something like: `fix-x-in-y`.
+
+- New branch should be rebased from `next` before submitting a PR in case there have been changes to avoid merge commits.
+i.e. this branches state:
+  ```
+          A---B---C fix-x-in-y
+         /
+    D---E---F---G next
+            |   |
+         (F, G) changes happened after `fix-x-in-y` forked
+  ```
+
+  should become this after rebase:
+
+
+  ```
+                  A'--B'--C' fix-x-in-y
+                 /
+    D---E---F---G next
+  ```
+
+
+  More about rebase [here](https://git-scm.com/docs/git-rebase) and [here](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase#:~:text=What%20is%20git%20rebase%3F,of%20a%20feature%20branching%20workflow.)
+
+
+### Commit messages
+- Commit messages should be written in a short, descriptive manner and be prefixed with tags for the change type and scope (if possible) according to the [semantic commit](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) scheme.
+For example, a new change to the AIR crate might have the following message: `feat(air): add constraints for the decoder`
+
+- Also squash commits to logically separated, distinguishable stages to keep git log clean:
+    ```
+    7hgf8978g9... Added A to X \
+                                \  (squash)
+    gh354354gh... oops, typo --- * ---------> 9fh1f51gh7... feat(X): add A && B
+                                /
+    85493g2458... Added B to X /
+
+
+    789fdfffdf... Fixed D in Y \
+                                \  (squash)
+    787g8fgf78... blah  blah --- * ---------> 4070df6f00... fix(Y): fixed D && C
+                                /
+    9080gf6567... Fixed C in Y /
+    ```
+
+### Code Style and Documentation
+- For documentation in the codebase, we follow the [rustdoc](https://doc.rust-lang.org/rust-by-example/meta/doc.html) convention with no more than 100 characters per line.
+- For code sections, we use code separators like the following to a width of 100 characters::
+    ```
+    // CODE SECTION HEADER
+    // ================================================================================
+    ```
+
+- [Rustfmt](https://github.com/rust-lang/rustfmt) and [Clippy](https://github.com/rust-lang/rust-clippy) linting is included in CI pipeline. Anyways it's prefferable to run linting locally before push:
+    ```
+    cargo fix --allow-staged --allow-dirty --all-targets --all-features; cargo fmt; cargo clippy --workspace --all-targets --all-features -- -D warnings
+    ```
+
+### Versioning
+We use [semver](https://semver.org/) naming convention.
+
+&nbsp;
+
+## Pre-PR checklist
+1. Repo forked and branch created from `next` according to the naming convention.
+2. Commit messages and code style follow conventions.
+3. Tests added for new functionality.
+4. Documentation/comments updated for all changes according to our documentation convention.
+5. Clippy and Rustfmt linting passed.
+6. New branch rebased from `next`.
+
+&nbsp;
+
+## Write bug reports with detail, background, and sample code
+
+**Great Bug Reports** tend to have:
+
+- A quick summary and/or background
+- Steps to reproduce
+- What you expected would happen
+- What actually happens
+- Notes (possibly including why you think this might be happening, or stuff you tried that didn't work)
+
+&nbsp;
+
+## Any contributions you make will be under the MIT Software License
+In short, when you submit code changes, your submissions are understood to be under the same [MIT License](http://choosealicense.com/licenses/mit/) that covers the project. Feel free to contact the maintainers if that's a concern.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,4 @@
+[workspace]
+members = [
+  "crypto"
+]

--- a/crypto/src/hash/mod.rs
+++ b/crypto/src/hash/mod.rs
@@ -11,7 +11,7 @@ pub type Digest = <Hasher as HashFn>::Digest;
 // ================================================================================================
 
 #[inline(always)]
-fn exp_acc<B: StarkField, const N: usize, const M: usize>(base: [B; N], tail: [B; N]) -> [B; N] {
+fn _exp_acc<B: StarkField, const N: usize, const M: usize>(base: [B; N], tail: [B; N]) -> [B; N] {
     let mut result = base;
     for _ in 0..M {
         result.iter_mut().for_each(|r| *r = r.square());

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -3,8 +3,8 @@ pub use winterfell::math::{
     ExtensionOf, FieldElement, StarkField,
 };
 
-pub(crate) mod hash;
-pub(crate) mod merkle;
+pub mod hash;
+pub mod merkle;
 
 // TYPE ALIASES
 // ================================================================================================


### PR DESCRIPTION
### feat(crypto): expose api modules

Currently the API modules are hidden to the crate scope.

In order to avoid global permissive allows, they can initially be
exported, and tweaked to local scopes as they get implemented, finalized
and tested.

Related to #3 

###  chore(workspace): add Cargo.toml with workspace setup

This commit introduces a workspace structure with a `Cargo.toml`.
Currently we have a single member `crypto`, but these can be added
incrementally in the future.

### chore(ci): add github ci script

This commit introduces a script that will enforce the following
constraints:

- Tests are successful
- Rustfmt is executed for every Rust source
- Clippy warnings are resolved

The same model of Miden VM is adopted here. However, `no-std` check
wasn't added because the library, as of the moment, doesn't implement
that.

closes #3 

###  chore(repo): add contributing guidelines

The contributing guidelines are defiend as standard for Miden VM and it
is desirable it is extended here.

If we use the guidelines from the beginning, we avoid future problems
related to big refactors and history migration.