### PR TITLE
feat: derive ord and partialord for blake3digest

### DIFF
--- a/src/hash/blake/mod.rs
+++ b/src/hash/blake/mod.rs
@@ -26,7 +26,7 @@ const DIGEST20_BYTES: usize = 20;
 ///
 /// Note: `N` can't be greater than `32` because [`Digest::as_bytes`] currently supports only 32
 /// bytes.
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "serde", serde(into = "String", try_from = "&str"))]
 pub struct Blake3Digest<const N: usize>([u8; N]);


### PR DESCRIPTION
## Describe your changes
Required to use `Blake3Digest` as keys in a map. (For https://github.com/0xPolygonMiden/miden-vm/issues/990)

## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
