### PR TITLE
Node index check value fits in depth

### DIFF
--- a/benches/store.rs
+++ b/benches/store.rs
@@ -1,5 +1,5 @@
 use criterion::{black_box, criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion};
-use miden_crypto::merkle::{MerkleStore, MerkleTree, NodeIndex, SimpleSmt};
+use miden_crypto::merkle::{MerkleError, MerkleStore, MerkleTree, NodeIndex, SimpleSmt};
 use miden_crypto::Word;
 use miden_crypto::{hash::rpo::RpoDigest, Felt};
 use rand_utils::{rand_array, rand_value};
@@ -39,7 +39,7 @@ fn get_empty_leaf_simplesmt(c: &mut Criterion) {
     group.bench_function(BenchmarkId::new("SimpleSmt", depth), |b| {
         b.iter_batched(
             || random_index(size),
-            |value| black_box(smt.get_node(&NodeIndex::new(depth, value))),
+            |value| black_box(smt.get_node(&NodeIndex::new_checked(depth, value)?)),
             BatchSize::SmallInput,
         )
     });
@@ -47,7 +47,7 @@ fn get_empty_leaf_simplesmt(c: &mut Criterion) {
     group.bench_function(BenchmarkId::new("MerkleStore", depth), |b| {
         b.iter_batched(
             || random_index(size),
-            |value| black_box(store.get_node(root, NodeIndex::new(depth, value))),
+            |value| black_box(store.get_node(root, NodeIndex::new_checked(depth, value)?)),
             BatchSize::SmallInput,
         )
     });
@@ -73,7 +73,7 @@ fn get_leaf_merkletree(c: &mut Criterion) {
         group.bench_function(BenchmarkId::new("MerkleTree", size), |b| {
             b.iter_batched(
                 || random_index(size_u64),
-                |value| black_box(mtree.get_node(NodeIndex::new(depth, value))),
+                |value| black_box(mtree.get_node(NodeIndex::new_checked(depth, value)?)),
                 BatchSize::SmallInput,
             )
         });
@@ -81,7 +81,7 @@ fn get_leaf_merkletree(c: &mut Criterion) {
         group.bench_function(BenchmarkId::new("MerkleStore", size), |b| {
             b.iter_batched(
                 || random_index(size_u64),
-                |value| black_box(store.get_node(root, NodeIndex::new(depth, value))),
+                |value| black_box(store.get_node(root, NodeIndex::new_checked(depth, value)?)),
                 BatchSize::SmallInput,
             )
         });
@@ -117,7 +117,7 @@ fn get_leaf_simplesmt(c: &mut Criterion) {
         group.bench_function(BenchmarkId::new("SimpleSmt", size), |b| {
             b.iter_batched(
                 || random_index(size_u64),
-                |value| black_box(smt.get_node(&NodeIndex::new(depth, value))),
+                |value| black_box(smt.get_node(&NodeIndex::new_checked(depth, value)?)),
                 BatchSize::SmallInput,
             )
         });
@@ -125,7 +125,7 @@ fn get_leaf_simplesmt(c: &mut Criterion) {
         group.bench_function(BenchmarkId::new("MerkleStore", size), |b| {
             b.iter_batched(
                 || random_index(size_u64),
-                |value| black_box(store.get_node(root, NodeIndex::new(depth, value))),
+                |value| black_box(store.get_node(root, NodeIndex::new_checked(depth, value)?)),
                 BatchSize::SmallInput,
             )
         });
@@ -150,7 +150,7 @@ fn get_node_of_empty_simplesmt(c: &mut Criterion) {
     group.bench_function(BenchmarkId::new("SimpleSmt", depth), |b| {
         b.iter_batched(
             || random_index(size),
-            |value| black_box(smt.get_node(&NodeIndex::new(half_depth, value))),
+            |value| black_box(smt.get_node(&NodeIndex::new_checked(half_depth, value)?)),
             BatchSize::SmallInput,
         )
     });
@@ -158,7 +158,7 @@ fn get_node_of_empty_simplesmt(c: &mut Criterion) {
     group.bench_function(BenchmarkId::new("MerkleStore", depth), |b| {
         b.iter_batched(
             || random_index(size),
-            |value| black_box(store.get_node(root, NodeIndex::new(half_depth, value))),
+            |value| black_box(store.get_node(root, NodeIndex::new_checked(half_depth, value)?)),
             BatchSize::SmallInput,
         )
     });
@@ -185,7 +185,7 @@ fn get_node_merkletree(c: &mut Criterion) {
         group.bench_function(BenchmarkId::new("MerkleTree", size), |b| {
             b.iter_batched(
                 || random_index(size_u64),
-                |value| black_box(mtree.get_node(NodeIndex::new(half_depth, value))),
+                |value| black_box(mtree.get_node(NodeIndex::new_checked(half_depth, value)?)),
                 BatchSize::SmallInput,
             )
         });
@@ -193,7 +193,7 @@ fn get_node_merkletree(c: &mut Criterion) {
         group.bench_function(BenchmarkId::new("MerkleStore", size), |b| {
             b.iter_batched(
                 || random_index(size_u64),
-                |value| black_box(store.get_node(root, NodeIndex::new(half_depth, value))),
+                |value| black_box(store.get_node(root, NodeIndex::new_checked(half_depth, value)?)),
                 BatchSize::SmallInput,
             )
         });
@@ -230,7 +230,7 @@ fn get_node_simplesmt(c: &mut Criterion) {
         group.bench_function(BenchmarkId::new("SimpleSmt", size), |b| {
             b.iter_batched(
                 || random_index(size_u64),
-                |value| black_box(smt.get_node(&NodeIndex::new(half_depth, value))),
+                |value| black_box(smt.get_node(&NodeIndex::new_checked(half_depth, value)?)),
                 BatchSize::SmallInput,
             )
         });
@@ -238,7 +238,7 @@ fn get_node_simplesmt(c: &mut Criterion) {
         group.bench_function(BenchmarkId::new("MerkleStore", size), |b| {
             b.iter_batched(
                 || random_index(size_u64),
-                |value| black_box(store.get_node(root, NodeIndex::new(half_depth, value))),
+                |value| black_box(store.get_node(root, NodeIndex::new_checked(half_depth, value)?)),
                 BatchSize::SmallInput,
             )
         });
@@ -265,7 +265,7 @@ fn get_leaf_path_merkletree(c: &mut Criterion) {
         group.bench_function(BenchmarkId::new("MerkleTree", size), |b| {
             b.iter_batched(
                 || random_index(size_u64),
-                |value| black_box(mtree.get_path(NodeIndex::new(depth, value))),
+                |value| black_box(mtree.get_path(NodeIndex::new_checked(depth, value)?)),
                 BatchSize::SmallInput,
             )
         });
@@ -273,7 +273,7 @@ fn get_leaf_path_merkletree(c: &mut Criterion) {
         group.bench_function(BenchmarkId::new("MerkleStore", size), |b| {
             b.iter_batched(
                 || random_index(size_u64),
-                |value| black_box(store.get_path(root, NodeIndex::new(depth, value))),
+                |value| black_box(store.get_path(root, NodeIndex::new_checked(depth, value)?)),
                 BatchSize::SmallInput,
             )
         });
@@ -309,7 +309,7 @@ fn get_leaf_path_simplesmt(c: &mut Criterion) {
         group.bench_function(BenchmarkId::new("SimpleSmt", size), |b| {
             b.iter_batched(
                 || random_index(size_u64),
-                |value| black_box(smt.get_path(NodeIndex::new(depth, value))),
+                |value| black_box(smt.get_path(NodeIndex::new_checked(depth, value)?)),
                 BatchSize::SmallInput,
             )
         });
@@ -317,7 +317,7 @@ fn get_leaf_path_simplesmt(c: &mut Criterion) {
         group.bench_function(BenchmarkId::new("MerkleStore", size), |b| {
             b.iter_batched(
                 || random_index(size_u64),
-                |value| black_box(store.get_path(root, NodeIndex::new(depth, value))),
+                |value| black_box(store.get_path(root, NodeIndex::new_checked(depth, value)?)),
                 BatchSize::SmallInput,
             )
         });
@@ -428,10 +428,10 @@ fn update_leaf_merkletree(c: &mut Criterion) {
                     // the old root and adds the new one. Here we update the root to have a fair
                     // comparison
                     store_root = store
-                        .set_node(root, NodeIndex::new(depth, index), value)
+                        .set_node(root, NodeIndex::new_checked(depth, index)?, value)
                         .unwrap()
                         .root;
-                    black_box(store_root)
+                    black_box(Ok::<Word, MerkleError>(store_root))
                 },
                 BatchSize::SmallInput,
             )
@@ -482,10 +482,10 @@ fn update_leaf_simplesmt(c: &mut Criterion) {
                     // the old root and adds the new one. Here we update the root to have a fair
                     // comparison
                     store_root = store
-                        .set_node(root, NodeIndex::new(depth, index), value)
+                        .set_node(root, NodeIndex::new_checked(depth, index)?, value)
                         .unwrap()
                         .root;
-                    black_box(store_root)
+                    black_box(Ok::<Word, MerkleError>(store_root))
                 },
                 BatchSize::SmallInput,
             )

--- a/src/merkle/index.rs
+++ b/src/merkle/index.rs
@@ -4,10 +4,21 @@ use crate::bit::BitIterator;
 // NODE INDEX
 // ================================================================================================
 
-/// A Merkle tree address to an arbitrary node.
+/// Address to an arbitrary node in a binary tree using level order form.
 ///
-/// The position is relative to a tree in level order, where for a given depth `d` elements are
-/// numbered from $0..2^d$.
+/// The position is represented by the pair `(depth, pos)`, where for a given depth `d` elements
+/// are numbered from $0..(2^d)-1$. Example:
+///
+/// ```ignore
+/// depth
+/// 0             0
+/// 1         0        1
+/// 2      0    1    2    3
+/// 3     0 1  2 3  4 5  6 7
+/// ```
+///
+/// The root is represented by the pair $(0, 0)$, its left child is $(1, 0)$ and its right child
+/// $(1, 1)$.
 #[derive(Debug, Default, Copy, Clone, Eq, PartialEq, PartialOrd, Ord, Hash)]
 pub struct NodeIndex {
     depth: u8,

--- a/src/merkle/merkle_tree.rs
+++ b/src/merkle/merkle_tree.rs
@@ -125,7 +125,7 @@ impl MerkleTree {
     /// Returns an error if the specified index value is not a valid leaf value for this tree.
     pub fn update_leaf<'a>(&'a mut self, index_value: u64, value: Word) -> Result<(), MerkleError> {
         let depth = self.depth();
-        let mut index = NodeIndex::new(depth, index_value);
+        let mut index = NodeIndex::new_checked(depth, index_value)?;
         if !index.is_valid() {
             return Err(MerkleError::InvalidIndex(index));
         }
@@ -169,7 +169,7 @@ pub fn tree_to_text(tree: &MerkleTree) -> Result<String, fmt::Error> {
     for d in 1..=tree.depth() {
         let entries = 2u64.pow(d.into());
         for i in 0..entries {
-            let index = NodeIndex::new(d, i);
+            let index = NodeIndex::new_checked(d, i).expect("Only valid indexes must be created");
 
             let node = tree
                 .get_node(index)
@@ -254,24 +254,26 @@ mod tests {
     }
 
     #[test]
-    fn get_leaf() {
+    fn get_leaf() -> Result<(), MerkleError> {
         let tree = super::MerkleTree::new(LEAVES4.to_vec()).unwrap();
 
         // check depth 2
-        assert_eq!(LEAVES4[0], tree.get_node(NodeIndex::new(2, 0)).unwrap());
-        assert_eq!(LEAVES4[1], tree.get_node(NodeIndex::new(2, 1)).unwrap());
-        assert_eq!(LEAVES4[2], tree.get_node(NodeIndex::new(2, 2)).unwrap());
-        assert_eq!(LEAVES4[3], tree.get_node(NodeIndex::new(2, 3)).unwrap());
+        assert_eq!(LEAVES4[0], tree.get_node(NodeIndex::new_checked(2, 0)?)?);
+        assert_eq!(LEAVES4[1], tree.get_node(NodeIndex::new_checked(2, 1)?)?);
+        assert_eq!(LEAVES4[2], tree.get_node(NodeIndex::new_checked(2, 2)?)?);
+        assert_eq!(LEAVES4[3], tree.get_node(NodeIndex::new_checked(2, 3)?)?);
 
         // check depth 1
         let (_, node2, node3) = compute_internal_nodes();
 
-        assert_eq!(node2, tree.get_node(NodeIndex::new(1, 0)).unwrap());
-        assert_eq!(node3, tree.get_node(NodeIndex::new(1, 1)).unwrap());
+        assert_eq!(node2, tree.get_node(NodeIndex::new_checked(1, 0)?).unwrap());
+        assert_eq!(node3, tree.get_node(NodeIndex::new_checked(1, 1)?).unwrap());
+
+        Ok(())
     }
 
     #[test]
-    fn get_path() {
+    fn get_path() -> Result<(), MerkleError> {
         let tree = super::MerkleTree::new(LEAVES4.to_vec()).unwrap();
 
         let (_, node2, node3) = compute_internal_nodes();
@@ -279,24 +281,26 @@ mod tests {
         // check depth 2
         assert_eq!(
             vec![LEAVES4[1], node3],
-            *tree.get_path(NodeIndex::new(2, 0)).unwrap()
+            *tree.get_path(NodeIndex::new_checked(2, 0)?)?
         );
         assert_eq!(
             vec![LEAVES4[0], node3],
-            *tree.get_path(NodeIndex::new(2, 1)).unwrap()
+            *tree.get_path(NodeIndex::new_checked(2, 1)?)?
         );
         assert_eq!(
             vec![LEAVES4[3], node2],
-            *tree.get_path(NodeIndex::new(2, 2)).unwrap()
+            *tree.get_path(NodeIndex::new_checked(2, 2)?)?
         );
         assert_eq!(
             vec![LEAVES4[2], node2],
-            *tree.get_path(NodeIndex::new(2, 3)).unwrap()
+            *tree.get_path(NodeIndex::new_checked(2, 3)?)?
         );
 
         // check depth 1
-        assert_eq!(vec![node3], *tree.get_path(NodeIndex::new(1, 0)).unwrap());
-        assert_eq!(vec![node2], *tree.get_path(NodeIndex::new(1, 1)).unwrap());
+        assert_eq!(vec![node3], *tree.get_path(NodeIndex::new_checked(1, 0)?)?);
+        assert_eq!(vec![node2], *tree.get_path(NodeIndex::new_checked(1, 1)?)?);
+
+        Ok(())
     }
 
     #[test]

--- a/src/merkle/mmr/accumulator.rs
+++ b/src/merkle/mmr/accumulator.rs
@@ -1,4 +1,5 @@
 use super::{super::Vec, MmrProof, Rpo256, Word};
+use crate::merkle::MerkleError;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct MmrPeaks {
@@ -35,7 +36,7 @@ impl MmrPeaks {
         Rpo256::hash_elements(&self.peaks.as_slice().concat()).into()
     }
 
-    pub fn verify(&self, value: Word, opening: MmrProof) -> bool {
+    pub fn verify(&self, value: Word, opening: MmrProof) -> Result<bool, MerkleError> {
         let root = &self.peaks[opening.peak_index()];
         opening
             .merkle_path

--- a/src/merkle/mmr/tests.rs
+++ b/src/merkle/mmr/tests.rs
@@ -212,7 +212,7 @@ fn test_mmr_open() {
     assert_eq!(opening.forest, mmr.forest);
     assert_eq!(opening.position, 6);
     assert!(
-        mmr.accumulator().verify(LEAVES[6], opening),
+        mmr.accumulator().verify(LEAVES[6], opening).unwrap(),
         "MmrProof should be valid for the current accumulator."
     );
 
@@ -225,7 +225,7 @@ fn test_mmr_open() {
     assert_eq!(opening.forest, mmr.forest);
     assert_eq!(opening.position, 5);
     assert!(
-        mmr.accumulator().verify(LEAVES[5], opening),
+        mmr.accumulator().verify(LEAVES[5], opening).unwrap(),
         "MmrProof should be valid for the current accumulator."
     );
 
@@ -237,7 +237,7 @@ fn test_mmr_open() {
     assert_eq!(opening.forest, mmr.forest);
     assert_eq!(opening.position, 4);
     assert!(
-        mmr.accumulator().verify(LEAVES[4], opening),
+        mmr.accumulator().verify(LEAVES[4], opening).unwrap(),
         "MmrProof should be valid for the current accumulator."
     );
 
@@ -250,7 +250,7 @@ fn test_mmr_open() {
     assert_eq!(opening.forest, mmr.forest);
     assert_eq!(opening.position, 3);
     assert!(
-        mmr.accumulator().verify(LEAVES[3], opening),
+        mmr.accumulator().verify(LEAVES[3], opening).unwrap(),
         "MmrProof should be valid for the current accumulator."
     );
 
@@ -262,7 +262,7 @@ fn test_mmr_open() {
     assert_eq!(opening.forest, mmr.forest);
     assert_eq!(opening.position, 2);
     assert!(
-        mmr.accumulator().verify(LEAVES[2], opening),
+        mmr.accumulator().verify(LEAVES[2], opening).unwrap(),
         "MmrProof should be valid for the current accumulator."
     );
 
@@ -274,7 +274,7 @@ fn test_mmr_open() {
     assert_eq!(opening.forest, mmr.forest);
     assert_eq!(opening.position, 1);
     assert!(
-        mmr.accumulator().verify(LEAVES[1], opening),
+        mmr.accumulator().verify(LEAVES[1], opening).unwrap(),
         "MmrProof should be valid for the current accumulator."
     );
 
@@ -286,7 +286,7 @@ fn test_mmr_open() {
     assert_eq!(opening.forest, mmr.forest);
     assert_eq!(opening.position, 0);
     assert!(
-        mmr.accumulator().verify(LEAVES[0], opening),
+        mmr.accumulator().verify(LEAVES[0], opening).unwrap(),
         "MmrProof should be valid for the current accumulator."
     );
 }

--- a/src/merkle/mod.rs
+++ b/src/merkle/mod.rs
@@ -41,6 +41,7 @@ pub enum MerkleError {
     DepthTooSmall(u8),
     DepthTooBig(u64),
     NodeNotInStore(Word, NodeIndex),
+    ValueTooBig { depth: u8, value: u64 },
     NumLeavesNotPowerOfTwo(usize),
     InvalidIndex(NodeIndex),
     InvalidDepth { expected: u8, provided: u8 },
@@ -57,6 +58,7 @@ impl fmt::Display for MerkleError {
             ConflictingRoots(roots) => write!(f, "the merkle paths roots do not match {roots:?}"),
             DepthTooSmall(depth) => write!(f, "the provided depth {depth} is too small"),
             DepthTooBig(depth) => write!(f, "the provided depth {depth} is too big"),
+            ValueTooBig{depth, value} => write!(f, "the provided pos {value} is too big for the depth {depth}"),
             NumLeavesNotPowerOfTwo(leaves) => {
                 write!(f, "the leaves count {leaves} is not a power of 2")
             }

--- a/src/merkle/path.rs
+++ b/src/merkle/path.rs
@@ -1,4 +1,4 @@
-use super::{vec, NodeIndex, Rpo256, Vec, Word};
+use super::{vec, MerkleError, NodeIndex, Rpo256, Vec, Word};
 use core::ops::{Deref, DerefMut};
 
 // MERKLE PATH
@@ -23,14 +23,15 @@ impl MerklePath {
     // --------------------------------------------------------------------------------------------
 
     /// Computes the merkle root for this opening.
-    pub fn compute_root(&self, index_value: u64, node: Word) -> Word {
-        let mut index = NodeIndex::new(self.depth(), index_value);
-        self.nodes.iter().copied().fold(node, |node, sibling| {
+    pub fn compute_root(&self, index_value: u64, node: Word) -> Result<Word, MerkleError> {
+        let mut index = NodeIndex::new_checked(self.depth(), index_value)?;
+        let word = self.nodes.iter().copied().fold(node, |node, sibling| {
             // compute the node and move to the next iteration.
             let input = index.build_node(node.into(), sibling.into());
             index.move_up();
             Rpo256::merge(&input).into()
-        })
+        });
+        Ok(word)
     }
 
     /// Returns the depth in which this Merkle path proof is valid.
@@ -41,8 +42,8 @@ impl MerklePath {
     /// Verifies the Merkle opening proof towards the provided root.
     ///
     /// Returns `true` if `node` exists at `index` in a Merkle tree with `root`.
-    pub fn verify(&self, index: u64, node: Word, root: &Word) -> bool {
-        root == &self.compute_root(index, node)
+    pub fn verify(&self, index: u64, node: Word, root: &Word) -> Result<bool, MerkleError> {
+        self.compute_root(index, node).map(|v| v == *root)
     }
 }
 

--- a/src/merkle/store/tests.rs
+++ b/src/merkle/store/tests.rs
@@ -22,12 +22,12 @@ fn test_root_not_in_store() -> Result<(), MerkleError> {
     let mtree = MerkleTree::new(LEAVES4.to_vec())?;
     let store = MerkleStore::default().with_merkle_tree(LEAVES4)?;
     assert_eq!(
-        store.get_node(LEAVES4[0], NodeIndex::new(mtree.depth(), 0)),
+        store.get_node(LEAVES4[0], NodeIndex::new_checked(mtree.depth(), 0)?),
         Err(MerkleError::RootNotInStore(LEAVES4[0])),
         "Leaf 0 is not a root"
     );
     assert_eq!(
-        store.get_path(LEAVES4[0], NodeIndex::new(mtree.depth(), 0)),
+        store.get_path(LEAVES4[0], NodeIndex::new_checked(mtree.depth(), 0)?),
         Err(MerkleError::RootNotInStore(LEAVES4[0])),
         "Leaf 0 is not a root"
     );
@@ -45,22 +45,22 @@ fn test_merkle_tree() -> Result<(), MerkleError> {
     // STORE LEAVES ARE CORRECT ==============================================================
     // checks the leaves in the store corresponds to the expected values
     assert_eq!(
-        store.get_node(mtree.root(), NodeIndex::new(mtree.depth(), 0)),
+        store.get_node(mtree.root(), NodeIndex::new_checked(mtree.depth(), 0)?),
         Ok(LEAVES4[0]),
         "node 0 must be in the tree"
     );
     assert_eq!(
-        store.get_node(mtree.root(), NodeIndex::new(mtree.depth(), 1)),
+        store.get_node(mtree.root(), NodeIndex::new_checked(mtree.depth(), 1)?),
         Ok(LEAVES4[1]),
         "node 1 must be in the tree"
     );
     assert_eq!(
-        store.get_node(mtree.root(), NodeIndex::new(mtree.depth(), 2)),
+        store.get_node(mtree.root(), NodeIndex::new_checked(mtree.depth(), 2)?),
         Ok(LEAVES4[2]),
         "node 2 must be in the tree"
     );
     assert_eq!(
-        store.get_node(mtree.root(), NodeIndex::new(mtree.depth(), 3)),
+        store.get_node(mtree.root(), NodeIndex::new_checked(mtree.depth(), 3)?),
         Ok(LEAVES4[3]),
         "node 3 must be in the tree"
     );
@@ -68,76 +68,76 @@ fn test_merkle_tree() -> Result<(), MerkleError> {
     // STORE LEAVES MATCH TREE ===============================================================
     // sanity check the values returned by the store and the tree
     assert_eq!(
-        mtree.get_node(NodeIndex::new(mtree.depth(), 0)),
-        store.get_node(mtree.root(), NodeIndex::new(mtree.depth(), 0)),
+        mtree.get_node(NodeIndex::new_checked(mtree.depth(), 0)?),
+        store.get_node(mtree.root(), NodeIndex::new_checked(mtree.depth(), 0)?),
         "node 0 must be the same for both MerkleTree and MerkleStore"
     );
     assert_eq!(
-        mtree.get_node(NodeIndex::new(mtree.depth(), 1)),
-        store.get_node(mtree.root(), NodeIndex::new(mtree.depth(), 1)),
+        mtree.get_node(NodeIndex::new_checked(mtree.depth(), 1)?),
+        store.get_node(mtree.root(), NodeIndex::new_checked(mtree.depth(), 1)?),
         "node 1 must be the same for both MerkleTree and MerkleStore"
     );
     assert_eq!(
-        mtree.get_node(NodeIndex::new(mtree.depth(), 2)),
-        store.get_node(mtree.root(), NodeIndex::new(mtree.depth(), 2)),
+        mtree.get_node(NodeIndex::new_checked(mtree.depth(), 2)?),
+        store.get_node(mtree.root(), NodeIndex::new_checked(mtree.depth(), 2)?),
         "node 2 must be the same for both MerkleTree and MerkleStore"
     );
     assert_eq!(
-        mtree.get_node(NodeIndex::new(mtree.depth(), 3)),
-        store.get_node(mtree.root(), NodeIndex::new(mtree.depth(), 3)),
+        mtree.get_node(NodeIndex::new_checked(mtree.depth(), 3)?),
+        store.get_node(mtree.root(), NodeIndex::new_checked(mtree.depth(), 3)?),
         "node 3 must be the same for both MerkleTree and MerkleStore"
     );
 
     // STORE MERKLE PATH MATCHS ==============================================================
     // assert the merkle path returned by the store is the same as the one in the tree
     let result = store
-        .get_path(mtree.root(), NodeIndex::new(mtree.depth(), 0))
+        .get_path(mtree.root(), NodeIndex::new_checked(mtree.depth(), 0)?)
         .unwrap();
     assert_eq!(
         LEAVES4[0], result.value,
         "Value for merkle path at index 0 must match leaf value"
     );
     assert_eq!(
-        mtree.get_path(NodeIndex::new(mtree.depth(), 0)),
+        mtree.get_path(NodeIndex::new_checked(mtree.depth(), 0)?),
         Ok(result.path),
         "merkle path for index 0 must be the same for the MerkleTree and MerkleStore"
     );
 
     let result = store
-        .get_path(mtree.root(), NodeIndex::new(mtree.depth(), 1))
+        .get_path(mtree.root(), NodeIndex::new_checked(mtree.depth(), 1)?)
         .unwrap();
     assert_eq!(
         LEAVES4[1], result.value,
         "Value for merkle path at index 0 must match leaf value"
     );
     assert_eq!(
-        mtree.get_path(NodeIndex::new(mtree.depth(), 1)),
+        mtree.get_path(NodeIndex::new_checked(mtree.depth(), 1)?),
         Ok(result.path),
         "merkle path for index 1 must be the same for the MerkleTree and MerkleStore"
     );
 
     let result = store
-        .get_path(mtree.root(), NodeIndex::new(mtree.depth(), 2))
+        .get_path(mtree.root(), NodeIndex::new_checked(mtree.depth(), 2)?)
         .unwrap();
     assert_eq!(
         LEAVES4[2], result.value,
         "Value for merkle path at index 0 must match leaf value"
     );
     assert_eq!(
-        mtree.get_path(NodeIndex::new(mtree.depth(), 2)),
+        mtree.get_path(NodeIndex::new_checked(mtree.depth(), 2)?),
         Ok(result.path),
         "merkle path for index 0 must be the same for the MerkleTree and MerkleStore"
     );
 
     let result = store
-        .get_path(mtree.root(), NodeIndex::new(mtree.depth(), 3))
+        .get_path(mtree.root(), NodeIndex::new_checked(mtree.depth(), 3)?)
         .unwrap();
     assert_eq!(
         LEAVES4[3], result.value,
         "Value for merkle path at index 0 must match leaf value"
     );
     assert_eq!(
-        mtree.get_path(NodeIndex::new(mtree.depth(), 3)),
+        mtree.get_path(NodeIndex::new_checked(mtree.depth(), 3)?),
         Ok(result.path),
         "merkle path for index 0 must be the same for the MerkleTree and MerkleStore"
     );
@@ -146,17 +146,21 @@ fn test_merkle_tree() -> Result<(), MerkleError> {
 }
 
 #[test]
-fn test_empty_roots() {
+fn test_empty_roots() -> Result<(), MerkleError> {
     let store = MerkleStore::default();
     let mut root = RpoDigest::new(EMPTY);
 
     for depth in 0..255 {
         root = Rpo256::merge(&[root; 2]);
         assert!(
-            store.get_node(root.into(), NodeIndex::new(0, 0)).is_ok(),
+            store
+                .get_node(root.into(), NodeIndex::new_checked(0, 0)?)
+                .is_ok(),
             "The root of the empty tree of depth {depth} must be registered"
         );
     }
+
+    Ok(())
 }
 
 #[test]
@@ -169,7 +173,7 @@ fn test_leaf_paths_for_empty_trees() -> Result<(), MerkleError> {
     for depth in 1..64 {
         let smt = SimpleSmt::new(depth)?;
 
-        let index = NodeIndex::new(depth, 0);
+        let index = NodeIndex::new_checked(depth, 0)?;
         let store_path = store.get_path(smt.root(), index)?;
         let smt_path = smt.get_path(index)?;
         assert_eq!(
@@ -181,7 +185,7 @@ fn test_leaf_paths_for_empty_trees() -> Result<(), MerkleError> {
             "the returned merkle path does not match the computed values"
         );
         assert_eq!(
-            store_path.path.compute_root(depth.into(), EMPTY),
+            store_path.path.compute_root(depth.into(), EMPTY)?,
             smt.root(),
             "computed root from the path must match the empty tree root"
         );
@@ -191,13 +195,15 @@ fn test_leaf_paths_for_empty_trees() -> Result<(), MerkleError> {
 }
 
 #[test]
-fn test_get_invalid_node() {
+fn test_get_invalid_node() -> Result<(), MerkleError> {
     let mut store = MerkleStore::default();
     let mtree = MerkleTree::new(LEAVES4.to_vec()).expect("creating a merkle tree must work");
     store
         .add_merkle_tree(LEAVES4.to_vec())
         .expect("adding a merkle tree to the store must work");
-    let _ = store.get_node(mtree.root(), NodeIndex::new(mtree.depth(), 3));
+    let _ = store.get_node(mtree.root(), NodeIndex::new_checked(mtree.depth(), 3)?);
+
+    Ok(())
 }
 
 #[test]
@@ -211,14 +217,14 @@ fn test_add_sparse_merkle_tree_one_level() -> Result<(), MerkleError> {
         .with_leaves(keys2.into_iter().zip(leaves2.into_iter()))
         .unwrap();
 
-    let idx = NodeIndex::new(1, 0);
+    let idx = NodeIndex::new_checked(1, 0)?;
     assert_eq!(smt.get_node(&idx).unwrap(), leaves2[0]);
     assert_eq!(
         store.get_node(smt.root(), idx).unwrap(),
         smt.get_node(&idx).unwrap()
     );
 
-    let idx = NodeIndex::new(1, 1);
+    let idx = NodeIndex::new_checked(1, 1)?;
     assert_eq!(smt.get_node(&idx).unwrap(), leaves2[1]);
     assert_eq!(
         store.get_node(smt.root(), idx).unwrap(),
@@ -244,27 +250,27 @@ fn test_sparse_merkle_tree() -> Result<(), MerkleError> {
     // STORE LEAVES ARE CORRECT ==============================================================
     // checks the leaves in the store corresponds to the expected values
     assert_eq!(
-        store.get_node(smt.root(), NodeIndex::new(smt.depth(), 0)),
+        store.get_node(smt.root(), NodeIndex::new_checked(smt.depth(), 0)?),
         Ok(LEAVES4[0]),
         "node 0 must be in the tree"
     );
     assert_eq!(
-        store.get_node(smt.root(), NodeIndex::new(smt.depth(), 1)),
+        store.get_node(smt.root(), NodeIndex::new_checked(smt.depth(), 1)?),
         Ok(LEAVES4[1]),
         "node 1 must be in the tree"
     );
     assert_eq!(
-        store.get_node(smt.root(), NodeIndex::new(smt.depth(), 2)),
+        store.get_node(smt.root(), NodeIndex::new_checked(smt.depth(), 2)?),
         Ok(LEAVES4[2]),
         "node 2 must be in the tree"
     );
     assert_eq!(
-        store.get_node(smt.root(), NodeIndex::new(smt.depth(), 3)),
+        store.get_node(smt.root(), NodeIndex::new_checked(smt.depth(), 3)?),
         Ok(LEAVES4[3]),
         "node 3 must be in the tree"
     );
     assert_eq!(
-        store.get_node(smt.root(), NodeIndex::new(smt.depth(), 4)),
+        store.get_node(smt.root(), NodeIndex::new_checked(smt.depth(), 4)?),
         Ok(EMPTY),
         "unmodified node 4 must be ZERO"
     );
@@ -272,94 +278,94 @@ fn test_sparse_merkle_tree() -> Result<(), MerkleError> {
     // STORE LEAVES MATCH TREE ===============================================================
     // sanity check the values returned by the store and the tree
     assert_eq!(
-        smt.get_node(&NodeIndex::new(smt.depth(), 0)),
-        store.get_node(smt.root(), NodeIndex::new(smt.depth(), 0)),
+        smt.get_node(&NodeIndex::new_checked(smt.depth(), 0)?),
+        store.get_node(smt.root(), NodeIndex::new_checked(smt.depth(), 0)?),
         "node 0 must be the same for both SparseMerkleTree and MerkleStore"
     );
     assert_eq!(
-        smt.get_node(&NodeIndex::new(smt.depth(), 1)),
-        store.get_node(smt.root(), NodeIndex::new(smt.depth(), 1)),
+        smt.get_node(&NodeIndex::new_checked(smt.depth(), 1)?),
+        store.get_node(smt.root(), NodeIndex::new_checked(smt.depth(), 1)?),
         "node 1 must be the same for both SparseMerkleTree and MerkleStore"
     );
     assert_eq!(
-        smt.get_node(&NodeIndex::new(smt.depth(), 2)),
-        store.get_node(smt.root(), NodeIndex::new(smt.depth(), 2)),
+        smt.get_node(&NodeIndex::new_checked(smt.depth(), 2)?),
+        store.get_node(smt.root(), NodeIndex::new_checked(smt.depth(), 2)?),
         "node 2 must be the same for both SparseMerkleTree and MerkleStore"
     );
     assert_eq!(
-        smt.get_node(&NodeIndex::new(smt.depth(), 3)),
-        store.get_node(smt.root(), NodeIndex::new(smt.depth(), 3)),
+        smt.get_node(&NodeIndex::new_checked(smt.depth(), 3)?),
+        store.get_node(smt.root(), NodeIndex::new_checked(smt.depth(), 3)?),
         "node 3 must be the same for both SparseMerkleTree and MerkleStore"
     );
     assert_eq!(
-        smt.get_node(&NodeIndex::new(smt.depth(), 4)),
-        store.get_node(smt.root(), NodeIndex::new(smt.depth(), 4)),
+        smt.get_node(&NodeIndex::new_checked(smt.depth(), 4)?),
+        store.get_node(smt.root(), NodeIndex::new_checked(smt.depth(), 4)?),
         "node 4 must be the same for both SparseMerkleTree and MerkleStore"
     );
 
     // STORE MERKLE PATH MATCHS ==============================================================
     // assert the merkle path returned by the store is the same as the one in the tree
     let result = store
-        .get_path(smt.root(), NodeIndex::new(smt.depth(), 0))
+        .get_path(smt.root(), NodeIndex::new_checked(smt.depth(), 0)?)
         .unwrap();
     assert_eq!(
         LEAVES4[0], result.value,
         "Value for merkle path at index 0 must match leaf value"
     );
     assert_eq!(
-        smt.get_path(NodeIndex::new(smt.depth(), 0)),
+        smt.get_path(NodeIndex::new_checked(smt.depth(), 0)?),
         Ok(result.path),
         "merkle path for index 0 must be the same for the MerkleTree and MerkleStore"
     );
 
     let result = store
-        .get_path(smt.root(), NodeIndex::new(smt.depth(), 1))
+        .get_path(smt.root(), NodeIndex::new_checked(smt.depth(), 1)?)
         .unwrap();
     assert_eq!(
         LEAVES4[1], result.value,
         "Value for merkle path at index 1 must match leaf value"
     );
     assert_eq!(
-        smt.get_path(NodeIndex::new(smt.depth(), 1)),
+        smt.get_path(NodeIndex::new_checked(smt.depth(), 1)?),
         Ok(result.path),
         "merkle path for index 1 must be the same for the MerkleTree and MerkleStore"
     );
 
     let result = store
-        .get_path(smt.root(), NodeIndex::new(smt.depth(), 2))
+        .get_path(smt.root(), NodeIndex::new_checked(smt.depth(), 2)?)
         .unwrap();
     assert_eq!(
         LEAVES4[2], result.value,
         "Value for merkle path at index 2 must match leaf value"
     );
     assert_eq!(
-        smt.get_path(NodeIndex::new(smt.depth(), 2)),
+        smt.get_path(NodeIndex::new_checked(smt.depth(), 2)?),
         Ok(result.path),
         "merkle path for index 2 must be the same for the MerkleTree and MerkleStore"
     );
 
     let result = store
-        .get_path(smt.root(), NodeIndex::new(smt.depth(), 3))
+        .get_path(smt.root(), NodeIndex::new_checked(smt.depth(), 3)?)
         .unwrap();
     assert_eq!(
         LEAVES4[3], result.value,
         "Value for merkle path at index 3 must match leaf value"
     );
     assert_eq!(
-        smt.get_path(NodeIndex::new(smt.depth(), 3)),
+        smt.get_path(NodeIndex::new_checked(smt.depth(), 3)?),
         Ok(result.path),
         "merkle path for index 3 must be the same for the MerkleTree and MerkleStore"
     );
 
     let result = store
-        .get_path(smt.root(), NodeIndex::new(smt.depth(), 4))
+        .get_path(smt.root(), NodeIndex::new_checked(smt.depth(), 4)?)
         .unwrap();
     assert_eq!(
         EMPTY, result.value,
         "Value for merkle path at index 4 must match leaf value"
     );
     assert_eq!(
-        smt.get_path(NodeIndex::new(smt.depth(), 4)),
+        smt.get_path(NodeIndex::new_checked(smt.depth(), 4)?),
         Ok(result.path),
         "merkle path for index 4 must be the same for the MerkleTree and MerkleStore"
     );
@@ -372,16 +378,16 @@ fn test_add_merkle_paths() -> Result<(), MerkleError> {
     let mtree = MerkleTree::new(LEAVES4.to_vec())?;
 
     let i0 = 0;
-    let p0 = mtree.get_path(NodeIndex::new(2, i0)).unwrap();
+    let p0 = mtree.get_path(NodeIndex::new_checked(2, i0)?).unwrap();
 
     let i1 = 1;
-    let p1 = mtree.get_path(NodeIndex::new(2, i1)).unwrap();
+    let p1 = mtree.get_path(NodeIndex::new_checked(2, i1)?).unwrap();
 
     let i2 = 2;
-    let p2 = mtree.get_path(NodeIndex::new(2, i2)).unwrap();
+    let p2 = mtree.get_path(NodeIndex::new_checked(2, i2)?).unwrap();
 
     let i3 = 3;
-    let p3 = mtree.get_path(NodeIndex::new(2, i3)).unwrap();
+    let p3 = mtree.get_path(NodeIndex::new_checked(2, i3)?).unwrap();
 
     let paths = [
         (i0, LEAVES4[i0 as usize], p0),
@@ -401,22 +407,22 @@ fn test_add_merkle_paths() -> Result<(), MerkleError> {
     // STORE LEAVES ARE CORRECT ==============================================================
     // checks the leaves in the store corresponds to the expected values
     assert_eq!(
-        store.get_node(set.root(), NodeIndex::new(set.depth(), 0)),
+        store.get_node(set.root(), NodeIndex::new_checked(set.depth(), 0)?),
         Ok(LEAVES4[0]),
         "node 0 must be in the set"
     );
     assert_eq!(
-        store.get_node(set.root(), NodeIndex::new(set.depth(), 1)),
+        store.get_node(set.root(), NodeIndex::new_checked(set.depth(), 1)?),
         Ok(LEAVES4[1]),
         "node 1 must be in the set"
     );
     assert_eq!(
-        store.get_node(set.root(), NodeIndex::new(set.depth(), 2)),
+        store.get_node(set.root(), NodeIndex::new_checked(set.depth(), 2)?),
         Ok(LEAVES4[2]),
         "node 2 must be in the set"
     );
     assert_eq!(
-        store.get_node(set.root(), NodeIndex::new(set.depth(), 3)),
+        store.get_node(set.root(), NodeIndex::new_checked(set.depth(), 3)?),
         Ok(LEAVES4[3]),
         "node 3 must be in the set"
     );
@@ -424,76 +430,76 @@ fn test_add_merkle_paths() -> Result<(), MerkleError> {
     // STORE LEAVES MATCH SET ================================================================
     // sanity check the values returned by the store and the set
     assert_eq!(
-        set.get_node(NodeIndex::new(set.depth(), 0)),
-        store.get_node(set.root(), NodeIndex::new(set.depth(), 0)),
+        set.get_node(NodeIndex::new_checked(set.depth(), 0)?),
+        store.get_node(set.root(), NodeIndex::new_checked(set.depth(), 0)?),
         "node 0 must be the same for both SparseMerkleTree and MerkleStore"
     );
     assert_eq!(
-        set.get_node(NodeIndex::new(set.depth(), 1)),
-        store.get_node(set.root(), NodeIndex::new(set.depth(), 1)),
+        set.get_node(NodeIndex::new_checked(set.depth(), 1)?),
+        store.get_node(set.root(), NodeIndex::new_checked(set.depth(), 1)?),
         "node 1 must be the same for both SparseMerkleTree and MerkleStore"
     );
     assert_eq!(
-        set.get_node(NodeIndex::new(set.depth(), 2)),
-        store.get_node(set.root(), NodeIndex::new(set.depth(), 2)),
+        set.get_node(NodeIndex::new_checked(set.depth(), 2)?),
+        store.get_node(set.root(), NodeIndex::new_checked(set.depth(), 2)?),
         "node 2 must be the same for both SparseMerkleTree and MerkleStore"
     );
     assert_eq!(
-        set.get_node(NodeIndex::new(set.depth(), 3)),
-        store.get_node(set.root(), NodeIndex::new(set.depth(), 3)),
+        set.get_node(NodeIndex::new_checked(set.depth(), 3)?),
+        store.get_node(set.root(), NodeIndex::new_checked(set.depth(), 3)?),
         "node 3 must be the same for both SparseMerkleTree and MerkleStore"
     );
 
     // STORE MERKLE PATH MATCHS ==============================================================
     // assert the merkle path returned by the store is the same as the one in the set
     let result = store
-        .get_path(set.root(), NodeIndex::new(set.depth(), 0))
+        .get_path(set.root(), NodeIndex::new_checked(set.depth(), 0)?)
         .unwrap();
     assert_eq!(
         LEAVES4[0], result.value,
         "Value for merkle path at index 0 must match leaf value"
     );
     assert_eq!(
-        set.get_path(NodeIndex::new(set.depth(), 0)),
+        set.get_path(NodeIndex::new_checked(set.depth(), 0)?),
         Ok(result.path),
         "merkle path for index 0 must be the same for the MerkleTree and MerkleStore"
     );
 
     let result = store
-        .get_path(set.root(), NodeIndex::new(set.depth(), 1))
+        .get_path(set.root(), NodeIndex::new_checked(set.depth(), 1)?)
         .unwrap();
     assert_eq!(
         LEAVES4[1], result.value,
         "Value for merkle path at index 0 must match leaf value"
     );
     assert_eq!(
-        set.get_path(NodeIndex::new(set.depth(), 1)),
+        set.get_path(NodeIndex::new_checked(set.depth(), 1)?),
         Ok(result.path),
         "merkle path for index 1 must be the same for the MerkleTree and MerkleStore"
     );
 
     let result = store
-        .get_path(set.root(), NodeIndex::new(set.depth(), 2))
+        .get_path(set.root(), NodeIndex::new_checked(set.depth(), 2)?)
         .unwrap();
     assert_eq!(
         LEAVES4[2], result.value,
         "Value for merkle path at index 0 must match leaf value"
     );
     assert_eq!(
-        set.get_path(NodeIndex::new(set.depth(), 2)),
+        set.get_path(NodeIndex::new_checked(set.depth(), 2)?),
         Ok(result.path),
         "merkle path for index 0 must be the same for the MerkleTree and MerkleStore"
     );
 
     let result = store
-        .get_path(set.root(), NodeIndex::new(set.depth(), 3))
+        .get_path(set.root(), NodeIndex::new_checked(set.depth(), 3)?)
         .unwrap();
     assert_eq!(
         LEAVES4[3], result.value,
         "Value for merkle path at index 0 must match leaf value"
     );
     assert_eq!(
-        set.get_path(NodeIndex::new(set.depth(), 3)),
+        set.get_path(NodeIndex::new_checked(set.depth(), 3)?),
         Ok(result.path),
         "merkle path for index 0 must be the same for the MerkleTree and MerkleStore"
     );
@@ -526,7 +532,7 @@ fn wont_open_to_different_depth_root() {
 }
 
 #[test]
-fn store_path_opens_from_leaf() {
+fn store_path_opens_from_leaf() -> Result<(), MerkleError> {
     let a = [Felt::new(1); 4];
     let b = [Felt::new(2); 4];
     let c = [Felt::new(3); 4];
@@ -550,12 +556,14 @@ fn store_path_opens_from_leaf() {
         .with_merkle_tree([a, b, c, d, e, f, g, h])
         .unwrap();
     let path = store
-        .get_path(root.into(), NodeIndex::new(3, 1))
+        .get_path(root.into(), NodeIndex::new_checked(3, 1)?)
         .unwrap()
         .path;
 
     let expected = MerklePath::new([a.into(), j.into(), n.into()].to_vec());
     assert_eq!(path, expected);
+
+    Ok(())
 }
 
 #[test]
@@ -563,7 +571,7 @@ fn test_set_node() -> Result<(), MerkleError> {
     let mtree = MerkleTree::new(LEAVES4.to_vec())?;
     let mut store = MerkleStore::default().with_merkle_tree(LEAVES4)?;
     let value = int_to_node(42);
-    let index = NodeIndex::new(mtree.depth(), 0);
+    let index = NodeIndex::new_checked(mtree.depth(), 0)?;
     let new_root = store.set_node(mtree.root(), index, value)?.root;
     assert_eq!(
         store.get_node(new_root, index),
@@ -582,7 +590,7 @@ fn test_constructors() -> Result<(), MerkleError> {
     let depth = mtree.depth();
     let leaves = 2u64.pow(depth.into());
     for index in 0..leaves {
-        let index = NodeIndex::new(depth, index);
+        let index = NodeIndex::new_checked(depth, index)?;
         let value_path = store.get_path(mtree.root(), index)?;
         assert_eq!(mtree.get_path(index)?, value_path.path);
     }
@@ -597,34 +605,66 @@ fn test_constructors() -> Result<(), MerkleError> {
     let depth = smt.depth();
 
     for key in KEYS4 {
-        let index = NodeIndex::new(depth, key);
+        let index = NodeIndex::new_checked(depth, key)?;
         let value_path = store.get_path(smt.root(), index)?;
         assert_eq!(smt.get_path(index)?, value_path.path);
     }
 
     let d = 2;
     let paths = [
-        (0, LEAVES4[0], mtree.get_path(NodeIndex::new(d, 0)).unwrap()),
-        (1, LEAVES4[1], mtree.get_path(NodeIndex::new(d, 1)).unwrap()),
-        (2, LEAVES4[2], mtree.get_path(NodeIndex::new(d, 2)).unwrap()),
-        (3, LEAVES4[3], mtree.get_path(NodeIndex::new(d, 3)).unwrap()),
+        (
+            0,
+            LEAVES4[0],
+            mtree.get_path(NodeIndex::new_checked(d, 0)?).unwrap(),
+        ),
+        (
+            1,
+            LEAVES4[1],
+            mtree.get_path(NodeIndex::new_checked(d, 1)?).unwrap(),
+        ),
+        (
+            2,
+            LEAVES4[2],
+            mtree.get_path(NodeIndex::new_checked(d, 2)?).unwrap(),
+        ),
+        (
+            3,
+            LEAVES4[3],
+            mtree.get_path(NodeIndex::new_checked(d, 3)?).unwrap(),
+        ),
     ];
 
     let store1 = MerkleStore::default().with_merkle_paths(paths.clone())?;
     let store2 = MerkleStore::default()
-        .with_merkle_path(0, LEAVES4[0], mtree.get_path(NodeIndex::new(d, 0))?)?
-        .with_merkle_path(1, LEAVES4[1], mtree.get_path(NodeIndex::new(d, 1))?)?
-        .with_merkle_path(2, LEAVES4[2], mtree.get_path(NodeIndex::new(d, 2))?)?
-        .with_merkle_path(3, LEAVES4[3], mtree.get_path(NodeIndex::new(d, 3))?)?;
+        .with_merkle_path(
+            0,
+            LEAVES4[0],
+            mtree.get_path(NodeIndex::new_checked(d, 0)?)?,
+        )?
+        .with_merkle_path(
+            1,
+            LEAVES4[1],
+            mtree.get_path(NodeIndex::new_checked(d, 1)?)?,
+        )?
+        .with_merkle_path(
+            2,
+            LEAVES4[2],
+            mtree.get_path(NodeIndex::new_checked(d, 2)?)?,
+        )?
+        .with_merkle_path(
+            3,
+            LEAVES4[3],
+            mtree.get_path(NodeIndex::new_checked(d, 3)?)?,
+        )?;
     let set = MerklePathSet::new(d).with_paths(paths).unwrap();
 
     for key in [0, 1, 2, 3] {
-        let index = NodeIndex::new(d, key);
+        let index = NodeIndex::new_checked(d, key)?;
         let value_path1 = store1.get_path(set.root(), index)?;
         let value_path2 = store2.get_path(set.root(), index)?;
         assert_eq!(value_path1, value_path2);
 
-        let index = NodeIndex::new(d, key);
+        let index = NodeIndex::new_checked(d, key)?;
         assert_eq!(set.get_path(index)?, value_path1.path);
     }
 


### PR DESCRIPTION
## Describe your changes

This modifies `NodeIndex::new` to validate that `value` is valid for `depth`.

## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.