### PR TITLE
Reexport publiccoin & publiccoinerror from winterfell

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,8 @@ pub mod merkle;
 // RE-EXPORTS
 // ================================================================================================
 
+pub use winter_crypto::{RandomCoin, RandomCoinError};
+
 pub use winter_math::{fields::f64::BaseElement as Felt, FieldElement, StarkField};
 
 pub mod utils {


### PR DESCRIPTION
## Describe your changes
This PR addresses #39. It reexports `PublicCoin` and `PublicCoinError` from winterfell.

## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.