### PR TITLE
fix: path set indexes

### DIFF
--- a/src/merkle/store/tests.rs
+++ b/src/merkle/store/tests.rs
@@ -320,28 +320,28 @@ fn test_add_merkle_paths() -> Result<(), MerkleError> {
         .add_merkle_paths(paths.clone())
         .expect("the valid paths must work");
 
-    let depth = 3;
+    let depth = 2;
     let set = MerklePathSet::new(depth).with_paths(paths).unwrap();
 
     // STORE LEAVES ARE CORRECT ==============================================================
     // checks the leaves in the store corresponds to the expected values
     assert_eq!(
-        store.get_node(set.root(), NodeIndex::new(set.depth() - 1, 0)),
+        store.get_node(set.root(), NodeIndex::new(set.depth(), 0)),
         Ok(LEAVES4[0]),
         "node 0 must be in the set"
     );
     assert_eq!(
-        store.get_node(set.root(), NodeIndex::new(set.depth() - 1, 1)),
+        store.get_node(set.root(), NodeIndex::new(set.depth(), 1)),
         Ok(LEAVES4[1]),
         "node 1 must be in the set"
     );
     assert_eq!(
-        store.get_node(set.root(), NodeIndex::new(set.depth() - 1, 2)),
+        store.get_node(set.root(), NodeIndex::new(set.depth(), 2)),
         Ok(LEAVES4[2]),
         "node 2 must be in the set"
     );
     assert_eq!(
-        store.get_node(set.root(), NodeIndex::new(set.depth() - 1, 3)),
+        store.get_node(set.root(), NodeIndex::new(set.depth(), 3)),
         Ok(LEAVES4[3]),
         "node 3 must be in the set"
     );
@@ -349,77 +349,77 @@ fn test_add_merkle_paths() -> Result<(), MerkleError> {
     // STORE LEAVES MATCH SET ================================================================
     // sanity check the values returned by the store and the set
     assert_eq!(
-        set.get_node(NodeIndex::new(set.depth(), 0)),
-        store.get_node(set.root(), NodeIndex::new(set.depth() - 1, 0)),
+        set.get_leaf(0),
+        store.get_node(set.root(), NodeIndex::new(set.depth(), 0)),
         "node 0 must be the same for both SparseMerkleTree and MerkleStore"
     );
     assert_eq!(
-        set.get_node(NodeIndex::new(set.depth(), 1)),
-        store.get_node(set.root(), NodeIndex::new(set.depth() - 1, 1)),
+        set.get_leaf(1),
+        store.get_node(set.root(), NodeIndex::new(set.depth(), 1)),
         "node 1 must be the same for both SparseMerkleTree and MerkleStore"
     );
     assert_eq!(
-        set.get_node(NodeIndex::new(set.depth(), 2)),
-        store.get_node(set.root(), NodeIndex::new(set.depth() - 1, 2)),
+        set.get_leaf(2),
+        store.get_node(set.root(), NodeIndex::new(set.depth(), 2)),
         "node 2 must be the same for both SparseMerkleTree and MerkleStore"
     );
     assert_eq!(
-        set.get_node(NodeIndex::new(set.depth(), 3)),
-        store.get_node(set.root(), NodeIndex::new(set.depth() - 1, 3)),
+        set.get_leaf(3),
+        store.get_node(set.root(), NodeIndex::new(set.depth(), 3)),
         "node 3 must be the same for both SparseMerkleTree and MerkleStore"
     );
 
     // STORE MERKLE PATH MATCHS ==============================================================
     // assert the merkle path returned by the store is the same as the one in the set
     let result = store
-        .get_path(set.root(), NodeIndex::new(set.depth() - 1, 0))
+        .get_path(set.root(), NodeIndex::new(set.depth(), 0))
         .unwrap();
     assert_eq!(
         LEAVES4[0], result.value,
         "Value for merkle path at index 0 must match leaf value"
     );
     assert_eq!(
-        set.get_path(NodeIndex::new(set.depth(), 0)),
-        Ok(result.path),
+        set.get_path(0),
+        Ok(&result.path),
         "merkle path for index 0 must be the same for the MerkleTree and MerkleStore"
     );
 
     let result = store
-        .get_path(set.root(), NodeIndex::new(set.depth() - 1, 1))
+        .get_path(set.root(), NodeIndex::new(set.depth(), 1))
         .unwrap();
     assert_eq!(
         LEAVES4[1], result.value,
         "Value for merkle path at index 0 must match leaf value"
     );
     assert_eq!(
-        set.get_path(NodeIndex::new(set.depth(), 1)),
-        Ok(result.path),
+        set.get_path(1),
+        Ok(&result.path),
         "merkle path for index 1 must be the same for the MerkleTree and MerkleStore"
     );
 
     let result = store
-        .get_path(set.root(), NodeIndex::new(set.depth() - 1, 2))
+        .get_path(set.root(), NodeIndex::new(set.depth(), 2))
         .unwrap();
     assert_eq!(
         LEAVES4[2], result.value,
         "Value for merkle path at index 0 must match leaf value"
     );
     assert_eq!(
-        set.get_path(NodeIndex::new(set.depth(), 2)),
-        Ok(result.path),
+        set.get_path(2),
+        Ok(&result.path),
         "merkle path for index 0 must be the same for the MerkleTree and MerkleStore"
     );
 
     let result = store
-        .get_path(set.root(), NodeIndex::new(set.depth() - 1, 3))
+        .get_path(set.root(), NodeIndex::new(set.depth(), 3))
         .unwrap();
     assert_eq!(
         LEAVES4[3], result.value,
         "Value for merkle path at index 0 must match leaf value"
     );
     assert_eq!(
-        set.get_path(NodeIndex::new(set.depth(), 3)),
-        Ok(result.path),
+        set.get_path(3),
+        Ok(&result.path),
         "merkle path for index 0 must be the same for the MerkleTree and MerkleStore"
     );
 
@@ -540,7 +540,7 @@ fn test_constructors() -> Result<(), MerkleError> {
         .with_merkle_path(1, LEAVES4[1], mtree.get_path(NodeIndex::new(d, 1))?)?
         .with_merkle_path(2, LEAVES4[2], mtree.get_path(NodeIndex::new(d, 2))?)?
         .with_merkle_path(3, LEAVES4[3], mtree.get_path(NodeIndex::new(d, 3))?)?;
-    let set = MerklePathSet::new(d + 1).with_paths(paths).unwrap();
+    let set = MerklePathSet::new(d).with_paths(paths).unwrap();
 
     for key in [0, 1, 2, 3] {
         let index = NodeIndex::new(d, key);
@@ -548,8 +548,8 @@ fn test_constructors() -> Result<(), MerkleError> {
         let value_path2 = store2.get_path(set.root(), index)?;
         assert_eq!(value_path1, value_path2);
 
-        let index = NodeIndex::new(d + 1, key);
-        assert_eq!(set.get_path(index)?, value_path1.path);
+        let index = NodeIndex::new(d, key);
+        assert_eq!(set.get_path(index.value())?, &value_path1.path);
     }
 
     Ok(())


### PR DESCRIPTION
Prior to this commit, the [MerklePathSet] was incorrectly incrementing the depth by 1 for a given path. The [MerklePath] length will always be the target depth, ranging from the sibling of the leaf until the node immediately before the root.
    
The method [MerklePathSet::update_leaf] was also removed. The [MerklePathSet] is expected to have the same root for all paths, and such update was breaking that consistency. It is impossible to update a Merkle path and maintain the same root. Also, a [MerklePathSet] will not necessarily contain all the paths that composes the provided root. This means it is impossible to compute the new root as some of the branches might be absent.
    
Finally, the internals of the [MerklePathSet] were simplified. It will contain a single map from an index to a leaf value+path pair.