### PR TITLE
feat: add .inner_nodes() to [MerkleStore]

### DIFF
--- a/src/merkle/store/mod.rs
+++ b/src/merkle/store/mod.rs
@@ -257,6 +257,15 @@ impl MerkleStore {
         Ok(tree_depth)
     }
 
+    /// Iterator over the inner nodes of the [MerkleStore].
+    pub fn inner_nodes(&self) -> impl Iterator<Item = InnerNodeInfo> + '_ {
+        self.nodes.iter().map(|(r, n)| InnerNodeInfo {
+            value: r.into(),
+            left: n.left.into(),
+            right: n.right.into(),
+        })
+    }
+
     // STATE MUTATORS
     // --------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
## Describe your changes
This PR introduces the `.inner_nodes()` method on `MerkleStore` which allows one merkle store to be extended by the contents of the other like so:

```rust
merkle_store.extend(other_merkle_store.inner_nodes());
```

closes: #142 

## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
