### PR TITLE
refactor: refactor crypto APIs to use RpoDigest instead of Word

### DIFF
--- a/benches/store.rs
+++ b/benches/store.rs
@@ -409,7 +409,7 @@ fn update_leaf_merkletree(c: &mut Criterion) {
                     // The MerkleTree automatically updates its internal root, the Store maintains
                     // the old root and adds the new one. Here we update the root to have a fair
                     // comparison
-                    store_root = store.set_node(root, index, value).unwrap().root;
+                    store_root = store.set_node(root, index, value.into()).unwrap().root;
                     black_box(store_root)
                 },
                 BatchSize::SmallInput,
@@ -455,7 +455,7 @@ fn update_leaf_simplesmt(c: &mut Criterion) {
                     // The MerkleTree automatically updates its internal root, the Store maintains
                     // the old root and adds the new one. Here we update the root to have a fair
                     // comparison
-                    store_root = store.set_node(root, index, value).unwrap().root;
+                    store_root = store.set_node(root, index, value.into()).unwrap().root;
                     black_box(store_root)
                 },
                 BatchSize::SmallInput,

--- a/src/hash/rpo/tests.rs
+++ b/src/hash/rpo/tests.rs
@@ -2,7 +2,10 @@ use super::{
     Felt, FieldElement, Hasher, Rpo256, RpoDigest, StarkField, ALPHA, INV_ALPHA, ONE, STATE_WIDTH,
     ZERO,
 };
-use crate::utils::collections::{BTreeSet, Vec};
+use crate::{
+    utils::collections::{BTreeSet, Vec},
+    Word,
+};
 use core::convert::TryInto;
 use proptest::prelude::*;
 use rand_utils::rand_value;
@@ -232,7 +235,7 @@ proptest! {
     }
 }
 
