### PR TITLE
feat: add iterator over compute paths for MerklePath

### DIFF
--- a/src/merkle/store/mod.rs
+++ b/src/merkle/store/mod.rs
@@ -478,26 +478,23 @@ impl MerkleStore {
         Ok(RootPath { root, path })
     }
 
+    /// Merges two elements and adds the resulting node into the store.
+    ///
+    /// Merges arbitrary values. They may be leafs, nodes, or a mixture of both.
     pub fn merge_roots(&mut self, root1: Word, root2: Word) -> Result<Word, MerkleError> {
         let root1: RpoDigest = root1.into();
         let root2: RpoDigest = root2.into();
 
-        if !self.nodes.contains_key(&root1) {
-            Err(MerkleError::NodeNotInStore(root1.into(), NodeIndex::root()))
-        } else if !self.nodes.contains_key(&root1) {
-            Err(MerkleError::NodeNotInStore(root2.into(), NodeIndex::root()))
-        } else {
-            let parent: Word = Rpo256::merge(&[root1, root2]).into();
-            self.nodes.insert(
-                parent.into(),
-                Node {
-                    left: root1,
-                    right: root2,
-                },
-            );
+        let parent: Word = Rpo256::merge(&[root1, root2]).into();
+        self.nodes.insert(
+            parent.into(),
+            Node {
+                left: root1,
+                right: root2,
+            },
+        );
 
-            Ok(parent)
-        }
+        Ok(parent)
     }
 }
 


### PR DESCRIPTION
## Describe your changes

This adds an iterator to expose the intermediary values computed while verifying a Merkle path. This is useful to visualize the values during debugging, I introduced this while looking at https://github.com/0xPolygonMiden/crypto/issues/119#issuecomment-1495955729 .

It also adds some tests for the MerklePath, it seems we didn't have direct tests for it.

## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
