### PR TITLE
feat: introduce `Diff` traits and objects

### DIFF
--- a/src/utils/diff.rs
+++ b/src/utils/diff.rs
@@ -1,0 +1,16 @@
+/// A trait for computing the difference between two objects.
+pub trait Diff<K: Ord + Clone, V: Clone> {
+    type DiffType;
+
+    /// Returns a `Self::DiffType` object that represents the difference between this object and
+    /// other.
+    fn diff(&self, other: &Self) -> Self::DiffType;
+}
+
+/// A trait for applying the difference between two objects.
+pub trait ApplyDiff<K: Ord + Clone, V: Clone> {
+    type DiffType;
+
+    /// Applies the provided changes described by [DiffType] to the object implementing this trait.
+    fn apply(&mut self, diff: Self::DiffType);
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -7,6 +7,7 @@ pub use alloc::format;
 #[cfg(feature = "std")]
 pub use std::format;
 
+mod diff;
 mod kv_map;
 
 // RE-EXPORTS
@@ -17,6 +18,7 @@ pub use winter_utils::{
 };
 
 pub mod collections {
+    pub use super::diff::*;
     pub use super::kv_map::*;
     pub use winter_utils::collections::*;
 }


### PR DESCRIPTION
This PR introduces functionality:
- `DiffT` trait that specifies the interface for computing the diff between two objects.
- `ApplyDiffT` trait that specifies the interface for applying a diff to a target object.
- Implementation of `DiffT` and `ApplyDiffT` on `MerkleStore` and `KvMap` (trait).
- Introduction of `KvMapDiff` that represents the diff between `KvMap` and by association `MerkleStore`.
- Introduction of `remove(..)` for `KvMap`.