### PR TITLE
Remove some of the undefined behavior from the merkle tree implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,10 @@ harness = false
 name = "smt"
 harness = false
 
+[[bench]]
+name = "merkle_tree"
+harness = false
+
 [features]
 default = ["blake3/default", "std", "winter_crypto/default", "winter_math/default", "winter_utils/default"]
 std = ["blake3/std", "winter_crypto/std", "winter_math/std", "winter_utils/std"]

--- a/benches/merkle_tree.rs
+++ b/benches/merkle_tree.rs
@@ -1,0 +1,21 @@
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use miden_crypto::{merkle::MerkleTree, Word};
+use rand_utils::rand_array;
+pub use winter_math::fields::f64::BaseElement as Felt;
+
+static BATCH_SIZES: [usize; 3] = [65536, 131072, 262144];
+
+pub fn merkle_tree_construction(c: &mut Criterion) {
+    let mut merkle_group = c.benchmark_group("MerkleTree");
+
+    for size in &BATCH_SIZES {
+        let data: Vec<Word> = (0..*size).map(|_| rand_array::<Felt, 4>()).collect();
+
+        merkle_group.bench_with_input(BenchmarkId::new("construction", size), &data, |b, i| {
+            b.iter(|| MerkleTree::new(i))
+        });
+    }
+}
+
+criterion_group!(merkle_tree, merkle_tree_construction);
+criterion_main!(merkle_tree);


### PR DESCRIPTION
## Describe your changes

This fixes some of the UB on the merkle tree implementation, the commit message has a few notes on the issues found (replicated below). The idea of these notes is to share some of the issues of writing unsafe code.

The final code still has some `unsafe` code, it was the best I could do and preserve the performance goals without breaking the existing behavior, but note there still may be issues that I'm unaware of.

<details><summary>commit message</summary>

```
This commit fixes some of the undefined behavior of the merkle tree implementation, it maintains the same behavior (as defined by the existing unit tests), and still uses some unsafe code, which **should** be correct.

The safety issues that I'm aware of are enlisted below:

1. `uninit_vector` did not satisfy the `set_len` safety requirement [1]:

> The elements at old_len..new_len **must** be initialized.

2. `uninit_vector` breaks the initialization-invariant and causes undefined behavior for types like `bool`:

    ```rust
    let v: Vec<bool> = uninit_vector(1);
    ```

As described on [2]:

> Similarly, entirely uninitialized memory may have any content, while a
> bool must always be true or false. Hence, creating an uninitialized bool
> is undefined behavior:

3. `uninit_vector` may hit undefined behavior for types with a `Drop`:

    ```rust
    let v: Vec<TypeWithDrop> = uninit_vector(1);
    panic!();
    ```

As describe on the nomicon reading uninitialized memory is UB [3]:

> All runtime-allocated memory in a Rust program begins its life as
> uninitialized. In this state the value of the memory is an indeterminate
> pile of bits that may or may not even reflect a valid state for the type
> that is supposed to inhabit that location of memory. Attempting to
> interpret this memory as a value of any type will cause Undefined
> Behavior. Do Not Do This.

4. The code breaks ownership rules of the language. The memory of the merkle tree has a mutable reference with `nodes` at the same time it has a immutable reference with `two_nodes`.

As describe in the language reference:

> Mutating immutable data. All data inside a const item is immutable.
> Moreover, all data reached through a shared reference or data owned by
> an immutable binding is immutable, unless that data is contained within
> an UnsafeCell<U>.

5. The memory is const cast among different types, and the language does not have data layout guarantees for these types of casts.

1- https://doc.rust-lang.org/std/vec/struct.Vec.html#method.set_len
2- https://doc.rust-lang.org/std/mem/union.MaybeUninit.html#initialization-invariant
3- https://doc.rust-lang.org/nomicon/uninitialized.html
4- https://doc.rust-lang.org/reference/behavior-considered-undefined.html
```

Edit: point `2` above is incorrect as long as the type is `Copy` and the memory is not read (it can be initialized with a write, and then it can be safely be read).

</details>

## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.