### PR TITLE
Remove SimpleSmt store

### DIFF
--- a/src/merkle/store/mod.rs
+++ b/src/merkle/store/mod.rs
@@ -296,7 +296,7 @@ impl MerkleStore {
         I: Iterator<Item = (u64, Word)> + ExactSizeIterator,
     {
         let smt = SimpleSmt::new(depth)?.with_leaves(entries)?;
-        for branch in smt.store.branches.values() {
+        for branch in smt.branches.values() {
             let parent = Rpo256::merge(&[branch.left, branch.right]);
             self.nodes.insert(
                 parent,


### PR DESCRIPTION
## Describe your changes

This is just a small simplification to the codebase. ATM the Store is not useful for much, and adds an extra layer of indirection that seems unnecessary for the time being.

We can add this later on if necessary (or not merge this, it is just a suggestion and it was a quick one to make)

edit: the original title was super confusing, I didn't mean the structure named `MerkleStore`, I meant the struct `Store` inside the `merkle::siple_smt` module. Sorry for any confusion, I have renamed the PR.

## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
