### PR TITLE
Fix benchmark code

### DIFF
--- a/benches/store.rs
+++ b/benches/store.rs
@@ -425,7 +425,8 @@ fn update_leaf_merkletree(c: &mut Criterion) {
                     // comparison
                     store_root = store
                         .set_node(root, NodeIndex::new(depth, index), value)
-                        .unwrap();
+                        .unwrap()
+                        .root;
                     black_box(store_root)
                 },
                 BatchSize::SmallInput,
@@ -478,7 +479,8 @@ fn update_leaf_simplesmt(c: &mut Criterion) {
                     // comparison
                     store_root = store
                         .set_node(root, NodeIndex::new(depth, index), value)
-                        .unwrap();
+                        .unwrap()
+                        .root;
                     black_box(store_root)
                 },
                 BatchSize::SmallInput,


### PR DESCRIPTION
## Describe your changes

It seems that https://github.com/0xPolygonMiden/crypto/pull/99 and https://github.com/0xPolygonMiden/crypto/pull/97 were merged at the same time, the first had a breaking API change, this fixes makes the benchmark code introduced by the later compatible with the new API.

## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.