-const EXPECTED: [[Felt; 4]; 19] = [
+const EXPECTED: [Word; 19] = [
     [
         Felt::new(1502364727743950833),
         Felt::new(5880949717274681448),

--- a/src/merkle/mmr/accumulator.rs
+++ b/src/merkle/mmr/accumulator.rs
@@ -1,4 +1,7 @@
-use super::{super::Vec, super::ZERO, Felt, MmrProof, Rpo256, Word};
+use super::{
+    super::{RpoDigest, Vec, ZERO},
+    Felt, MmrProof, Rpo256, Word,
+};
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct MmrPeaks {
@@ -25,7 +28,7 @@ pub struct MmrPeaks {
     /// leaves, starting from the peak with most children, to the one with least.
     ///
     /// Invariant: The length of `peaks` must be equal to the number of true bits in `num_leaves`.
-    pub peaks: Vec<Word>,
+    pub peaks: Vec<RpoDigest>,
 }
 
 impl MmrPeaks {
@@ -38,7 +41,7 @@ impl MmrPeaks {
         Rpo256::hash_elements(&self.flatten_and_pad_peaks()).into()
     }
 
-    pub fn verify(&self, value: Word, opening: MmrProof) -> bool {
+    pub fn verify(&self, value: RpoDigest, opening: MmrProof) -> bool {
         let root = &self.peaks[opening.peak_index()];
         opening.merkle_path.verify(opening.relative_pos() as u64, value, root)
     }
@@ -72,7 +75,15 @@ impl MmrPeaks {
         };
 
         let mut elements = Vec::with_capacity(len);
-        elements.extend_from_slice(&self.peaks.as_slice().concat());
+        elements.extend_from_slice(
+            &self
+                .peaks
+                .as_slice()
+                .iter()
+                .map(|digest| digest.into())
+                .collect::<Vec<Word>>()
+                .concat(),
+        );
         elements.resize(len, ZERO);
         elements
     }

--- a/src/merkle/mmr/full.rs
+++ b/src/merkle/mmr/full.rs
@@ -10,10 +10,10 @@
 //! depths, i.e. as part of adding adding a new element to the forest the trees with same depth are
 //! merged, creating a new tree with depth d+1, this process is continued until the property is
 //! restabilished.
-use super::bit::TrueBitPositionIterator;
 use super::{
-    super::{InnerNodeInfo, MerklePath, Vec},
-    MmrPeaks, MmrProof, Rpo256, Word,
+    super::{InnerNodeInfo, MerklePath, RpoDigest, Vec},
+    bit::TrueBitPositionIterator,
+    MmrPeaks, MmrProof, Rpo256,
 };
 use core::fmt::{Display, Formatter};
 
@@ -38,7 +38,7 @@ pub struct Mmr {
     /// the elements of every tree in the forest to be stored in the same sequential buffer. It
     /// also means new elements can be added to the forest, and merging of trees is very cheap with
     /// no need to copy elements.
-    pub(super) nodes: Vec<Word>,
+    pub(super) nodes: Vec<RpoDigest>,
 }
 
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
@@ -129,7 +129,7 @@ impl Mmr {
     /// Note: The leaf position is the 0-indexed number corresponding to the order the leaves were
     /// added, this corresponds to the MMR size _prior_ to adding the element. So the 1st element
     /// has position 0, the second position 1, and so on.
-    pub fn get(&self, pos: usize) -> Result<Word, MmrError> {
+    pub fn get(&self, pos: usize) -> Result<RpoDigest, MmrError> {
         // find the target tree responsible for the MMR position
         let tree_bit =
             leaf_to_corresponding_tree(pos, self.forest).ok_or(MmrError::InvalidPosition(pos))?;
@@ -153,7 +153,7 @@ impl Mmr {
     }
 
     /// Adds a new element to the MMR.
-    pub fn add(&mut self, el: Word) {
+    pub fn add(&mut self, el: RpoDigest) {
         // Note: every node is also a tree of size 1, adding an element to the forest creates a new
         // rooted-tree of size 1. This may temporarily break the invariant that every tree in the
         // forest has different sizes, the loop below will eagerly merge trees of same size and
@@ -164,7 +164,7 @@ impl Mmr {
         let mut right = el;
         let mut left_tree = 1;
         while self.forest & left_tree != 0 {
-            right = *Rpo256::merge(&[self.nodes[left_offset].into(), right.into()]);
+            right = Rpo256::merge(&[self.nodes[left_offset], right]);
             self.nodes.push(right);
 
             left_offset = left_offset.saturating_sub(nodes_in_forest(left_tree));
@@ -176,7 +176,7 @@ impl Mmr {
 
     /// Returns an accumulator representing the current state of the MMR.
     pub fn accumulator(&self) -> MmrPeaks {
-        let peaks: Vec<Word> = TrueBitPositionIterator::new(self.forest)
+        let peaks: Vec<RpoDigest> = TrueBitPositionIterator::new(self.forest)
             .rev()
             .map(|bit| nodes_in_forest(1 << bit))
             .scan(0, |offset, el| {
@@ -212,7 +212,7 @@ impl Mmr {
         relative_pos: usize,
         index_offset: usize,
         mut index: usize,
-    ) -> (Word, Vec<Word>) {
+    ) -> (RpoDigest, Vec<RpoDigest>) {
         // collect the Merkle path
         let mut tree_depth = tree_bit as usize;
         let mut path = Vec::with_capacity(tree_depth + 1);
@@ -247,7 +247,7 @@ impl Mmr {
 
 impl<T> From<T> for Mmr
 where
-    T: IntoIterator<Item = Word>,
+    T: IntoIterator<Item = RpoDigest>,
 {
     fn from(values: T) -> Self {
         let mut mmr = Mmr::new();

--- a/src/merkle/mmr/tests.rs
+++ b/src/merkle/mmr/tests.rs
@@ -1,10 +1,14 @@
-use super::bit::TrueBitPositionIterator;
-use super::full::{high_bitmask, leaf_to_corresponding_tree, nodes_in_forest};
 use super::{
-    super::{InnerNodeInfo, Vec, WORD_SIZE, ZERO},
-    Mmr, MmrPeaks, Rpo256, Word,
+    super::{InnerNodeInfo, Vec, WORD_SIZE},
+    bit::TrueBitPositionIterator,
+    full::{high_bitmask, leaf_to_corresponding_tree, nodes_in_forest},
+    Mmr, MmrPeaks, Rpo256,
 };
-use crate::merkle::{int_to_node, MerklePath};
+use crate::{
+    hash::rpo::RpoDigest,
+    merkle::{int_to_node, MerklePath},
+    Felt, Word,
+};
 
 #[test]
 fn test_position_equal_or_higher_than_leafs_is_never_contained() {
@@ -99,7 +103,7 @@ fn test_nodes_in_forest_single_bit() {
     }
 }
 
-const LEAVES: [Word; 7] = [
+const LEAVES: [RpoDigest; 7] = [
     int_to_node(0),
     int_to_node(1),
     int_to_node(2),
@@ -114,14 +118,38 @@ fn test_mmr_simple() {
     let mut postorder = Vec::new();
     postorder.push(LEAVES[0]);
     postorder.push(LEAVES[1]);
-    postorder.push(*Rpo256::hash_elements(&[LEAVES[0], LEAVES[1]].concat()));
+    postorder.push(Rpo256::hash_elements(
+        &[LEAVES[0], LEAVES[1]]
+            .iter()
+            .map(|digest| digest.into())
+            .collect::<Vec<[Felt; WORD_SIZE]>>()
+            .concat(),
+    ));
     postorder.push(LEAVES[2]);
     postorder.push(LEAVES[3]);
-    postorder.push(*Rpo256::hash_elements(&[LEAVES[2], LEAVES[3]].concat()));
-    postorder.push(*Rpo256::hash_elements(&[postorder[2], postorder[5]].concat()));
+    postorder.push(Rpo256::hash_elements(
+        &[LEAVES[2], LEAVES[3]]
+            .iter()
+            .map(|digest| digest.into())
+            .collect::<Vec<[Felt; WORD_SIZE]>>()
+            .concat(),
+    ));
+    postorder.push(Rpo256::hash_elements(
+        &[postorder[2], postorder[5]]
+            .iter()
+            .map(|digest| digest.into())
+            .collect::<Vec<[Felt; WORD_SIZE]>>()
+            .concat(),
+    ));
     postorder.push(LEAVES[4]);
     postorder.push(LEAVES[5]);
-    postorder.push(*Rpo256::hash_elements(&[LEAVES[4], LEAVES[5]].concat()));
+    postorder.push(Rpo256::hash_elements(
+        &[LEAVES[4], LEAVES[5]]
+            .iter()
+            .map(|digest| digest.into())
+            .collect::<Vec<[Felt; WORD_SIZE]>>()
+            .concat(),
+    ));
     postorder.push(LEAVES[6]);
 
     let mut mmr = Mmr::new();
@@ -195,8 +223,20 @@ fn test_mmr_simple() {
 #[test]
 fn test_mmr_open() {
     let mmr: Mmr = LEAVES.into();
-    let h01: Word = Rpo256::hash_elements(&LEAVES[0..2].concat()).into();
-    let h23: Word = Rpo256::hash_elements(&LEAVES[2..4].concat()).into();
+    let h01: RpoDigest = Rpo256::hash_elements(
+        &LEAVES[0..2]
+            .iter()
+            .map(|digest| digest.into())
+            .collect::<Vec<[Felt; WORD_SIZE]>>()
+            .concat(),
+    );
+    let h23: RpoDigest = Rpo256::hash_elements(
+        &LEAVES[2..4]
+            .iter()
+            .map(|digest| digest.into())
+            .collect::<Vec<[Felt; WORD_SIZE]>>()
+            .concat(),
+    );
 
     // node at pos 7 is the root
     assert!(mmr.open(7).is_err(), "Element 7 is not in the tree, result should be None");
@@ -214,7 +254,7 @@ fn test_mmr_open() {
         "MmrProof should be valid for the current accumulator."
     );
 
-    // nodes 4,5 are detph 1
+    // nodes 4,5 are depth 1
     let root_to_path = MerklePath::new(vec![LEAVES[4]]);
     let opening = mmr
         .open(5)
@@ -361,10 +401,34 @@ fn test_mmr_inner_nodes() {
     let mmr: Mmr = LEAVES.into();
     let nodes: Vec<InnerNodeInfo> = mmr.inner_nodes().collect();
 
-    let h01 = *Rpo256::hash_elements(&[LEAVES[0], LEAVES[1]].concat());
-    let h23 = *Rpo256::hash_elements(&[LEAVES[2], LEAVES[3]].concat());
-    let h0123 = *Rpo256::hash_elements(&[h01, h23].concat());
-    let h45 = *Rpo256::hash_elements(&[LEAVES[4], LEAVES[5]].concat());
+    let h01 = Rpo256::hash_elements(
+        &[LEAVES[0], LEAVES[1]]
+            .iter()
+            .map(|digest| digest.into())
+            .collect::<Vec<[Felt; WORD_SIZE]>>()
+            .concat(),
+    );
+    let h23 = Rpo256::hash_elements(
+        &[LEAVES[2], LEAVES[3]]
+            .iter()
+            .map(|digest| digest.into())
+            .collect::<Vec<[Felt; WORD_SIZE]>>()
+            .concat(),
+    );
+    let h0123 = Rpo256::hash_elements(
+        &[h01, h23]
+            .iter()
+            .map(|digest| digest.into())
+            .collect::<Vec<[Felt; WORD_SIZE]>>()
+            .concat(),
+    );
+    let h45 = Rpo256::hash_elements(
+        &[LEAVES[4], LEAVES[5]]
+            .iter()
+            .map(|digest| digest.into())
+            .collect::<Vec<[Felt; WORD_SIZE]>>()
+            .concat(),
+    );
     let postorder = vec![
         InnerNodeInfo {
             value: h01,
@@ -396,17 +460,45 @@ fn test_mmr_hash_peaks() {
     let mmr: Mmr = LEAVES.into();
     let peaks = mmr.accumulator();
 
-    let first_peak = *Rpo256::merge(&[
-        Rpo256::hash_elements(&[LEAVES[0], LEAVES[1]].concat()),
-        Rpo256::hash_elements(&[LEAVES[2], LEAVES[3]].concat()),
+    let first_peak = Rpo256::merge(&[
+        Rpo256::hash_elements(
+            &[LEAVES[0], LEAVES[1]]
+                .iter()
+                .map(|digest| digest.into())
+                .collect::<Vec<Word>>()
+                .concat(),
+        ),
+        Rpo256::hash_elements(
+            &[LEAVES[2], LEAVES[3]]
+                .iter()
+                .map(|digest| digest.into())
+                .collect::<Vec<Word>>()
+                .concat(),
+        ),
     ]);
-    let second_peak = *Rpo256::hash_elements(&[LEAVES[4], LEAVES[5]].concat());
+    let second_peak = Rpo256::hash_elements(
+        &[LEAVES[4], LEAVES[5]]
+            .iter()
+            .map(|digest| digest.into())
+            .collect::<Vec<[Felt; WORD_SIZE]>>()
+            .concat(),
+    );
     let third_peak = LEAVES[6];
 
     // minimum length is 16
     let mut expected_peaks = [first_peak, second_peak, third_peak].to_vec();
-    expected_peaks.resize(16, [ZERO; WORD_SIZE]);
-    assert_eq!(peaks.hash_peaks(), *Rpo256::hash_elements(&expected_peaks.as_slice().concat()));
+    expected_peaks.resize(16, RpoDigest::default());
+    assert_eq!(
+        peaks.hash_peaks(),
+        *Rpo256::hash_elements(
+            &expected_peaks
+                .as_slice()
+                .iter()
+                .map(|digest| digest.into())
+                .collect::<Vec<Word>>()
+                .concat()
+        )
+    );
 }
 
 #[test]
@@ -422,10 +514,17 @@ fn test_mmr_peaks_hash_less_than_16() {
 
         // minimum length is 16
         let mut expected_peaks = peaks.clone();
-        expected_peaks.resize(16, [ZERO; WORD_SIZE]);
+        expected_peaks.resize(16, RpoDigest::default());
         assert_eq!(
             accumulator.hash_peaks(),
-            *Rpo256::hash_elements(&expected_peaks.as_slice().concat())
+            *Rpo256::hash_elements(
+                &expected_peaks
+                    .as_slice()
+                    .iter()
+                    .map(|digest| digest.into())
+                    .collect::<Vec<Word>>()
+                    .concat()
+            )
         );
     }
 }
@@ -441,10 +540,17 @@ fn test_mmr_peaks_hash_odd() {
 
     // odd length bigger than 16 is padded to the next even nubmer
     let mut expected_peaks = peaks.clone();
-    expected_peaks.resize(18, [ZERO; WORD_SIZE]);
+    expected_peaks.resize(18, RpoDigest::default());
     assert_eq!(
         accumulator.hash_peaks(),
-        *Rpo256::hash_elements(&expected_peaks.as_slice().concat())
+        *Rpo256::hash_elements(
+            &expected_peaks
+                .as_slice()
+                .iter()
+                .map(|digest| digest.into())
+                .collect::<Vec<Word>>()
+                .concat()
+        )
     );
 }
 

--- a/src/merkle/mod.rs
+++ b/src/merkle/mod.rs
@@ -10,7 +10,6 @@ use core::fmt;
 
 mod empty_roots;
 pub use empty_roots::EmptySubtreeRoots;
-use empty_roots::EMPTY_WORD;
 
 mod index;
 pub use index::NodeIndex;
@@ -44,7 +43,7 @@ pub use node::InnerNodeInfo;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum MerkleError {
-    ConflictingRoots(Vec<Word>),
+    ConflictingRoots(Vec<RpoDigest>),
     DepthTooSmall(u8),
     DepthTooBig(u64),
     DuplicateValuesForIndex(u64),
@@ -54,9 +53,9 @@ pub enum MerkleError {
     InvalidPath(MerklePath),
     InvalidNumEntries(usize, usize),
     NodeNotInSet(NodeIndex),
-    NodeNotInStore(Word, NodeIndex),
+    NodeNotInStore(RpoDigest, NodeIndex),
     NumLeavesNotPowerOfTwo(usize),
-    RootNotInStore(Word),
+    RootNotInStore(RpoDigest),
 }
 
 impl fmt::Display for MerkleError {
@@ -95,6 +94,11 @@ impl std::error::Error for MerkleError {}
 // ================================================================================================
 
 #[cfg(test)]
-const fn int_to_node(value: u64) -> Word {
+const fn int_to_node(value: u64) -> RpoDigest {
+    RpoDigest::new([Felt::new(value), ZERO, ZERO, ZERO])
+}
+
+#[cfg(test)]
+const fn int_to_leaf(value: u64) -> Word {
     [Felt::new(value), ZERO, ZERO, ZERO]
 }

--- a/src/merkle/mod.rs
+++ b/src/merkle/mod.rs
@@ -103,6 +103,7 @@ const fn int_to_leaf(value: u64) -> Word {
     [Felt::new(value), ZERO, ZERO, ZERO]
 }
 
-pub fn digests_to_words(digests: &[RpoDigest]) -> Vec<Word> {
+#[cfg(test)]
+fn digests_to_words(digests: &[RpoDigest]) -> Vec<Word> {
     digests.iter().map(|d| d.into()).collect()
 }

--- a/src/merkle/mod.rs
+++ b/src/merkle/mod.rs
@@ -102,3 +102,7 @@ const fn int_to_node(value: u64) -> RpoDigest {
 const fn int_to_leaf(value: u64) -> Word {
     [Felt::new(value), ZERO, ZERO, ZERO]
 }
+
+pub fn digests_to_words(digests: &[RpoDigest]) -> Vec<Word> {
+    digests.iter().map(|d| d.into()).collect()
+}

--- a/src/merkle/node.rs
+++ b/src/merkle/node.rs
@@ -1,9 +1,9 @@
-use super::Word;
+use crate::hash::rpo::RpoDigest;
 
 /// Representation of a node with two children used for iterating over containers.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InnerNodeInfo {
-    pub value: Word,
-    pub left: Word,
-    pub right: Word,
+    pub value: RpoDigest,
+    pub left: RpoDigest,
+    pub right: RpoDigest,
 }

--- a/src/merkle/path.rs
+++ b/src/merkle/path.rs
@@ -1,4 +1,4 @@
-use super::{vec, InnerNodeInfo, MerkleError, NodeIndex, Rpo256, Vec, Word};
+use super::{vec, InnerNodeInfo, MerkleError, NodeIndex, Rpo256, RpoDigest, Vec};
 use core::ops::{Deref, DerefMut};
 
 // MERKLE PATH
@@ -7,7 +7,7 @@ use core::ops::{Deref, DerefMut};
 /// A merkle path container, composed of a sequence of nodes of a Merkle tree.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct MerklePath {
-    nodes: Vec<Word>,
+    nodes: Vec<RpoDigest>,
 }
 
 impl MerklePath {
@@ -15,7 +15,7 @@ impl MerklePath {
     // --------------------------------------------------------------------------------------------
 
     /// Creates a new Merkle path from a list of nodes.
-    pub fn new(nodes: Vec<Word>) -> Self {
+    pub fn new(nodes: Vec<RpoDigest>) -> Self {
         Self { nodes }
     }
 
@@ -28,13 +28,13 @@ impl MerklePath {
     }
 
     /// Computes the merkle root for this opening.
-    pub fn compute_root(&self, index: u64, node: Word) -> Result<Word, MerkleError> {
+    pub fn compute_root(&self, index: u64, node: RpoDigest) -> Result<RpoDigest, MerkleError> {
         let mut index = NodeIndex::new(self.depth(), index)?;
         let root = self.nodes.iter().copied().fold(node, |node, sibling| {
             // compute the node and move to the next iteration.
-            let input = index.build_node(node.into(), sibling.into());
+            let input = index.build_node(node, sibling);
             index.move_up();
-            Rpo256::merge(&input).into()
+            Rpo256::merge(&input)
         });
         Ok(root)
     }
@@ -42,7 +42,7 @@ impl MerklePath {
     /// Verifies the Merkle opening proof towards the provided root.
     ///
     /// Returns `true` if `node` exists at `index` in a Merkle tree with `root`.
-    pub fn verify(&self, index: u64, node: Word, root: &Word) -> bool {
+    pub fn verify(&self, index: u64, node: RpoDigest, root: &RpoDigest) -> bool {
         match self.compute_root(index, node) {
             Ok(computed_root) => root == &computed_root,
             Err(_) => false,
@@ -55,7 +55,11 @@ impl MerklePath {
     ///
     /// # Errors
     /// Returns an error if the specified index is not valid for this path.
-    pub fn inner_nodes(&self, index: u64, node: Word) -> Result<InnerNodeIterator, MerkleError> {
+    pub fn inner_nodes(
+        &self,
+        index: u64,
+        node: RpoDigest,
+    ) -> Result<InnerNodeIterator, MerkleError> {
         Ok(InnerNodeIterator {
             nodes: &self.nodes,
             index: NodeIndex::new(self.depth(), index)?,
@@ -64,8 +68,8 @@ impl MerklePath {
     }
 }
 
-impl From<Vec<Word>> for MerklePath {
-    fn from(path: Vec<Word>) -> Self {
+impl From<Vec<RpoDigest>> for MerklePath {
+    fn from(path: Vec<RpoDigest>) -> Self {
         Self::new(path)
     }
 }
@@ -73,7 +77,7 @@ impl From<Vec<Word>> for MerklePath {
 impl Deref for MerklePath {
     // we use `Vec` here instead of slice so we can call vector mutation methods directly from the
     // merkle path (example: `Vec::remove`).
-    type Target = Vec<Word>;
+    type Target = Vec<RpoDigest>;
 
     fn deref(&self) -> &Self::Target {
         &self.nodes
@@ -89,15 +93,15 @@ impl DerefMut for MerklePath {
 // ITERATORS
 // ================================================================================================
 
-impl FromIterator<Word> for MerklePath {
-    fn from_iter<T: IntoIterator<Item = Word>>(iter: T) -> Self {
+impl FromIterator<RpoDigest> for MerklePath {
+    fn from_iter<T: IntoIterator<Item = RpoDigest>>(iter: T) -> Self {
         Self::new(iter.into_iter().collect())
     }
 }
 
 impl IntoIterator for MerklePath {
-    type Item = Word;
-    type IntoIter = vec::IntoIter<Word>;
+    type Item = RpoDigest;
+    type IntoIter = vec::IntoIter<RpoDigest>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.nodes.into_iter()
@@ -106,9 +110,9 @@ impl IntoIterator for MerklePath {
 
 /// An iterator over internal nodes of a [MerklePath].
 pub struct InnerNodeIterator<'a> {
-    nodes: &'a Vec<Word>,
+    nodes: &'a Vec<RpoDigest>,
     index: NodeIndex,
-    value: Word,
+    value: RpoDigest,
 }
 
 impl<'a> Iterator for InnerNodeIterator<'a> {
@@ -123,7 +127,7 @@ impl<'a> Iterator for InnerNodeIterator<'a> {
                 (self.value, self.nodes[sibling_pos])
             };
 
-            self.value = Rpo256::merge(&[left.into(), right.into()]).into();
+            self.value = Rpo256::merge(&[left, right]);
             self.index.move_up();
 
             Some(InnerNodeInfo {
@@ -144,7 +148,7 @@ impl<'a> Iterator for InnerNodeIterator<'a> {
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct ValuePath {
     /// The node value opening for `path`.
-    pub value: Word,
+    pub value: RpoDigest,
     /// The path from `value` to `root` (exclusive).
     pub path: MerklePath,
 }
@@ -156,7 +160,7 @@ pub struct ValuePath {
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct RootPath {
     /// The node value opening for `path`.
-    pub root: Word,
+    pub root: RpoDigest,
     /// The path from `value` to `root` (exclusive).
     pub path: MerklePath,
 }

--- a/src/merkle/path_set.rs
+++ b/src/merkle/path_set.rs
@@ -1,4 +1,5 @@
-use super::{BTreeMap, MerkleError, MerklePath, NodeIndex, Rpo256, ValuePath, Vec, Word, ZERO};
+use super::{BTreeMap, MerkleError, MerklePath, NodeIndex, Rpo256, ValuePath, Vec};
+use crate::{hash::rpo::RpoDigest, Word};
 
 // MERKLE PATH SET
 // ================================================================================================
@@ -6,7 +7,7 @@ use super::{BTreeMap, MerkleError, MerklePath, NodeIndex, Rpo256, ValuePath, Vec
 /// A set of Merkle paths.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MerklePathSet {
-    root: Word,
+    root: RpoDigest,
     total_depth: u8,
     paths: BTreeMap<u64, MerklePath>,
 }
@@ -17,7 +18,7 @@ impl MerklePathSet {
 
     /// Returns an empty MerklePathSet.
     pub fn new(depth: u8) -> Self {
-        let root = [ZERO; 4];
+        let root = RpoDigest::default();
         let paths = BTreeMap::new();
 
         Self {
@@ -32,7 +33,7 @@ impl MerklePathSet {
     /// Analogous to `[Self::add_path]`.
     pub fn with_paths<I>(self, paths: I) -> Result<Self, MerkleError>
     where
-        I: IntoIterator<Item = (u64, Word, MerklePath)>,
+        I: IntoIterator<Item = (u64, RpoDigest, MerklePath)>,
     {
         paths.into_iter().try_fold(self, |mut set, (index, value, path)| {
             set.add_path(index, value, path)?;
@@ -44,7 +45,7 @@ impl MerklePathSet {
     // --------------------------------------------------------------------------------------------
 
     /// Returns the root to which all paths in this set resolve.
-    pub const fn root(&self) -> Word {
+    pub const fn root(&self) -> RpoDigest {
         self.root
     }
 
@@ -61,7 +62,7 @@ impl MerklePathSet {
     /// Returns an error if:
     /// * The specified index is not valid for the depth of structure.
     /// * Requested node does not exist in the set.
-    pub fn get_node(&self, index: NodeIndex) -> Result<Word, MerkleError> {
+    pub fn get_node(&self, index: NodeIndex) -> Result<RpoDigest, MerkleError> {
         if index.depth() != self.total_depth {
             return Err(MerkleError::InvalidDepth {
                 expected: self.total_depth,
@@ -84,7 +85,7 @@ impl MerklePathSet {
     /// * Leaf with the requested path does not exist in the set.
     pub fn get_leaf(&self, index: u64) -> Result<Word, MerkleError> {
         let index = NodeIndex::new(self.depth(), index)?;
-        self.get_node(index)
+        Ok(self.get_node(index)?.into())
     }
 
     /// Returns a Merkle path to the node at the specified index. The node itself is
@@ -150,7 +151,7 @@ impl MerklePathSet {
     pub fn add_path(
         &mut self,
         index_value: u64,
-        value: Word,
+        value: RpoDigest,
         mut path: MerklePath,
     ) -> Result<(), MerkleError> {
         let mut index = NodeIndex::new(path.len() as u8, index_value)?;
@@ -166,15 +167,15 @@ impl MerklePathSet {
         path.insert(parity as usize, value);
 
         // traverse to the root, updating the nodes
-        let root: Word = Rpo256::merge(&[path[0].into(), path[1].into()]).into();
+        let root: RpoDigest = Rpo256::merge(&[path[0], path[1]]);
         let root = path.iter().skip(2).copied().fold(root, |root, hash| {
             index.move_up();
-            Rpo256::merge(&index.build_node(root.into(), hash.into())).into()
+            Rpo256::merge(&index.build_node(root, hash))
         });
 
         // if the path set is empty (the root is all ZEROs), set the root to the root of the added
         // path; otherwise, the root of the added path must be identical to the current root
-        if self.root == [ZERO; 4] {
+        if self.root == RpoDigest::default() {
             self.root = root;
         } else if self.root != root {
             return Err(MerkleError::ConflictingRoots([self.root, root].to_vec()));
@@ -191,7 +192,11 @@ impl MerklePathSet {
     /// # Errors
     /// Returns an error if:
     /// * Requested node does not exist in the set.
-    pub fn update_leaf(&mut self, base_index_value: u64, value: Word) -> Result<(), MerkleError> {
+    pub fn update_leaf(
+        &mut self,
+        base_index_value: u64,
+        value: RpoDigest,
+    ) -> Result<(), MerkleError> {
         let mut index = NodeIndex::new(self.depth(), base_index_value)?;
         let parity = index.value() & 1;
         let path_key = index.value() - parity;
@@ -203,24 +208,24 @@ impl MerklePathSet {
         // Fill old_hashes vector -----------------------------------------------------------------
         let mut current_index = index;
         let mut old_hashes = Vec::with_capacity(path.len().saturating_sub(2));
-        let mut root: Word = Rpo256::merge(&[path[0].into(), path[1].into()]).into();
+        let mut root: RpoDigest = Rpo256::merge(&[path[0], path[1]]);
         for hash in path.iter().skip(2).copied() {
             old_hashes.push(root);
             current_index.move_up();
-            let input = current_index.build_node(hash.into(), root.into());
-            root = Rpo256::merge(&input).into();
+            let input = current_index.build_node(hash, root);
+            root = Rpo256::merge(&input);
         }
 
         // Fill new_hashes vector -----------------------------------------------------------------
         path[index.is_value_odd() as usize] = value;
 
         let mut new_hashes = Vec::with_capacity(path.len().saturating_sub(2));
-        let mut new_root: Word = Rpo256::merge(&[path[0].into(), path[1].into()]).into();
+        let mut new_root: RpoDigest = Rpo256::merge(&[path[0], path[1]]);
         for path_hash in path.iter().skip(2).copied() {
             new_hashes.push(new_root);
             index.move_up();
-            let input = current_index.build_node(path_hash.into(), new_root.into());
-            new_root = Rpo256::merge(&input).into();
+            let input = current_index.build_node(path_hash, new_root);
+            new_root = Rpo256::merge(&input);
         }
 
         self.root = new_root;
@@ -345,13 +350,13 @@ mod tests {
         let g = int_to_node(7);
         let h = int_to_node(8);
 
-        let i = Rpo256::merge(&[a.into(), b.into()]);
-        let j = Rpo256::merge(&[c.into(), d.into()]);
-        let k = Rpo256::merge(&[e.into(), f.into()]);
-        let l = Rpo256::merge(&[g.into(), h.into()]);
+        let i = Rpo256::merge(&[a, b]);
+        let j = Rpo256::merge(&[c, d]);
+        let k = Rpo256::merge(&[e, f]);
+        let l = Rpo256::merge(&[g, h]);
 
-        let m = Rpo256::merge(&[i.into(), j.into()]);
-        let n = Rpo256::merge(&[k.into(), l.into()]);
+        let m = Rpo256::merge(&[i, j]);
+        let n = Rpo256::merge(&[k, l]);
 
         let root = Rpo256::merge(&[m.into(), n.into()]);
 
@@ -359,31 +364,31 @@ mod tests {
 
         let value = b;
         let index = 1;
-        let path = MerklePath::new([a.into(), j.into(), n.into()].to_vec());
+        let path = MerklePath::new([a, j, n].to_vec());
         set.add_path(index, value, path.clone()).unwrap();
-        assert_eq!(value, set.get_leaf(index).unwrap());
-        assert_eq!(Word::from(root), set.root());
+        assert_eq!(*value, set.get_leaf(index).unwrap());
+        assert_eq!(RpoDigest::from(root), set.root());
 
         let value = e;
         let index = 4;
         let path = MerklePath::new([f.into(), l.into(), m.into()].to_vec());
         set.add_path(index, value, path.clone()).unwrap();
-        assert_eq!(value, set.get_leaf(index).unwrap());
-        assert_eq!(Word::from(root), set.root());
+        assert_eq!(*value, set.get_leaf(index).unwrap());
+        assert_eq!(RpoDigest::from(root), set.root());
 
         let value = a;
         let index = 0;
         let path = MerklePath::new([b.into(), j.into(), n.into()].to_vec());
         set.add_path(index, value, path.clone()).unwrap();
-        assert_eq!(value, set.get_leaf(index).unwrap());
-        assert_eq!(Word::from(root), set.root());
+        assert_eq!(*value, set.get_leaf(index).unwrap());
+        assert_eq!(RpoDigest::from(root), set.root());
 
         let value = h;
         let index = 7;
         let path = MerklePath::new([g.into(), k.into(), m.into()].to_vec());
         set.add_path(index, value, path.clone()).unwrap();
-        assert_eq!(value, set.get_leaf(index).unwrap());
-        assert_eq!(Word::from(root), set.root());
+        assert_eq!(*value, set.get_leaf(index).unwrap());
+        assert_eq!(RpoDigest::from(root), set.root());
     }
 
     // HELPER FUNCTIONS
@@ -397,11 +402,11 @@ mod tests {
     /// - node — current node
     /// - node_pos — position of the current node
     /// - sibling — neighboring vertex in the tree
-    fn calculate_parent_hash(node: Word, node_pos: u64, sibling: Word) -> Word {
+    fn calculate_parent_hash(node: RpoDigest, node_pos: u64, sibling: RpoDigest) -> RpoDigest {
         if is_even(node_pos) {
-            Rpo256::merge(&[node.into(), sibling.into()]).into()
+            Rpo256::merge(&[node, sibling])
         } else {
-            Rpo256::merge(&[sibling.into(), node.into()]).into()
+            Rpo256::merge(&[sibling, node])
         }
     }
 }

--- a/src/merkle/simple_smt/tests.rs
+++ b/src/merkle/simple_smt/tests.rs
@@ -36,7 +36,7 @@ fn build_empty_tree() {
     // tree of depth 3
     let smt = SimpleSmt::new(3).unwrap();
     let mt = MerkleTree::new(ZERO_VALUES8.to_vec()).unwrap();
-    assert_eq!(mt.root(), smt.root().into());
+    assert_eq!(mt.root(), smt.root());
 }
 
 #[test]
@@ -47,10 +47,10 @@ fn build_sparse_tree() {
     // insert single value
     let key = 6;
     let new_node = int_to_leaf(7);
-    values[key as usize] = new_node.into();
+    values[key as usize] = new_node;
     let old_value = smt.update_leaf(key, new_node).expect("Failed to update leaf");
     let mt2 = MerkleTree::new(values.clone()).unwrap();
-    assert_eq!(mt2.root(), smt.root().into());
+    assert_eq!(mt2.root(), smt.root());
     assert_eq!(
         mt2.get_path(NodeIndex::make(3, 6)).unwrap(),
         smt.get_path(NodeIndex::make(3, 6)).unwrap()
@@ -63,7 +63,7 @@ fn build_sparse_tree() {
     values[key as usize] = new_node;
     let old_value = smt.update_leaf(key, new_node).expect("Failed to update leaf");
     let mt3 = MerkleTree::new(values).unwrap();
-    assert_eq!(mt3.root(), smt.root().into());
+    assert_eq!(mt3.root(), smt.root());
     assert_eq!(
         mt3.get_path(NodeIndex::make(3, 2)).unwrap(),
         smt.get_path(NodeIndex::make(3, 2)).unwrap()
@@ -90,10 +90,10 @@ fn test_depth2_tree() {
     assert_eq!(VALUES4[3], tree.get_node(NodeIndex::make(2, 3)).unwrap());
 
     // check get_path(): depth 2
-    assert_eq!(vec![VALUES4[1].into(), node3], *tree.get_path(NodeIndex::make(2, 0)).unwrap());
-    assert_eq!(vec![VALUES4[0].into(), node3], *tree.get_path(NodeIndex::make(2, 1)).unwrap());
-    assert_eq!(vec![VALUES4[3].into(), node2], *tree.get_path(NodeIndex::make(2, 2)).unwrap());
-    assert_eq!(vec![VALUES4[2].into(), node2], *tree.get_path(NodeIndex::make(2, 3)).unwrap());
+    assert_eq!(vec![VALUES4[1], node3], *tree.get_path(NodeIndex::make(2, 0)).unwrap());
+    assert_eq!(vec![VALUES4[0], node3], *tree.get_path(NodeIndex::make(2, 1)).unwrap());
+    assert_eq!(vec![VALUES4[3], node2], *tree.get_path(NodeIndex::make(2, 2)).unwrap());
+    assert_eq!(vec![VALUES4[2], node2], *tree.get_path(NodeIndex::make(2, 3)).unwrap());
 
     // check get_path(): depth 1
     assert_eq!(vec![node3], *tree.get_path(NodeIndex::make(1, 0)).unwrap());
@@ -189,15 +189,15 @@ fn small_tree_opening_is_consistent() {
     let c = Word::from(Rpo256::merge(&[b.into(); 2]));
     let d = Word::from(Rpo256::merge(&[c.into(); 2]));
 
-    let e = RpoDigest::from(Rpo256::merge(&[a.into(), b.into()]));
-    let f = RpoDigest::from(Rpo256::merge(&[z.into(), z.into()]));
-    let g = RpoDigest::from(Rpo256::merge(&[c.into(), z.into()]));
-    let h = RpoDigest::from(Rpo256::merge(&[z.into(), d.into()]));
+    let e = Rpo256::merge(&[a.into(), b.into()]);
+    let f = Rpo256::merge(&[z.into(), z.into()]);
+    let g = Rpo256::merge(&[c.into(), z.into()]);
+    let h = Rpo256::merge(&[z.into(), d.into()]);
 
-    let i = RpoDigest::from(Rpo256::merge(&[e.into(), f.into()]));
-    let j = RpoDigest::from(Rpo256::merge(&[g.into(), h.into()]));
+    let i = Rpo256::merge(&[e, f]);
+    let j = Rpo256::merge(&[g, h]);
 
-    let k = RpoDigest::from(Rpo256::merge(&[i.into(), j.into()]));
+    let k = Rpo256::merge(&[i, j]);
 
     let depth = 3;
     let entries = vec![(0, a), (1, b), (4, c), (7, d)];
@@ -255,21 +255,9 @@ fn with_no_duplicates_empty_node() {
 // --------------------------------------------------------------------------------------------
 
 fn compute_internal_nodes() -> (RpoDigest, RpoDigest, RpoDigest) {
-    let node2 = Rpo256::hash_elements(
-        &[VALUES4[0], VALUES4[1]]
-            .iter()
-            .map(|digest| digest.into())
-            .collect::<Vec<Word>>()
-            .concat(),
-    );
-    let node3 = Rpo256::hash_elements(
-        &[VALUES4[2], VALUES4[3]]
-            .iter()
-            .map(|digest| digest.into())
-            .collect::<Vec<Word>>()
-            .concat(),
-    );
+    let node2 = Rpo256::merge(&[VALUES4[0], VALUES4[1]]);
+    let node3 = Rpo256::merge(&[VALUES4[2], VALUES4[3]]);
     let root = Rpo256::merge(&[node2, node3]);
 
-    (root.into(), node2.into(), node3.into())
+    (root, node2, node3)
 }

--- a/src/merkle/store/tests.rs
+++ b/src/merkle/store/tests.rs
@@ -485,7 +485,6 @@ fn wont_open_to_different_depth_root() {
     for depth in (1..=63).rev() {
         root = Rpo256::merge(&[root, empty[depth]]);
     }
-    let root = RpoDigest::from(root);
 
     // For this example, the depth of the Merkle tree is 1, as we have only two leaves. Here we
     // attempt to fetch a node on the maximum depth, and it should fail because the root shouldn't
@@ -513,16 +512,16 @@ fn store_path_opens_from_leaf() {
     let k = Rpo256::merge(&[e.into(), f.into()]);
     let l = Rpo256::merge(&[g.into(), h.into()]);
 
-    let m = Rpo256::merge(&[i.into(), j.into()]);
-    let n = Rpo256::merge(&[k.into(), l.into()]);
+    let m = Rpo256::merge(&[i, j]);
+    let n = Rpo256::merge(&[k, l]);
 
-    let root = Rpo256::merge(&[m.into(), n.into()]);
+    let root = Rpo256::merge(&[m, n]);
 
     let mtree = MerkleTree::new(vec![a, b, c, d, e, f, g, h]).unwrap();
     let store = MerkleStore::from(&mtree);
     let path = store.get_path(root, NodeIndex::make(3, 1)).unwrap().path;
 
-    let expected = MerklePath::new([a.into(), j.into(), n.into()].to_vec());
+    let expected = MerklePath::new([a.into(), j, n].to_vec());
     assert_eq!(path, expected);
 }
 

--- a/src/merkle/tiered_smt/mod.rs
+++ b/src/merkle/tiered_smt/mod.rs
@@ -1,6 +1,6 @@
 use super::{
-    BTreeMap, BTreeSet, EmptySubtreeRoots, Felt, InnerNodeInfo, MerkleError, MerklePath, NodeIndex,
-    Rpo256, RpoDigest, StarkField, Vec, Word, EMPTY_WORD, ZERO,
+    empty_roots::EMPTY_WORD, BTreeMap, BTreeSet, EmptySubtreeRoots, Felt, InnerNodeInfo,
+    MerkleError, MerklePath, NodeIndex, Rpo256, RpoDigest, StarkField, Vec, Word, ZERO,
 };
 use core::cmp;
 
@@ -123,7 +123,7 @@ impl TieredSmt {
         let mut path = Vec::with_capacity(index.depth() as usize);
         for _ in 0..index.depth() {
             let node = self.get_node_unchecked(&index.sibling());
-            path.push(node.into());
+            path.push(node);
             index.move_up();
         }
 
@@ -200,9 +200,9 @@ impl TieredSmt {
         self.nodes.iter().filter_map(|(index, node)| {
             if is_inner_node(index) {
                 Some(InnerNodeInfo {
-                    value: node.into(),
-                    left: self.get_node_unchecked(&index.left_child()).into(),
-                    right: self.get_node_unchecked(&index.right_child()).into(),
+                    value: *node,
+                    left: self.get_node_unchecked(&index.left_child()),
+                    right: self.get_node_unchecked(&index.right_child()),
                 })
             } else {
                 None
@@ -456,7 +456,7 @@ impl BottomLeaf {
         let mut elements = Vec::with_capacity(self.values.len() * 2);
         for (key, val) in self.values.iter() {
             key.iter().for_each(|&v| elements.push(Felt::new(v)));
-            elements.extend_from_slice(val);
+            elements.extend_from_slice(val.as_slice());
         }
         // TODO: hash in domain
         Rpo256::hash_elements(&elements)

--- a/src/merkle/tiered_smt/tests.rs
+++ b/src/merkle/tiered_smt/tests.rs
@@ -21,7 +21,7 @@ fn tsmt_insert_one() {
 
     smt.insert(key, value);
 
-    assert_eq!(smt.root(), tree_root.into());
+    assert_eq!(smt.root(), tree_root);
 
     // make sure the value was inserted, and the node is at the expected index
     assert_eq!(smt.get_value(key), value);
@@ -74,16 +74,16 @@ fn tsmt_insert_two_16() {
 
     // --- verify that data is consistent between store and tree --------------
 
-    assert_eq!(smt.root(), tree_root.into());
+    assert_eq!(smt.root(), tree_root);
 
     assert_eq!(smt.get_value(key_a), val_a);
     assert_eq!(smt.get_node(index_a).unwrap(), leaf_node_a);
-    let expected_path = store.get_path(tree_root.into(), index_a).unwrap().path;
+    let expected_path = store.get_path(tree_root, index_a).unwrap().path;
     assert_eq!(smt.get_path(index_a).unwrap(), expected_path);
 
     assert_eq!(smt.get_value(key_b), val_b);
     assert_eq!(smt.get_node(index_b).unwrap(), leaf_node_b);
-    let expected_path = store.get_path(tree_root.into(), index_b).unwrap().path;
+    let expected_path = store.get_path(tree_root, index_b).unwrap().path;
     assert_eq!(smt.get_path(index_b).unwrap(), expected_path);
 
     // make sure inner nodes match - the store contains more entries because it keeps track of
@@ -130,16 +130,16 @@ fn tsmt_insert_two_32() {
 
     // --- verify that data is consistent between store and tree --------------
 
-    assert_eq!(smt.root(), tree_root.into());
+    assert_eq!(smt.root(), tree_root);
 
     assert_eq!(smt.get_value(key_a), val_a);
     assert_eq!(smt.get_node(index_a).unwrap(), leaf_node_a);
-    let expected_path = store.get_path(tree_root.into(), index_a).unwrap().path;
+    let expected_path = store.get_path(tree_root, index_a).unwrap().path;
     assert_eq!(smt.get_path(index_a).unwrap(), expected_path);
 
     assert_eq!(smt.get_value(key_b), val_b);
     assert_eq!(smt.get_node(index_b).unwrap(), leaf_node_b);
-    let expected_path = store.get_path(tree_root.into(), index_b).unwrap().path;
+    let expected_path = store.get_path(tree_root, index_b).unwrap().path;
     assert_eq!(smt.get_path(index_b).unwrap(), expected_path);
 
     // make sure inner nodes match - the store contains more entries because it keeps track of
@@ -193,21 +193,21 @@ fn tsmt_insert_three() {
 
     // --- verify that data is consistent between store and tree --------------
 
-    assert_eq!(smt.root(), tree_root.into());
+    assert_eq!(smt.root(), tree_root);
 
     assert_eq!(smt.get_value(key_a), val_a);
     assert_eq!(smt.get_node(index_a).unwrap(), leaf_node_a);
-    let expected_path = store.get_path(tree_root.into(), index_a).unwrap().path;
+    let expected_path = store.get_path(tree_root, index_a).unwrap().path;
     assert_eq!(smt.get_path(index_a).unwrap(), expected_path);
 
     assert_eq!(smt.get_value(key_b), val_b);
     assert_eq!(smt.get_node(index_b).unwrap(), leaf_node_b);
-    let expected_path = store.get_path(tree_root.into(), index_b).unwrap().path;
+    let expected_path = store.get_path(tree_root, index_b).unwrap().path;
     assert_eq!(smt.get_path(index_b).unwrap(), expected_path);
 
     assert_eq!(smt.get_value(key_c), val_c);
     assert_eq!(smt.get_node(index_c).unwrap(), leaf_node_c);
-    let expected_path = store.get_path(tree_root.into(), index_c).unwrap().path;
+    let expected_path = store.get_path(tree_root, index_c).unwrap().path;
     assert_eq!(smt.get_path(index_c).unwrap(), expected_path);
 
     // make sure inner nodes match - the store contains more entries because it keeps track of
@@ -238,11 +238,11 @@ fn tsmt_update() {
     let leaf_node = build_leaf_node(key, value_b, 16);
     tree_root = store.set_node(tree_root, index, leaf_node).unwrap().root;
 
-    assert_eq!(smt.root(), tree_root.into());
+    assert_eq!(smt.root(), tree_root);
 
     assert_eq!(smt.get_value(key), value_b);
     assert_eq!(smt.get_node(index).unwrap(), leaf_node);
-    let expected_path = store.get_path(tree_root.into(), index).unwrap().path;
+    let expected_path = store.get_path(tree_root, index).unwrap().path;
     assert_eq!(smt.get_path(index).unwrap(), expected_path);
 
     // make sure inner nodes match - the store contains more entries because it keeps track of
@@ -285,13 +285,13 @@ fn tsmt_bottom_tier() {
 
     // --- verify that data is consistent between store and tree --------------
 
-    assert_eq!(smt.root(), tree_root.into());
+    assert_eq!(smt.root(), tree_root);
 
     assert_eq!(smt.get_value(key_a), val_a);
     assert_eq!(smt.get_value(key_b), val_b);
 
     assert_eq!(smt.get_node(index).unwrap(), leaf_node);
-    let expected_path = store.get_path(tree_root.into(), index).unwrap().path;
+    let expected_path = store.get_path(tree_root, index).unwrap().path;
     assert_eq!(smt.get_path(index).unwrap(), expected_path);
 
     // make sure inner nodes match - the store contains more entries because it keeps track of
@@ -337,16 +337,16 @@ fn tsmt_bottom_tier_two() {
 
     // --- verify that data is consistent between store and tree --------------
 
-    assert_eq!(smt.root(), tree_root.into());
+    assert_eq!(smt.root(), tree_root);
 
     assert_eq!(smt.get_value(key_a), val_a);
     assert_eq!(smt.get_node(index_a).unwrap(), leaf_node_a);
-    let expected_path = store.get_path(tree_root.into(), index_a).unwrap().path;
+    let expected_path = store.get_path(tree_root, index_a).unwrap().path;
     assert_eq!(smt.get_path(index_a).unwrap(), expected_path);
 
     assert_eq!(smt.get_value(key_b), val_b);
     assert_eq!(smt.get_node(index_b).unwrap(), leaf_node_b);
-    let expected_path = store.get_path(tree_root.into(), index_b).unwrap().path;
+    let expected_path = store.get_path(tree_root, index_b).unwrap().path;
     assert_eq!(smt.get_path(index_b).unwrap(), expected_path);
 
     // make sure inner nodes match - the store contains more entries because it keeps track of

--- a/src/merkle/tiered_smt/tests.rs
+++ b/src/merkle/tiered_smt/tests.rs
@@ -66,11 +66,19 @@ fn tsmt_insert_two_16() {
     let mut tree_root = get_init_root();
     let index_a = NodeIndex::make(32, raw_a >> 32);
     let leaf_node_a = build_leaf_node(key_a, val_a, 32);
-    tree_root = store.set_node(tree_root, index_a, leaf_node_a.into()).unwrap().root;
+    tree_root = store
+        .set_node(tree_root.into(), index_a, leaf_node_a.into())
+        .unwrap()
+        .root
+        .into();
 
     let index_b = NodeIndex::make(32, raw_b >> 32);
     let leaf_node_b = build_leaf_node(key_b, val_b, 32);
-    tree_root = store.set_node(tree_root, index_b, leaf_node_b.into()).unwrap().root;
+    tree_root = store
+        .set_node(tree_root.into(), index_b, leaf_node_b.into())
+        .unwrap()
+        .root
+        .into();
 
     // --- verify that data is consistent between store and tree --------------
 
@@ -78,12 +86,12 @@ fn tsmt_insert_two_16() {
 
     assert_eq!(smt.get_value(key_a), val_a);
     assert_eq!(smt.get_node(index_a).unwrap(), leaf_node_a);
-    let expected_path = store.get_path(tree_root, index_a).unwrap().path;
+    let expected_path = store.get_path(tree_root.into(), index_a).unwrap().path;
     assert_eq!(smt.get_path(index_a).unwrap(), expected_path);
 
     assert_eq!(smt.get_value(key_b), val_b);
     assert_eq!(smt.get_node(index_b).unwrap(), leaf_node_b);
-    let expected_path = store.get_path(tree_root, index_b).unwrap().path;
+    let expected_path = store.get_path(tree_root.into(), index_b).unwrap().path;
     assert_eq!(smt.get_path(index_b).unwrap(), expected_path);
 
     // make sure inner nodes match - the store contains more entries because it keeps track of
@@ -122,11 +130,19 @@ fn tsmt_insert_two_32() {
     let mut tree_root = get_init_root();
     let index_a = NodeIndex::make(48, raw_a >> 16);
     let leaf_node_a = build_leaf_node(key_a, val_a, 48);
-    tree_root = store.set_node(tree_root, index_a, leaf_node_a.into()).unwrap().root;
+    tree_root = store
+        .set_node(tree_root.into(), index_a, leaf_node_a.into())
+        .unwrap()
+        .root
+        .into();
 
     let index_b = NodeIndex::make(48, raw_b >> 16);
     let leaf_node_b = build_leaf_node(key_b, val_b, 48);
-    tree_root = store.set_node(tree_root, index_b, leaf_node_b.into()).unwrap().root;
+    tree_root = store
+        .set_node(tree_root.into(), index_b, leaf_node_b.into())
+        .unwrap()
+        .root
+        .into();
 
     // --- verify that data is consistent between store and tree --------------
 
@@ -134,12 +150,12 @@ fn tsmt_insert_two_32() {
 
     assert_eq!(smt.get_value(key_a), val_a);
     assert_eq!(smt.get_node(index_a).unwrap(), leaf_node_a);
-    let expected_path = store.get_path(tree_root, index_a).unwrap().path;
+    let expected_path = store.get_path(tree_root.into(), index_a).unwrap().path;
     assert_eq!(smt.get_path(index_a).unwrap(), expected_path);
 
     assert_eq!(smt.get_value(key_b), val_b);
     assert_eq!(smt.get_node(index_b).unwrap(), leaf_node_b);
-    let expected_path = store.get_path(tree_root, index_b).unwrap().path;
+    let expected_path = store.get_path(tree_root.into(), index_b).unwrap().path;
     assert_eq!(smt.get_path(index_b).unwrap(), expected_path);
 
     // make sure inner nodes match - the store contains more entries because it keeps track of
@@ -181,15 +197,27 @@ fn tsmt_insert_three() {
     let mut tree_root = get_init_root();
     let index_a = NodeIndex::make(32, raw_a >> 32);
     let leaf_node_a = build_leaf_node(key_a, val_a, 32);
-    tree_root = store.set_node(tree_root, index_a, leaf_node_a.into()).unwrap().root;
+    tree_root = store
+        .set_node(tree_root.into(), index_a, leaf_node_a.into())
+        .unwrap()
+        .root
+        .into();
 
     let index_b = NodeIndex::make(32, raw_b >> 32);
     let leaf_node_b = build_leaf_node(key_b, val_b, 32);
-    tree_root = store.set_node(tree_root, index_b, leaf_node_b.into()).unwrap().root;
+    tree_root = store
+        .set_node(tree_root.into(), index_b, leaf_node_b.into())
+        .unwrap()
+        .root
+        .into();
 
     let index_c = NodeIndex::make(32, raw_c >> 32);
     let leaf_node_c = build_leaf_node(key_c, val_c, 32);
-    tree_root = store.set_node(tree_root, index_c, leaf_node_c.into()).unwrap().root;
+    tree_root = store
+        .set_node(tree_root.into(), index_c, leaf_node_c.into())
+        .unwrap()
+        .root
+        .into();
 
     // --- verify that data is consistent between store and tree --------------
 
@@ -197,17 +225,17 @@ fn tsmt_insert_three() {
 
     assert_eq!(smt.get_value(key_a), val_a);
     assert_eq!(smt.get_node(index_a).unwrap(), leaf_node_a);
-    let expected_path = store.get_path(tree_root, index_a).unwrap().path;
+    let expected_path = store.get_path(tree_root.into(), index_a).unwrap().path;
     assert_eq!(smt.get_path(index_a).unwrap(), expected_path);
 
     assert_eq!(smt.get_value(key_b), val_b);
     assert_eq!(smt.get_node(index_b).unwrap(), leaf_node_b);
-    let expected_path = store.get_path(tree_root, index_b).unwrap().path;
+    let expected_path = store.get_path(tree_root.into(), index_b).unwrap().path;
     assert_eq!(smt.get_path(index_b).unwrap(), expected_path);
 
     assert_eq!(smt.get_value(key_c), val_c);
     assert_eq!(smt.get_node(index_c).unwrap(), leaf_node_c);
-    let expected_path = store.get_path(tree_root, index_c).unwrap().path;
+    let expected_path = store.get_path(tree_root.into(), index_c).unwrap().path;
     assert_eq!(smt.get_path(index_c).unwrap(), expected_path);
 
     // make sure inner nodes match - the store contains more entries because it keeps track of
@@ -236,13 +264,13 @@ fn tsmt_update() {
     let mut tree_root = get_init_root();
     let index = NodeIndex::make(16, raw >> 48);
     let leaf_node = build_leaf_node(key, value_b, 16);
-    tree_root = store.set_node(tree_root, index, leaf_node.into()).unwrap().root;
+    tree_root = store.set_node(tree_root.into(), index, leaf_node.into()).unwrap().root.into();
 
     assert_eq!(smt.root(), tree_root.into());
 
     assert_eq!(smt.get_value(key), value_b);
     assert_eq!(smt.get_node(index).unwrap(), leaf_node);
-    let expected_path = store.get_path(tree_root, index).unwrap().path;
+    let expected_path = store.get_path(tree_root.into(), index).unwrap().path;
     assert_eq!(smt.get_path(index).unwrap(), expected_path);
 
     // make sure inner nodes match - the store contains more entries because it keeps track of
@@ -281,7 +309,7 @@ fn tsmt_bottom_tier() {
     // key_b is smaller than key_a.
     let leaf_node = build_bottom_leaf_node(&[key_b, key_a], &[val_b, val_a]);
     let mut tree_root = get_init_root();
-    tree_root = store.set_node(tree_root, index, leaf_node.into()).unwrap().root;
+    tree_root = store.set_node(tree_root.into(), index, leaf_node.into()).unwrap().root.into();
 
     // --- verify that data is consistent between store and tree --------------
 
@@ -291,7 +319,7 @@ fn tsmt_bottom_tier() {
     assert_eq!(smt.get_value(key_b), val_b);
 
     assert_eq!(smt.get_node(index).unwrap(), leaf_node);
-    let expected_path = store.get_path(tree_root, index).unwrap().path;
+    let expected_path = store.get_path(tree_root.into(), index).unwrap().path;
     assert_eq!(smt.get_path(index).unwrap(), expected_path);
 
     // make sure inner nodes match - the store contains more entries because it keeps track of
@@ -329,11 +357,19 @@ fn tsmt_bottom_tier_two() {
     let mut tree_root = get_init_root();
     let index_a = NodeIndex::make(64, raw_a);
     let leaf_node_a = build_bottom_leaf_node(&[key_a], &[val_a]);
-    tree_root = store.set_node(tree_root, index_a, leaf_node_a.into()).unwrap().root;
+    tree_root = store
+        .set_node(tree_root.into(), index_a, leaf_node_a.into())
+        .unwrap()
+        .root
+        .into();
 
     let index_b = NodeIndex::make(64, raw_b);
     let leaf_node_b = build_bottom_leaf_node(&[key_b], &[val_b]);
-    tree_root = store.set_node(tree_root, index_b, leaf_node_b.into()).unwrap().root;
+    tree_root = store
+        .set_node(tree_root.into(), index_b, leaf_node_b.into())
+        .unwrap()
+        .root
+        .into();
 
     // --- verify that data is consistent between store and tree --------------
 
@@ -341,12 +377,12 @@ fn tsmt_bottom_tier_two() {
 
     assert_eq!(smt.get_value(key_a), val_a);
     assert_eq!(smt.get_node(index_a).unwrap(), leaf_node_a);
-    let expected_path = store.get_path(tree_root, index_a).unwrap().path;
+    let expected_path = store.get_path(tree_root.into(), index_a).unwrap().path;
     assert_eq!(smt.get_path(index_a).unwrap(), expected_path);
 
     assert_eq!(smt.get_value(key_b), val_b);
     assert_eq!(smt.get_node(index_b).unwrap(), leaf_node_b);
-    let expected_path = store.get_path(tree_root, index_b).unwrap().path;
+    let expected_path = store.get_path(tree_root.into(), index_b).unwrap().path;
     assert_eq!(smt.get_path(index_b).unwrap(), expected_path);
 
     // make sure inner nodes match - the store contains more entries because it keeps track of
@@ -423,7 +459,7 @@ fn build_bottom_leaf_node(keys: &[RpoDigest], values: &[Word]) -> RpoDigest {
         let mut key = Word::from(key);
         key[3] = ZERO;
         elements.extend_from_slice(&key);
-        elements.extend_from_slice(val);
+        elements.extend_from_slice(val.as_slice());
     }
 
     Rpo256::hash_elements(&elements)

--- a/src/merkle/tiered_smt/tests.rs
+++ b/src/merkle/tiered_smt/tests.rs
@@ -17,7 +17,7 @@ fn tsmt_insert_one() {
     // 16 most significant bits of the key
     let index = NodeIndex::make(16, raw >> 48);
     let leaf_node = build_leaf_node(key, value, 16);
-    let tree_root = store.set_node(smt.root().into(), index, leaf_node.into()).unwrap().root;
+    let tree_root = store.set_node(smt.root(), index, leaf_node).unwrap().root;
 
     smt.insert(key, value);
 
@@ -66,19 +66,11 @@ fn tsmt_insert_two_16() {
     let mut tree_root = get_init_root();
     let index_a = NodeIndex::make(32, raw_a >> 32);
     let leaf_node_a = build_leaf_node(key_a, val_a, 32);
-    tree_root = store
-        .set_node(tree_root.into(), index_a, leaf_node_a.into())
-        .unwrap()
-        .root
-        .into();
+    tree_root = store.set_node(tree_root, index_a, leaf_node_a).unwrap().root;
 
     let index_b = NodeIndex::make(32, raw_b >> 32);
     let leaf_node_b = build_leaf_node(key_b, val_b, 32);
-    tree_root = store
-        .set_node(tree_root.into(), index_b, leaf_node_b.into())
-        .unwrap()
-        .root
-        .into();
+    tree_root = store.set_node(tree_root, index_b, leaf_node_b).unwrap().root;
 
     // --- verify that data is consistent between store and tree --------------
 
@@ -130,19 +122,11 @@ fn tsmt_insert_two_32() {
     let mut tree_root = get_init_root();
     let index_a = NodeIndex::make(48, raw_a >> 16);
     let leaf_node_a = build_leaf_node(key_a, val_a, 48);
-    tree_root = store
-        .set_node(tree_root.into(), index_a, leaf_node_a.into())
-        .unwrap()
-        .root
-        .into();
+    tree_root = store.set_node(tree_root, index_a, leaf_node_a).unwrap().root;
 
     let index_b = NodeIndex::make(48, raw_b >> 16);
     let leaf_node_b = build_leaf_node(key_b, val_b, 48);
-    tree_root = store
-        .set_node(tree_root.into(), index_b, leaf_node_b.into())
-        .unwrap()
-        .root
-        .into();
+    tree_root = store.set_node(tree_root, index_b, leaf_node_b).unwrap().root;
 
     // --- verify that data is consistent between store and tree --------------
 
@@ -197,27 +181,15 @@ fn tsmt_insert_three() {
     let mut tree_root = get_init_root();
     let index_a = NodeIndex::make(32, raw_a >> 32);
     let leaf_node_a = build_leaf_node(key_a, val_a, 32);
-    tree_root = store
-        .set_node(tree_root.into(), index_a, leaf_node_a.into())
-        .unwrap()
-        .root
-        .into();
+    tree_root = store.set_node(tree_root, index_a, leaf_node_a).unwrap().root;
 
     let index_b = NodeIndex::make(32, raw_b >> 32);
     let leaf_node_b = build_leaf_node(key_b, val_b, 32);
-    tree_root = store
-        .set_node(tree_root.into(), index_b, leaf_node_b.into())
-        .unwrap()
-        .root
-        .into();
+    tree_root = store.set_node(tree_root, index_b, leaf_node_b).unwrap().root;
 
     let index_c = NodeIndex::make(32, raw_c >> 32);
     let leaf_node_c = build_leaf_node(key_c, val_c, 32);
-    tree_root = store
-        .set_node(tree_root.into(), index_c, leaf_node_c.into())
-        .unwrap()
-        .root
-        .into();
+    tree_root = store.set_node(tree_root, index_c, leaf_node_c).unwrap().root;
 
     // --- verify that data is consistent between store and tree --------------
 
@@ -264,7 +236,7 @@ fn tsmt_update() {
     let mut tree_root = get_init_root();
     let index = NodeIndex::make(16, raw >> 48);
     let leaf_node = build_leaf_node(key, value_b, 16);
-    tree_root = store.set_node(tree_root.into(), index, leaf_node.into()).unwrap().root.into();
+    tree_root = store.set_node(tree_root, index, leaf_node).unwrap().root;
 
     assert_eq!(smt.root(), tree_root.into());
 
@@ -309,7 +281,7 @@ fn tsmt_bottom_tier() {
     // key_b is smaller than key_a.
     let leaf_node = build_bottom_leaf_node(&[key_b, key_a], &[val_b, val_a]);
     let mut tree_root = get_init_root();
-    tree_root = store.set_node(tree_root.into(), index, leaf_node.into()).unwrap().root.into();
+    tree_root = store.set_node(tree_root, index, leaf_node).unwrap().root;
 
     // --- verify that data is consistent between store and tree --------------
 
@@ -357,19 +329,11 @@ fn tsmt_bottom_tier_two() {
     let mut tree_root = get_init_root();
     let index_a = NodeIndex::make(64, raw_a);
     let leaf_node_a = build_bottom_leaf_node(&[key_a], &[val_a]);
-    tree_root = store
-        .set_node(tree_root.into(), index_a, leaf_node_a.into())
-        .unwrap()
-        .root
-        .into();
+    tree_root = store.set_node(tree_root, index_a, leaf_node_a).unwrap().root;
 
     let index_b = NodeIndex::make(64, raw_b);
     let leaf_node_b = build_bottom_leaf_node(&[key_b], &[val_b]);
-    tree_root = store
-        .set_node(tree_root.into(), index_b, leaf_node_b.into())
-        .unwrap()
-        .root
-        .into();
+    tree_root = store.set_node(tree_root, index_b, leaf_node_b).unwrap().root;
 
     // --- verify that data is consistent between store and tree --------------
 
@@ -442,8 +406,8 @@ fn tsmt_node_not_available() {
 // HELPER FUNCTIONS
 // ================================================================================================
 
-fn get_init_root() -> Word {
-    EmptySubtreeRoots::empty_hashes(64)[0].into()
+fn get_init_root() -> RpoDigest {
+    EmptySubtreeRoots::empty_hashes(64)[0]
 }
 
 fn build_leaf_node(key: RpoDigest, value: Word, depth: u8) -> RpoDigest {


### PR DESCRIPTION
## Describe your changes
Addressing #131. Replaces `Word` in the structures in the crypto crate to `RpoDigest` to avoid unnecessary conversions and to maintain consistency.

## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
