### PR TITLE
store: support adding existing structures

### DIFF
--- a/benches/store.rs
+++ b/benches/store.rs
@@ -34,7 +34,7 @@ fn get_empty_leaf_simplesmt(c: &mut Criterion) {
     // both SMT and the store are pre-populated with empty hashes, accessing these values is what is
     // being benchmarked here, so no values are inserted into the backends
     let smt = SimpleSmt::new(depth).unwrap();
-    let store: MerkleStore = smt.clone().into();
+    let store = MerkleStore::from(&smt);
     let root = smt.root();
 
     group.bench_function(BenchmarkId::new("SimpleSmt", depth), |b| {
@@ -66,7 +66,7 @@ fn get_leaf_merkletree(c: &mut Criterion) {
 
         let mtree_leaves: Vec<Word> = leaves.iter().map(|v| v.into()).collect();
         let mtree = MerkleTree::new(mtree_leaves.clone()).unwrap();
-        let store: MerkleStore = mtree.clone().into();
+        let store = MerkleStore::from(&mtree);
         let depth = mtree.depth();
         let root = mtree.root();
         let size_u64 = size as u64;
@@ -108,7 +108,7 @@ fn get_leaf_simplesmt(c: &mut Criterion) {
             .unwrap()
             .with_leaves(smt_leaves.clone())
             .unwrap();
-        let store: MerkleStore = smt.clone().into();
+        let store = MerkleStore::from(&smt);
         let depth = smt.depth();
         let root = smt.root();
         let size_u64 = size as u64;
@@ -141,7 +141,7 @@ fn get_node_of_empty_simplesmt(c: &mut Criterion) {
     // of these values is what is being benchmarked here, so no values are inserted into the
     // backends.
     let smt = SimpleSmt::new(depth).unwrap();
-    let store: MerkleStore = smt.clone().into();
+    let store = MerkleStore::from(&smt);
     let root = smt.root();
     let half_depth = depth / 2;
     let half_size = 2_u64.pow(half_depth as u32);
@@ -176,7 +176,7 @@ fn get_node_merkletree(c: &mut Criterion) {
 
         let mtree_leaves: Vec<Word> = leaves.iter().map(|v| v.into()).collect();
         let mtree = MerkleTree::new(mtree_leaves.clone()).unwrap();
-        let store: MerkleStore = mtree.clone().into();
+        let store = MerkleStore::from(&mtree);
         let root = mtree.root();
         let half_depth = mtree.depth() / 2;
         let half_size = 2_u64.pow(half_depth as u32);
@@ -219,7 +219,7 @@ fn get_node_simplesmt(c: &mut Criterion) {
             .unwrap()
             .with_leaves(smt_leaves.clone())
             .unwrap();
-        let store: MerkleStore = smt.clone().into();
+        let store = MerkleStore::from(&smt);
         let root = smt.root();
         let half_depth = smt.depth() / 2;
         let half_size = 2_u64.pow(half_depth as u32);
@@ -254,7 +254,7 @@ fn get_leaf_path_merkletree(c: &mut Criterion) {
 
         let mtree_leaves: Vec<Word> = leaves.iter().map(|v| v.into()).collect();
         let mtree = MerkleTree::new(mtree_leaves.clone()).unwrap();
-        let store: MerkleStore = mtree.clone().into();
+        let store = MerkleStore::from(&mtree);
         let depth = mtree.depth();
         let root = mtree.root();
         let size_u64 = size as u64;
@@ -296,7 +296,7 @@ fn get_leaf_path_simplesmt(c: &mut Criterion) {
             .unwrap()
             .with_leaves(smt_leaves.clone())
             .unwrap();
-        let store: MerkleStore = smt.clone().into();
+        let store = MerkleStore::from(&smt);
         let depth = smt.depth();
         let root = smt.root();
         let size_u64 = size as u64;
@@ -346,7 +346,7 @@ fn new(c: &mut Criterion) {
                 || leaves.iter().map(|v| v.into()).collect::<Vec<Word>>(),
                 |l| {
                     let mtree = MerkleTree::new(l).unwrap();
-                    black_box(MerkleStore::from(mtree));
+                    black_box(MerkleStore::from(&mtree));
                 },
                 BatchSize::SmallInput,
             )
@@ -377,7 +377,7 @@ fn new(c: &mut Criterion) {
                 },
                 |l| {
                     let smt = SimpleSmt::new(SimpleSmt::MAX_DEPTH).unwrap().with_leaves(l).unwrap();
-                    black_box(MerkleStore::from(smt));
+                    black_box(MerkleStore::from(&smt));
                 },
                 BatchSize::SmallInput,
             )
@@ -397,7 +397,7 @@ fn update_leaf_merkletree(c: &mut Criterion) {
 
         let mtree_leaves: Vec<Word> = leaves.iter().map(|v| v.into()).collect();
         let mut mtree = MerkleTree::new(mtree_leaves.clone()).unwrap();
-        let mut store: MerkleStore = mtree.clone().into();
+        let mut store = MerkleStore::from(&mtree);
         let depth = mtree.depth();
         let root = mtree.root();
         let size_u64 = size as u64;
@@ -446,7 +446,7 @@ fn update_leaf_simplesmt(c: &mut Criterion) {
             .unwrap()
             .with_leaves(smt_leaves.clone())
             .unwrap();
-        let mut store: MerkleStore = smt.clone().into();
+        let mut store = MerkleStore::from(&smt);
         let depth = smt.depth();
         let root = smt.root();
         let size_u64 = size as u64;

--- a/benches/store.rs
+++ b/benches/store.rs
@@ -34,7 +34,7 @@ fn get_empty_leaf_simplesmt(c: &mut Criterion) {
     // both SMT and the store are pre-populated with empty hashes, accessing these values is what is
     // being benchmarked here, so no values are inserted into the backends
     let smt = SimpleSmt::new(depth).unwrap();
-    let store = MerkleStore::new();
+    let store: MerkleStore = smt.clone().into();
     let root = smt.root();
 
     group.bench_function(BenchmarkId::new("SimpleSmt", depth), |b| {
@@ -66,8 +66,7 @@ fn get_leaf_merkletree(c: &mut Criterion) {
 
         let mtree_leaves: Vec<Word> = leaves.iter().map(|v| v.into()).collect();
         let mtree = MerkleTree::new(mtree_leaves.clone()).unwrap();
-        let mut store = MerkleStore::new();
-        store.extend(mtree.inner_nodes());
+        let store: MerkleStore = mtree.clone().into();
         let depth = mtree.depth();
         let root = mtree.root();
         let size_u64 = size as u64;
@@ -109,8 +108,7 @@ fn get_leaf_simplesmt(c: &mut Criterion) {
             .unwrap()
             .with_leaves(smt_leaves.clone())
             .unwrap();
-        let mut store = MerkleStore::new();
-        store.extend(smt.inner_nodes());
+        let store: MerkleStore = smt.clone().into();
         let depth = smt.depth();
         let root = smt.root();
         let size_u64 = size as u64;
@@ -143,7 +141,7 @@ fn get_node_of_empty_simplesmt(c: &mut Criterion) {
     // of these values is what is being benchmarked here, so no values are inserted into the
     // backends.
     let smt = SimpleSmt::new(depth).unwrap();
-    let store = MerkleStore::new();
+    let store: MerkleStore = smt.clone().into();
     let root = smt.root();
     let half_depth = depth / 2;
     let half_size = 2_u64.pow(half_depth as u32);
@@ -178,8 +176,7 @@ fn get_node_merkletree(c: &mut Criterion) {
 
         let mtree_leaves: Vec<Word> = leaves.iter().map(|v| v.into()).collect();
         let mtree = MerkleTree::new(mtree_leaves.clone()).unwrap();
-        let mut store = MerkleStore::new();
-        store.extend(mtree.inner_nodes());
+        let store: MerkleStore = mtree.clone().into();
         let root = mtree.root();
         let half_depth = mtree.depth() / 2;
         let half_size = 2_u64.pow(half_depth as u32);
@@ -222,8 +219,7 @@ fn get_node_simplesmt(c: &mut Criterion) {
             .unwrap()
             .with_leaves(smt_leaves.clone())
             .unwrap();
-        let mut store = MerkleStore::new();
-        store.extend(smt.inner_nodes());
+        let store: MerkleStore = smt.clone().into();
         let root = smt.root();
         let half_depth = smt.depth() / 2;
         let half_size = 2_u64.pow(half_depth as u32);
@@ -258,8 +254,7 @@ fn get_leaf_path_merkletree(c: &mut Criterion) {
 
         let mtree_leaves: Vec<Word> = leaves.iter().map(|v| v.into()).collect();
         let mtree = MerkleTree::new(mtree_leaves.clone()).unwrap();
-        let mut store = MerkleStore::new();
-        store.extend(mtree.inner_nodes());
+        let store: MerkleStore = mtree.clone().into();
         let depth = mtree.depth();
         let root = mtree.root();
         let size_u64 = size as u64;
@@ -301,8 +296,7 @@ fn get_leaf_path_simplesmt(c: &mut Criterion) {
             .unwrap()
             .with_leaves(smt_leaves.clone())
             .unwrap();
-        let mut store = MerkleStore::new();
-        store.extend(smt.inner_nodes());
+        let store: MerkleStore = smt.clone().into();
         let depth = smt.depth();
         let root = smt.root();
         let size_u64 = size as u64;
@@ -352,7 +346,7 @@ fn new(c: &mut Criterion) {
                 || leaves.iter().map(|v| v.into()).collect::<Vec<Word>>(),
                 |l| {
                     let mtree = MerkleTree::new(l).unwrap();
-                    black_box(MerkleStore::new().extend(mtree.inner_nodes()));
+                    black_box(MerkleStore::from(mtree));
                 },
                 BatchSize::SmallInput,
             )
@@ -383,7 +377,7 @@ fn new(c: &mut Criterion) {
                 },
                 |l| {
                     let smt = SimpleSmt::new(SimpleSmt::MAX_DEPTH).unwrap().with_leaves(l).unwrap();
-                    black_box(MerkleStore::new().extend(smt.inner_nodes()));
+                    black_box(MerkleStore::from(smt));
                 },
                 BatchSize::SmallInput,
             )
@@ -403,8 +397,7 @@ fn update_leaf_merkletree(c: &mut Criterion) {
 
         let mtree_leaves: Vec<Word> = leaves.iter().map(|v| v.into()).collect();
         let mut mtree = MerkleTree::new(mtree_leaves.clone()).unwrap();
-        let mut store = MerkleStore::new();
-        store.extend(mtree.inner_nodes());
+        let mut store: MerkleStore = mtree.clone().into();
         let depth = mtree.depth();
         let root = mtree.root();
         let size_u64 = size as u64;
@@ -453,8 +446,7 @@ fn update_leaf_simplesmt(c: &mut Criterion) {
             .unwrap()
             .with_leaves(smt_leaves.clone())
             .unwrap();
-        let mut store = MerkleStore::new();
-        store.extend(smt.inner_nodes());
+        let mut store: MerkleStore = smt.clone().into();
         let depth = smt.depth();
         let root = smt.root();
         let size_u64 = size as u64;

--- a/benches/store.rs
+++ b/benches/store.rs
@@ -66,7 +66,8 @@ fn get_leaf_merkletree(c: &mut Criterion) {
 
         let mtree_leaves: Vec<Word> = leaves.iter().map(|v| v.into()).collect();
         let mtree = MerkleTree::new(mtree_leaves.clone()).unwrap();
-        let store = MerkleStore::new().with_merkle_tree(mtree_leaves).unwrap();
+        let mut store = MerkleStore::new();
+        store.extend(mtree.inner_nodes());
         let depth = mtree.depth();
         let root = mtree.root();
         let size_u64 = size as u64;
@@ -108,9 +109,8 @@ fn get_leaf_simplesmt(c: &mut Criterion) {
             .unwrap()
             .with_leaves(smt_leaves.clone())
             .unwrap();
-        let store = MerkleStore::new()
-            .with_sparse_merkle_tree(SimpleSmt::MAX_DEPTH, smt_leaves)
-            .unwrap();
+        let mut store = MerkleStore::new();
+        store.extend(smt.inner_nodes());
         let depth = smt.depth();
         let root = smt.root();
         let size_u64 = size as u64;
@@ -178,7 +178,8 @@ fn get_node_merkletree(c: &mut Criterion) {
 
         let mtree_leaves: Vec<Word> = leaves.iter().map(|v| v.into()).collect();
         let mtree = MerkleTree::new(mtree_leaves.clone()).unwrap();
-        let store = MerkleStore::new().with_merkle_tree(mtree_leaves).unwrap();
+        let mut store = MerkleStore::new();
+        store.extend(mtree.inner_nodes());
         let root = mtree.root();
         let half_depth = mtree.depth() / 2;
         let half_size = 2_u64.pow(half_depth as u32);
@@ -221,9 +222,8 @@ fn get_node_simplesmt(c: &mut Criterion) {
             .unwrap()
             .with_leaves(smt_leaves.clone())
             .unwrap();
-        let store = MerkleStore::new()
-            .with_sparse_merkle_tree(SimpleSmt::MAX_DEPTH, smt_leaves)
-            .unwrap();
+        let mut store = MerkleStore::new();
+        store.extend(smt.inner_nodes());
         let root = smt.root();
         let half_depth = smt.depth() / 2;
         let half_size = 2_u64.pow(half_depth as u32);
@@ -258,7 +258,8 @@ fn get_leaf_path_merkletree(c: &mut Criterion) {
 
         let mtree_leaves: Vec<Word> = leaves.iter().map(|v| v.into()).collect();
         let mtree = MerkleTree::new(mtree_leaves.clone()).unwrap();
-        let store = MerkleStore::new().with_merkle_tree(mtree_leaves).unwrap();
+        let mut store = MerkleStore::new();
+        store.extend(mtree.inner_nodes());
         let depth = mtree.depth();
         let root = mtree.root();
         let size_u64 = size as u64;
@@ -300,9 +301,8 @@ fn get_leaf_path_simplesmt(c: &mut Criterion) {
             .unwrap()
             .with_leaves(smt_leaves.clone())
             .unwrap();
-        let store = MerkleStore::new()
-            .with_sparse_merkle_tree(SimpleSmt::MAX_DEPTH, smt_leaves)
-            .unwrap();
+        let mut store = MerkleStore::new();
+        store.extend(smt.inner_nodes());
         let depth = smt.depth();
         let root = smt.root();
         let size_u64 = size as u64;
@@ -347,10 +347,13 @@ fn new(c: &mut Criterion) {
 
         // This could be done with `bench_with_input`, however to remove variables while comparing
         // with MerkleTree it is using `iter_batched`
-        group.bench_function(BenchmarkId::new("MerkleStore::with_merkle_tree", size), |b| {
+        group.bench_function(BenchmarkId::new("MerkleStore::extend::MerkleTree", size), |b| {
             b.iter_batched(
                 || leaves.iter().map(|v| v.into()).collect::<Vec<Word>>(),
-                |l| black_box(MerkleStore::new().with_merkle_tree(l)),
+                |l| {
+                    let mtree = MerkleTree::new(l).unwrap();
+                    black_box(MerkleStore::new().extend(mtree.inner_nodes()));
+                },
                 BatchSize::SmallInput,
             )
         });
@@ -369,7 +372,7 @@ fn new(c: &mut Criterion) {
             )
         });
 
-        group.bench_function(BenchmarkId::new("MerkleStore::with_sparse_merkle_tree", size), |b| {
+        group.bench_function(BenchmarkId::new("MerkleStore::extend::SimpleSmt", size), |b| {
             b.iter_batched(
                 || {
                     leaves
@@ -378,7 +381,10 @@ fn new(c: &mut Criterion) {
                         .map(|(c, v)| (c.try_into().unwrap(), v.into()))
                         .collect::<Vec<(u64, Word)>>()
                 },
-                |l| black_box(MerkleStore::new().with_sparse_merkle_tree(SimpleSmt::MAX_DEPTH, l)),
+                |l| {
+                    let smt = SimpleSmt::new(SimpleSmt::MAX_DEPTH).unwrap().with_leaves(l).unwrap();
+                    black_box(MerkleStore::new().extend(smt.inner_nodes()));
+                },
                 BatchSize::SmallInput,
             )
         });
@@ -397,7 +403,8 @@ fn update_leaf_merkletree(c: &mut Criterion) {
 
         let mtree_leaves: Vec<Word> = leaves.iter().map(|v| v.into()).collect();
         let mut mtree = MerkleTree::new(mtree_leaves.clone()).unwrap();
-        let mut store = MerkleStore::new().with_merkle_tree(mtree_leaves).unwrap();
+        let mut store = MerkleStore::new();
+        store.extend(mtree.inner_nodes());
         let depth = mtree.depth();
         let root = mtree.root();
         let size_u64 = size as u64;
@@ -446,9 +453,8 @@ fn update_leaf_simplesmt(c: &mut Criterion) {
             .unwrap()
             .with_leaves(smt_leaves.clone())
             .unwrap();
-        let mut store = MerkleStore::new()
-            .with_sparse_merkle_tree(SimpleSmt::MAX_DEPTH, smt_leaves)
-            .unwrap();
+        let mut store = MerkleStore::new();
+        store.extend(smt.inner_nodes());
         let depth = smt.depth();
         let root = smt.root();
         let size_u64 = size as u64;

--- a/src/merkle/merkle_tree.rs
+++ b/src/merkle/merkle_tree.rs
@@ -192,6 +192,9 @@ impl<'a> Iterator for MerkleTreeNodes<'a> {
     }
 }
 
+// UTILITY FUNCTIONS
+// ================================================================================================
+
 /// Utility to visualize a [MerkleTree] in text.
 pub fn tree_to_text(tree: &MerkleTree) -> Result<String, fmt::Error> {
     let indent = "  ";

--- a/src/merkle/merkle_tree.rs
+++ b/src/merkle/merkle_tree.rs
@@ -150,9 +150,11 @@ impl MerkleTree {
         Ok(())
     }
 
-    /// An iterator over every inner node in the tree. The iterator order is unspecified.
-    pub fn inner_nodes(&self) -> MerkleTreeNodes<'_> {
-        MerkleTreeNodes {
+    /// Returns n iterator over every inner node of this [MerkleTree].
+    ///
+    /// The iterator order is unspecified.
+    pub fn inner_nodes(&self) -> InnerNodeIterator<'_> {
+        InnerNodeIterator {
             nodes: &self.nodes,
             index: 1, // index 0 is just padding, start at 1
         }
@@ -165,12 +167,12 @@ impl MerkleTree {
 /// An iterator over every inner node of the [MerkleTree].
 ///
 /// Use this to extract the data of the tree, there is no guarantee on the order of the elements.
-pub struct MerkleTreeNodes<'a> {
+pub struct InnerNodeIterator<'a> {
     nodes: &'a Vec<Word>,
     index: usize,
 }
 
-impl<'a> Iterator for MerkleTreeNodes<'a> {
+impl<'a> Iterator for InnerNodeIterator<'a> {
     type Item = InnerNodeInfo;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/src/merkle/store/mod.rs
+++ b/src/merkle/store/mod.rs
@@ -1,7 +1,7 @@
-use super::mmr::{Mmr, MmrPeaks};
+use super::mmr::Mmr;
 use super::{
-    BTreeMap, EmptySubtreeRoots, InnerNodeInfo, MerkleError, MerklePath, MerklePathSet, MerkleTree,
-    NodeIndex, RootPath, Rpo256, RpoDigest, SimpleSmt, ValuePath, Vec, Word,
+    BTreeMap, EmptySubtreeRoots, InnerNodeInfo, MerkleError, MerklePath, MerklePathSet, NodeIndex,
+    RootPath, Rpo256, RpoDigest, ValuePath, Vec, Word,
 };
 use crate::utils::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable};
 
@@ -47,9 +47,13 @@ pub struct Node {
 /// // the store is initialized with the SMT empty nodes
 /// assert_eq!(store.num_internal_nodes(), 255);
 ///
+/// let tree1 = MerkleTree::new(vec![A, B, C, D, E, F, G, H0]).unwrap();
+/// let tree2 = MerkleTree::new(vec![A, B, C, D, E, F, G, H1]).unwrap();
+///
 /// // populates the store with two merkle trees, common nodes are shared
-/// store.add_merkle_tree([A, B, C, D, E, F, G, H0]);
-/// store.add_merkle_tree([A, B, C, D, E, F, G, H1]);
+/// store
+///     .extend(tree1.inner_nodes())
+///     .extend(tree2.inner_nodes());
 ///
 /// // every leaf except the last are the same
 /// for i in 0..7 {
@@ -111,31 +115,6 @@ impl MerkleStore {
         MerkleStore { nodes }
     }
 
-    /// Appends the provided merkle tree represented by its `leaves` to the set.
-    pub fn with_merkle_tree<I>(mut self, leaves: I) -> Result<Self, MerkleError>
-    where
-        I: IntoIterator<Item = Word>,
-    {
-        self.add_merkle_tree(leaves)?;
-        Ok(self)
-    }
-
-    /// Appends the provided Sparse Merkle tree represented by its `entries` to the set.
-    ///
-    /// For more information, check [MerkleStore::add_sparse_merkle_tree].
-    pub fn with_sparse_merkle_tree<R, I>(
-        mut self,
-        depth: u8,
-        entries: R,
-    ) -> Result<Self, MerkleError>
-    where
-        R: IntoIterator<IntoIter = I>,
-        I: Iterator<Item = (u64, Word)> + ExactSizeIterator,
-    {
-        self.add_sparse_merkle_tree(depth, entries)?;
-        Ok(self)
-    }
-
     /// Appends the provided merkle path set.
     pub fn with_merkle_path(
         mut self,
@@ -153,15 +132,6 @@ impl MerkleStore {
         I: IntoIterator<Item = (u64, Word, MerklePath)>,
     {
         self.add_merkle_paths(paths)?;
-        Ok(self)
-    }
-
-    /// Appends the provided [Mmr] represented by its `leaves` to the set.
-    pub fn with_mmr<I>(mut self, leaves: I) -> Result<Self, MerkleError>
-    where
-        I: IntoIterator<Item = Word>,
-    {
-        self.add_mmr(leaves)?;
         Ok(self)
     }
 
@@ -324,54 +294,6 @@ impl MerkleStore {
         self
     }
 
-    /// Adds all the nodes of a Merkle tree represented by `leaves`.
-    ///
-    /// This will instantiate a Merkle tree using `leaves` and include all the nodes into the
-    /// store.
-    ///
-    /// # Errors
-    ///
-    /// This method may return the following errors:
-    /// - `DepthTooSmall` if leaves is empty or contains only 1 element
-    /// - `NumLeavesNotPowerOfTwo` if the number of leaves is not a power-of-two
-    pub fn add_merkle_tree<I>(&mut self, leaves: I) -> Result<Word, MerkleError>
-    where
-        I: IntoIterator<Item = Word>,
-    {
-        let leaves: Vec<_> = leaves.into_iter().collect();
-        if leaves.len() < 2 {
-            return Err(MerkleError::DepthTooSmall(leaves.len() as u8));
-        }
-
-        let tree = MerkleTree::new(leaves)?;
-        self.extend(tree.inner_nodes());
-
-        Ok(tree.root())
-    }
-
-    /// Adds a Sparse Merkle tree defined by the specified `entries` to the store, and returns the
-    /// root of the added tree.
-    ///
-    /// The entries are expected to contain tuples of `(index, node)` describing nodes in the tree
-    /// at `depth`.
-    ///
-    /// # Errors
-    /// Returns an error if the provided `depth` is greater than [SimpleSmt::MAX_DEPTH].
-    pub fn add_sparse_merkle_tree<R, I>(
-        &mut self,
-        depth: u8,
-        entries: R,
-    ) -> Result<Word, MerkleError>
-    where
-        R: IntoIterator<IntoIter = I>,
-        I: Iterator<Item = (u64, Word)> + ExactSizeIterator,
-    {
-        let smt = SimpleSmt::new(depth)?.with_leaves(entries)?;
-        self.extend(smt.inner_nodes());
-
-        Ok(smt.root())
-    }
-
     /// Adds all the nodes of a Merkle path represented by `path`, opening to `node`. Returns the
     /// new root.
     ///
@@ -431,17 +353,6 @@ impl MerkleStore {
             self.add_merkle_path(index, path.value, path.path)?;
         }
         Ok(root)
-    }
-
-    /// Appends the provided [Mmr] into the store.
-    pub fn add_mmr<I>(&mut self, leaves: I) -> Result<MmrPeaks, MerkleError>
-    where
-        I: IntoIterator<Item = Word>,
-    {
-        let mmr = Mmr::from(leaves);
-        self.extend(mmr.inner_nodes());
-
-        Ok(mmr.accumulator())
     }
 
     /// Sets a node to `value`.

--- a/src/merkle/store/mod.rs
+++ b/src/merkle/store/mod.rs
@@ -1,7 +1,7 @@
 use super::mmr::Mmr;
 use super::{
-    BTreeMap, EmptySubtreeRoots, InnerNodeInfo, MerkleError, MerklePath, MerklePathSet, NodeIndex,
-    RootPath, Rpo256, RpoDigest, ValuePath, Vec, Word,
+    BTreeMap, EmptySubtreeRoots, InnerNodeInfo, MerkleError, MerklePath, MerklePathSet, MerkleTree,
+    NodeIndex, RootPath, Rpo256, RpoDigest, SimpleSmt, ValuePath, Vec, Word,
 };
 use crate::utils::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable};
 
@@ -390,6 +390,33 @@ impl MerkleStore {
         self.nodes.insert(parent, Node { left, right });
 
         Ok(parent.into())
+    }
+}
+
+// CONVERTIONS
+// ================================================================================================
+
+impl From<MerkleTree> for MerkleStore {
+    fn from(value: MerkleTree) -> Self {
+        let mut store = MerkleStore::new();
+        store.extend(value.inner_nodes());
+        store
+    }
+}
+
+impl From<SimpleSmt> for MerkleStore {
+    fn from(value: SimpleSmt) -> Self {
+        let mut store = MerkleStore::new();
+        store.extend(value.inner_nodes());
+        store
+    }
+}
+
+impl From<Mmr> for MerkleStore {
+    fn from(value: Mmr) -> Self {
+        let mut store = MerkleStore::new();
+        store.extend(value.inner_nodes());
+        store
     }
 }
 

--- a/src/merkle/store/mod.rs
+++ b/src/merkle/store/mod.rs
@@ -393,29 +393,37 @@ impl MerkleStore {
     }
 }
 
-// CONVERTIONS
+// CONVERSIONS
 // ================================================================================================
 
-impl From<MerkleTree> for MerkleStore {
-    fn from(value: MerkleTree) -> Self {
+impl From<&MerkleTree> for MerkleStore {
+    fn from(value: &MerkleTree) -> Self {
         let mut store = MerkleStore::new();
         store.extend(value.inner_nodes());
         store
     }
 }
 
-impl From<SimpleSmt> for MerkleStore {
-    fn from(value: SimpleSmt) -> Self {
+impl From<&SimpleSmt> for MerkleStore {
+    fn from(value: &SimpleSmt) -> Self {
         let mut store = MerkleStore::new();
         store.extend(value.inner_nodes());
         store
     }
 }
 
-impl From<Mmr> for MerkleStore {
-    fn from(value: Mmr) -> Self {
+impl From<&Mmr> for MerkleStore {
+    fn from(value: &Mmr) -> Self {
         let mut store = MerkleStore::new();
         store.extend(value.inner_nodes());
+        store
+    }
+}
+
+impl FromIterator<InnerNodeInfo> for MerkleStore {
+    fn from_iter<T: IntoIterator<Item = InnerNodeInfo>>(iter: T) -> Self {
+        let mut store = MerkleStore::new();
+        store.extend(iter.into_iter());
         store
     }
 }

--- a/src/merkle/store/tests.rs
+++ b/src/merkle/store/tests.rs
@@ -5,7 +5,7 @@ use crate::{
     Felt, Word, WORD_SIZE, ZERO,
 };
 
-#[cfg(std)]
+#[cfg(feature = "std")]
 use std::error::Error;
 
 const KEYS4: [u64; 4] = [0, 1, 2, 3];
@@ -716,12 +716,12 @@ fn get_leaf_depth_works_with_depth_8() {
     assert_eq!(Err(MerkleError::DepthTooBig(9)), store.get_leaf_depth(root, 8, a));
 }
 
-#[cfg(std)]
+#[cfg(feature = "std")]
 #[test]
 fn test_serialization() -> Result<(), Box<dyn Error>> {
     let mtree = MerkleTree::new(LEAVES4.to_vec())?;
-    let store: MerkleStore = mtree.clone().into();
-    let decoded = MerkleStore::read_from_bytes(&original.to_bytes())?;
-    assert_eq!(original, decoded);
+    let store = MerkleStore::from(&mtree);
+    let decoded = MerkleStore::read_from_bytes(&store.to_bytes()).expect("deserialization failed");
+    assert_eq!(store, decoded);
     Ok(())
 }

--- a/src/merkle/store/tests.rs
+++ b/src/merkle/store/tests.rs
@@ -15,8 +15,7 @@ const EMPTY: Word = [ZERO; WORD_SIZE];
 #[test]
 fn test_root_not_in_store() -> Result<(), MerkleError> {
     let mtree = MerkleTree::new(LEAVES4.to_vec())?;
-    let mut store = MerkleStore::new();
-    store.extend(mtree.inner_nodes());
+    let store: MerkleStore = mtree.clone().into();
     assert_eq!(
         store.get_node(LEAVES4[0], NodeIndex::make(mtree.depth(), 0)),
         Err(MerkleError::RootNotInStore(LEAVES4[0])),
@@ -34,8 +33,7 @@ fn test_root_not_in_store() -> Result<(), MerkleError> {
 #[test]
 fn test_merkle_tree() -> Result<(), MerkleError> {
     let mtree = MerkleTree::new(LEAVES4.to_vec())?;
-    let mut store = MerkleStore::default();
-    store.extend(mtree.inner_nodes());
+    let store: MerkleStore = mtree.clone().into();
 
     // STORE LEAVES ARE CORRECT ==============================================================
     // checks the leaves in the store corresponds to the expected values
@@ -177,8 +175,7 @@ fn test_leaf_paths_for_empty_trees() -> Result<(), MerkleError> {
 #[test]
 fn test_get_invalid_node() {
     let mtree = MerkleTree::new(LEAVES4.to_vec()).expect("creating a merkle tree must work");
-    let mut store = MerkleStore::default();
-    store.extend(mtree.inner_nodes());
+    let store: MerkleStore = mtree.clone().into();
     let _ = store.get_node(mtree.root(), NodeIndex::make(mtree.depth(), 3));
 }
 
@@ -190,8 +187,7 @@ fn test_add_sparse_merkle_tree_one_level() -> Result<(), MerkleError> {
         .unwrap()
         .with_leaves(keys2.into_iter().zip(leaves2.into_iter()))
         .unwrap();
-    let mut store = MerkleStore::default();
-    store.extend(smt.inner_nodes());
+    let store: MerkleStore = smt.clone().into();
 
     let idx = NodeIndex::make(1, 0);
     assert_eq!(smt.get_node(idx).unwrap(), leaves2[0]);
@@ -211,8 +207,7 @@ fn test_sparse_merkle_tree() -> Result<(), MerkleError> {
         .with_leaves(KEYS4.into_iter().zip(LEAVES4.into_iter()))
         .unwrap();
 
-    let mut store = MerkleStore::default();
-    store.extend(smt.inner_nodes());
+    let store: MerkleStore = smt.clone().into();
 
     // STORE LEAVES ARE CORRECT ==============================================================
     // checks the leaves in the store corresponds to the expected values
@@ -470,8 +465,7 @@ fn wont_open_to_different_depth_root() {
     // attempt to fetch a node on the maximum depth, and it should fail because the root shouldn't
     // exist for the set.
     let mtree = MerkleTree::new(vec![a, b]).unwrap();
-    let mut store = MerkleStore::new();
-    store.extend(mtree.inner_nodes());
+    let store: MerkleStore = mtree.clone().into();
     let index = NodeIndex::root();
     let err = store.get_node(root, index).err().unwrap();
     assert_eq!(err, MerkleError::RootNotInStore(root));
@@ -499,8 +493,7 @@ fn store_path_opens_from_leaf() {
     let root = Rpo256::merge(&[m.into(), n.into()]);
 
     let mtree = MerkleTree::new(vec![a, b, c, d, e, f, g, h]).unwrap();
-    let mut store = MerkleStore::new();
-    store.extend(mtree.inner_nodes());
+    let store: MerkleStore = mtree.clone().into();
     let path = store.get_path(root.into(), NodeIndex::make(3, 1)).unwrap().path;
 
     let expected = MerklePath::new([a.into(), j.into(), n.into()].to_vec());
@@ -510,8 +503,7 @@ fn store_path_opens_from_leaf() {
 #[test]
 fn test_set_node() -> Result<(), MerkleError> {
     let mtree = MerkleTree::new(LEAVES4.to_vec())?;
-    let mut store = MerkleStore::new();
-    store.extend(mtree.inner_nodes());
+    let mut store: MerkleStore = mtree.clone().into();
     let value = int_to_node(42);
     let index = NodeIndex::make(mtree.depth(), 0);
     let new_root = store.set_node(mtree.root(), index, value)?.root;
@@ -523,8 +515,7 @@ fn test_set_node() -> Result<(), MerkleError> {
 #[test]
 fn test_constructors() -> Result<(), MerkleError> {
     let mtree = MerkleTree::new(LEAVES4.to_vec())?;
-    let mut store = MerkleStore::new();
-    store.extend(mtree.inner_nodes());
+    let store: MerkleStore = mtree.clone().into();
 
     let depth = mtree.depth();
     let leaves = 2u64.pow(depth.into());
@@ -539,8 +530,7 @@ fn test_constructors() -> Result<(), MerkleError> {
         .unwrap()
         .with_leaves(KEYS4.into_iter().zip(LEAVES4.into_iter()))
         .unwrap();
-    let mut store = MerkleStore::new();
-    store.extend(smt.inner_nodes());
+    let store: MerkleStore = smt.clone().into();
     let depth = smt.depth();
 
     for key in KEYS4 {
@@ -730,8 +720,7 @@ fn get_leaf_depth_works_with_depth_8() {
 #[test]
 fn test_serialization() -> Result<(), Box<dyn Error>> {
     let mtree = MerkleTree::new(LEAVES4.to_vec())?;
-    let mut store = MerkleStore::new();
-    store.extend(mtree.inner_nodes());
+    let store: MerkleStore = mtree.clone().into();
     let decoded = MerkleStore::read_from_bytes(&original.to_bytes())?;
     assert_eq!(original, decoded);
     Ok(())

--- a/src/merkle/store/tests.rs
+++ b/src/merkle/store/tests.rs
@@ -547,12 +547,14 @@ fn test_constructors() -> Result<(), MerkleError> {
         (3, LEAVES4[3], mtree.get_path(NodeIndex::make(d, 3)).unwrap()),
     ];
 
-    let store1 = MerkleStore::default().with_merkle_paths(paths.clone())?;
-    let store2 = MerkleStore::default()
-        .with_merkle_path(0, LEAVES4[0], mtree.get_path(NodeIndex::make(d, 0))?)?
-        .with_merkle_path(1, LEAVES4[1], mtree.get_path(NodeIndex::make(d, 1))?)?
-        .with_merkle_path(2, LEAVES4[2], mtree.get_path(NodeIndex::make(d, 2))?)?
-        .with_merkle_path(3, LEAVES4[3], mtree.get_path(NodeIndex::make(d, 3))?)?;
+    let mut store1 = MerkleStore::default();
+    store1.add_merkle_paths(paths.clone())?;
+
+    let mut store2 = MerkleStore::default();
+    store2.add_merkle_path(0, LEAVES4[0], mtree.get_path(NodeIndex::make(d, 0))?)?;
+    store2.add_merkle_path(1, LEAVES4[1], mtree.get_path(NodeIndex::make(d, 1))?)?;
+    store2.add_merkle_path(2, LEAVES4[2], mtree.get_path(NodeIndex::make(d, 2))?)?;
+    store2.add_merkle_path(3, LEAVES4[3], mtree.get_path(NodeIndex::make(d, 3))?)?;
     let set = MerklePathSet::new(d).with_paths(paths).unwrap();
 
     for key in [0, 1, 2, 3] {

--- a/src/merkle/store/tests.rs
+++ b/src/merkle/store/tests.rs
@@ -15,7 +15,7 @@ const EMPTY: Word = [ZERO; WORD_SIZE];
 #[test]
 fn test_root_not_in_store() -> Result<(), MerkleError> {
     let mtree = MerkleTree::new(LEAVES4.to_vec())?;
-    let store: MerkleStore = mtree.clone().into();
+    let store = MerkleStore::from(&mtree);
     assert_eq!(
         store.get_node(LEAVES4[0], NodeIndex::make(mtree.depth(), 0)),
         Err(MerkleError::RootNotInStore(LEAVES4[0])),
@@ -33,7 +33,7 @@ fn test_root_not_in_store() -> Result<(), MerkleError> {
 #[test]
 fn test_merkle_tree() -> Result<(), MerkleError> {
     let mtree = MerkleTree::new(LEAVES4.to_vec())?;
-    let store: MerkleStore = mtree.clone().into();
+    let store = MerkleStore::from(&mtree);
 
     // STORE LEAVES ARE CORRECT ==============================================================
     // checks the leaves in the store corresponds to the expected values
@@ -175,7 +175,7 @@ fn test_leaf_paths_for_empty_trees() -> Result<(), MerkleError> {
 #[test]
 fn test_get_invalid_node() {
     let mtree = MerkleTree::new(LEAVES4.to_vec()).expect("creating a merkle tree must work");
-    let store: MerkleStore = mtree.clone().into();
+    let store = MerkleStore::from(&mtree);
     let _ = store.get_node(mtree.root(), NodeIndex::make(mtree.depth(), 3));
 }
 
@@ -187,7 +187,7 @@ fn test_add_sparse_merkle_tree_one_level() -> Result<(), MerkleError> {
         .unwrap()
         .with_leaves(keys2.into_iter().zip(leaves2.into_iter()))
         .unwrap();
-    let store: MerkleStore = smt.clone().into();
+    let store = MerkleStore::from(&smt);
 
     let idx = NodeIndex::make(1, 0);
     assert_eq!(smt.get_node(idx).unwrap(), leaves2[0]);
@@ -207,7 +207,7 @@ fn test_sparse_merkle_tree() -> Result<(), MerkleError> {
         .with_leaves(KEYS4.into_iter().zip(LEAVES4.into_iter()))
         .unwrap();
 
-    let store: MerkleStore = smt.clone().into();
+    let store = MerkleStore::from(&smt);
 
     // STORE LEAVES ARE CORRECT ==============================================================
     // checks the leaves in the store corresponds to the expected values
@@ -465,7 +465,7 @@ fn wont_open_to_different_depth_root() {
     // attempt to fetch a node on the maximum depth, and it should fail because the root shouldn't
     // exist for the set.
     let mtree = MerkleTree::new(vec![a, b]).unwrap();
-    let store: MerkleStore = mtree.clone().into();
+    let store = MerkleStore::from(&mtree);
     let index = NodeIndex::root();
     let err = store.get_node(root, index).err().unwrap();
     assert_eq!(err, MerkleError::RootNotInStore(root));
@@ -493,7 +493,7 @@ fn store_path_opens_from_leaf() {
     let root = Rpo256::merge(&[m.into(), n.into()]);
 
     let mtree = MerkleTree::new(vec![a, b, c, d, e, f, g, h]).unwrap();
-    let store: MerkleStore = mtree.clone().into();
+    let store = MerkleStore::from(&mtree);
     let path = store.get_path(root.into(), NodeIndex::make(3, 1)).unwrap().path;
 
     let expected = MerklePath::new([a.into(), j.into(), n.into()].to_vec());
@@ -503,7 +503,7 @@ fn store_path_opens_from_leaf() {
 #[test]
 fn test_set_node() -> Result<(), MerkleError> {
     let mtree = MerkleTree::new(LEAVES4.to_vec())?;
-    let mut store: MerkleStore = mtree.clone().into();
+    let mut store = MerkleStore::from(&mtree);
     let value = int_to_node(42);
     let index = NodeIndex::make(mtree.depth(), 0);
     let new_root = store.set_node(mtree.root(), index, value)?.root;
@@ -515,7 +515,7 @@ fn test_set_node() -> Result<(), MerkleError> {
 #[test]
 fn test_constructors() -> Result<(), MerkleError> {
     let mtree = MerkleTree::new(LEAVES4.to_vec())?;
-    let store: MerkleStore = mtree.clone().into();
+    let store = MerkleStore::from(&mtree);
 
     let depth = mtree.depth();
     let leaves = 2u64.pow(depth.into());
@@ -530,7 +530,7 @@ fn test_constructors() -> Result<(), MerkleError> {
         .unwrap()
         .with_leaves(KEYS4.into_iter().zip(LEAVES4.into_iter()))
         .unwrap();
-    let store: MerkleStore = smt.clone().into();
+    let store = MerkleStore::from(&smt);
     let depth = smt.depth();
 
     for key in KEYS4 {


### PR DESCRIPTION
## Describe your changes

fixes #136   

implemented the extend trait for the merkle store, consume an iterator over inner nodes. this can be used to add existing structures into the store.


## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
