### PR TITLE
feat: allow merging of leaves

### DIFF
--- a/src/merkle/store/mod.rs
+++ b/src/merkle/store/mod.rs
@@ -478,26 +478,23 @@ impl MerkleStore {
         Ok(RootPath { root, path })
     }
 
+    /// Merges two elements and adds the resulting node into the store.
+    ///
+    /// Merges arbitrary values. They may be leafs, nodes, or a mixture of both.
     pub fn merge_roots(&mut self, root1: Word, root2: Word) -> Result<Word, MerkleError> {
         let root1: RpoDigest = root1.into();
         let root2: RpoDigest = root2.into();
 
-        if !self.nodes.contains_key(&root1) {
-            Err(MerkleError::NodeNotInStore(root1.into(), NodeIndex::root()))
-        } else if !self.nodes.contains_key(&root1) {
-            Err(MerkleError::NodeNotInStore(root2.into(), NodeIndex::root()))
-        } else {
-            let parent: Word = Rpo256::merge(&[root1, root2]).into();
-            self.nodes.insert(
-                parent.into(),
-                Node {
-                    left: root1,
-                    right: root2,
-                },
-            );
+        let parent: Word = Rpo256::merge(&[root1, root2]).into();
+        self.nodes.insert(
+            parent.into(),
+            Node {
+                left: root1,
+                right: root2,
+            },
+        );
 
-            Ok(parent)
-        }
+        Ok(parent)
     }
 }
 


### PR DESCRIPTION
## Describe your changes


Consider the case of a MMR with one entry and a new entry is being added. Both of these values are quite unique, they are at the same time the root and only leaf of their corresponding tree. Currently this representation is not supported by the [MerkleStore], so this data is not in it, but once the two values are merged, they both become leaves of a new tree under the new parent.

The existing validation didn't permit that promotion from happening, which meant a [Mmr] couldn't be implemented with the method `merge_roots`.

This lifts the validation, and changes the method to clarify that not only `root` are being merged, by arbitrary nodes of a tree (leafs, internal, or roots), with arbitrary mixing of each.

## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
