### PR TITLE
Improve BLAKE3 sequential hashing performance

### DIFF
--- a/src/hash/blake/mod.rs
+++ b/src/hash/blake/mod.rs
@@ -276,13 +276,11 @@ where
     let digest = if Felt::IS_CANONICAL {
         blake3::hash(E::elements_as_bytes(elements))
     } else {
-        E::as_base_elements(elements)
-            .iter()
-            .fold(blake3::Hasher::new(), |mut hasher, felt| {
-                hasher.update(&felt.as_int().to_le_bytes());
-                hasher
-            })
-            .finalize()
+        let mut hasher = blake3::Hasher::new();
+        for element in E::as_base_elements(elements) {
+            hasher.update(&element.as_int().to_le_bytes());
+        }
+        hasher.finalize()
     };
     *shrink_bytes(&digest.into())
 }


### PR DESCRIPTION
This PR came about as a result of the discrepancy noticed in https://github.com/0xPolygonMiden/crypto/pull/26#issuecomment-1344540033. The surprising result is that changing from an iterator to a for loop led to over 4x improvement in sequential hashing of elements using BLAKE3. So, the new performance on my machine looks like 1.7us for hashing 100 elements (vs. 7us previously).

This performance is still lower than what I would have expected (i.g., I would have thought it would be around 1.2us) - but at least there might be a reasonable explanation for this now.

Separately, I noticed that there might be a small optimization opportunity in Winterfell. Specifically, in the [as_int()](https://github.com/novifinancial/winterfell/blob/main/math/src/field/f64/mod.rs#L229) we know that the value is a `u64` and therefore we might be able to simplify Montgomery reduction routine a bit.