### PR TITLE
docs: mention tree form order of NodeIndex docs

### DIFF
--- a/src/merkle/index.rs
+++ b/src/merkle/index.rs
@@ -4,6 +4,9 @@ use super::{Felt, MerkleError, RpoDigest, StarkField};
 // ================================================================================================
 
 /// A Merkle tree address to an arbitrary node.
+///
+/// The position is relative to a tree in level order, where for a given depth `d` elements are
+/// numbered from $0..2^d$.
 #[derive(Debug, Default, Copy, Clone, Eq, PartialEq, PartialOrd, Ord, Hash)]
 pub struct NodeIndex {
     depth: u8,


### PR DESCRIPTION
## Describe your changes

While working on https://github.com/0xPolygonMiden/crypto/pull/67 I looked into using `NodeIndex`, however this structure uses level form, whereas the MMR uses postorder form, so it couldn't be used.

This just adds a bit of documentation for that detail, hopefully making that easier for the next person to spot.

## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.