### PR TITLE
Domain separator during merge

### DIFF
--- a/src/hash/rpo/mod.rs
+++ b/src/hash/rpo/mod.rs
@@ -297,7 +297,7 @@ impl Rpo256 {
     // DOMAIN IDENTIFIER
     // --------------------------------------------------------------------------------------------
 
-    /// Returns a hash of two digests and a domain separator.
+    /// Returns a hash of two digests and a domain identifier.
     pub fn merge_in_domain(values: &[RpoDigest; 2], domain: Felt) -> RpoDigest {
         // initialize the state by copying the digest elements into the rate portion of the state
         // (8 total elements), and set the capacity elements to 0.

--- a/src/hash/rpo/mod.rs
+++ b/src/hash/rpo/mod.rs
@@ -294,6 +294,28 @@ impl Rpo256 {
         <Self as ElementHasher>::hash_elements(elements)
     }
 
+    // DOMAIN IDENTIFIER
+    // --------------------------------------------------------------------------------------------
+
+    /// Returns a hash of two digests and a domain separator.
+    pub fn merge_in_domain(values: &[RpoDigest; 2], domain: Felt) -> RpoDigest {
+        // initialize the state by copying the digest elements into the rate portion of the state
+        // (8 total elements), and set the capacity elements to 0.
+        let mut state = [ZERO; STATE_WIDTH];
+        let it = RpoDigest::digests_as_elements(values.iter());
+        for (i, v) in it.enumerate() {
+            state[RATE_RANGE.start + i] = *v;
+        }
+
+        // set the second capacity element to the domain value. The first capacity element is used
+        // for padding purposes.
+        state[CAPACITY_RANGE.start + 1] = domain;
+
+        // apply the RPO permutation and return the first four elements of the state
+        Self::apply_permutation(&mut state);
+        RpoDigest::new(state[DIGEST_RANGE].try_into().unwrap())
+    }
+
     // RESCUE PERMUTATION
     // --------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
## Describe your changes
This PR addresses #35. It introduces a new method `merge_in_domain` as mentioned by @bobbinth [here](https://github.com/0xPolygonMiden/crypto/issues/35#issuecomment-1380989610) when impl Rpo256.

## Checklist before requesting a review
- [X]  Repo forked and branch created from `next` according to naming convention.
- [X] Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- [X] Relevant issues are linked in the PR description.
- [X] Tests added for new functionality.
- [X] Documentation/comments updated according to changes.