### PR TITLE
Optimize BLAKE3 Sequential Hashing

### DIFF
--- a/src/hash/blake/mod.rs
+++ b/src/hash/blake/mod.rs
@@ -276,10 +276,15 @@ where
     let digest = if Felt::IS_CANONICAL {
         blake3::hash(E::elements_as_bytes(elements))
     } else {
-        let mut hasher = blake3::Hasher::new();
-        for element in E::as_base_elements(elements) {
-            hasher.update(&element.as_int().to_le_bytes());
+        let blen = elements.len() << 3;
+        let mut bytes = vec![0u8; blen];
+
+        for (idx, element) in E::as_base_elements(elements).iter().enumerate() {
+            bytes[idx * 8..(idx + 1) * 8].copy_from_slice(&element.as_int().to_le_bytes());
         }
+
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(&bytes);
         hasher.finalize()
     };
     *shrink_bytes(&digest.into())

--- a/src/hash/blake/mod.rs
+++ b/src/hash/blake/mod.rs
@@ -5,6 +5,7 @@ use core::{
     ops::Deref,
     slice::from_raw_parts,
 };
+use winter_utils::collections::Vec;
 
 #[cfg(test)]
 mod tests;
@@ -277,7 +278,12 @@ where
         blake3::hash(E::elements_as_bytes(elements))
     } else {
         let blen = elements.len() << 3;
-        let mut bytes = vec![0u8; blen];
+
+        let mut bytes = Vec::with_capacity(blen);
+        #[allow(clippy::uninit_vec)]
+        unsafe {
+            bytes.set_len(blen)
+        }
 
         for (idx, element) in E::as_base_elements(elements).iter().enumerate() {
             bytes[idx * 8..(idx + 1) * 8].copy_from_slice(&element.as_int().to_le_bytes());

--- a/src/hash/blake/mod.rs
+++ b/src/hash/blake/mod.rs
@@ -1,11 +1,12 @@
 use super::{Digest, ElementHasher, Felt, FieldElement, Hasher, StarkField};
-use crate::utils::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable};
+use crate::utils::{
+    uninit_vector, ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable,
+};
 use core::{
     mem::{size_of, transmute, transmute_copy},
     ops::Deref,
     slice::from_raw_parts,
 };
-use winter_utils::collections::Vec;
 
 #[cfg(test)]
 mod tests;
@@ -277,21 +278,15 @@ where
     let digest = if Felt::IS_CANONICAL {
         blake3::hash(E::elements_as_bytes(elements))
     } else {
-        let blen = elements.len() << 3;
+        let base_elements = E::as_base_elements(elements);
+        let blen = base_elements.len() << 3;
 
-        let mut bytes = Vec::with_capacity(blen);
-        #[allow(clippy::uninit_vec)]
-        unsafe {
-            bytes.set_len(blen)
-        }
-
-        for (idx, element) in E::as_base_elements(elements).iter().enumerate() {
+        let mut bytes = unsafe { uninit_vector(blen) };
+        for (idx, element) in base_elements.iter().enumerate() {
             bytes[idx * 8..(idx + 1) * 8].copy_from_slice(&element.as_int().to_le_bytes());
         }
 
-        let mut hasher = blake3::Hasher::new();
-        hasher.update(&bytes);
-        hasher.finalize()
+        blake3::hash(&bytes)
     };
     *shrink_bytes(&digest.into())
 }


### PR DESCRIPTION
- First convert all `Felts` to their canonical form and write into preallocated buffer, in little-endian byte order
- Finally hash all input bytes by calling BLAKE3 hasher **only once**

---

## When benchmarked on _Intel(R) Core(TM) i5-8279U CPU @ 2.40GHz_

At commit 9782992662c1c01e89d0c55de220a1235877abdc ( before )

<img width="696" alt="image" src="https://user-images.githubusercontent.com/45074836/206839569-bebbf20a-8a33-4bab-9b67-cde4439baff9.png">

At commit aa4e31369017c6093b171f4302c6908751b43575 ( after )

<img width="696" alt="image" src="https://user-images.githubusercontent.com/45074836/206839595-7844f606-8617-4eaa-83c5-4e91e1eafdcb.png">
