### PR TITLE
feat: add parent node iterator for SimpleSMT

### DIFF
--- a/src/merkle/store/mod.rs
+++ b/src/merkle/store/mod.rs
@@ -281,13 +281,12 @@ impl MerkleStore {
         I: Iterator<Item = (u64, Word)> + ExactSizeIterator,
     {
         let smt = SimpleSmt::new(depth)?.with_leaves(entries)?;
-        for branch in smt.branches.values() {
-            let parent = Rpo256::merge(&[branch.left, branch.right]);
+        for node in smt.inner_nodes() {
             self.nodes.insert(
-                parent,
+                node.value.into(),
                 Node {
-                    left: branch.left,
-                    right: branch.right,
+                    left: node.left.into(),
+                    right: node.right.into(),
                 },
             );
         }


### PR DESCRIPTION
## Describe your changes

This adds the parent node iterator, and no longer exposes the internal of the struct (as discussed on https://github.com/0xPolygonMiden/crypto/pull/116#discussion_r1153918263)

review/merge after: https://github.com/0xPolygonMiden/crypto/pull/117

## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
