### PR TITLE
re-export mmr proof

### DIFF
--- a/src/merkle/mod.rs
+++ b/src/merkle/mod.rs
@@ -27,7 +27,7 @@ mod simple_smt;
 pub use simple_smt::SimpleSmt;
 
 mod mmr;
-pub use mmr::{Mmr, MmrPeaks};
+pub use mmr::{Mmr, MmrPeaks, MmrProof};
 
 mod store;
 pub use store::MerkleStore;


### PR DESCRIPTION
This PR exports `MmrProof` such that is is part of the public interface of the `crypto` crate.
