### PR TITLE
tsmt: generic over the value type

### DIFF
--- a/src/merkle/store/mod.rs
+++ b/src/merkle/store/mod.rs
@@ -448,8 +448,8 @@ impl<T: KvMap<RpoDigest, StoreNode>> From<&Mmr> for MerkleStore<T> {
     }
 }
 
-impl<T: KvMap<RpoDigest, StoreNode>> From<&TieredSmt> for MerkleStore<T> {
-    fn from(value: &TieredSmt) -> Self {
+impl<T: KvMap<RpoDigest, StoreNode>, V> From<&TieredSmt<V>> for MerkleStore<T> {
+    fn from(value: &TieredSmt<V>) -> Self {
         let nodes = combine_nodes_with_empty_hashes(value.inner_nodes()).collect();
         Self { nodes }
     }

--- a/src/merkle/tiered_smt/nodes.rs
+++ b/src/merkle/tiered_smt/nodes.rs
@@ -1,19 +1,7 @@
 use super::{
     BTreeMap, BTreeSet, EmptySubtreeRoots, InnerNodeInfo, LeafNodeIndex, MerkleError, MerklePath,
-    NodeIndex, Rpo256, RpoDigest, Vec,
+    NodeIndex, Rpo256, RpoDigest, Vec, MAX_DEPTH, TIER_DEPTHS, TIER_SIZE,
 };
-
-// CONSTANTS
-// ================================================================================================
-
-/// The number of levels between tiers.
-const TIER_SIZE: u8 = super::TieredSmt::TIER_SIZE;
-
-/// Depths at which leaves can exist in a tiered SMT.
-const TIER_DEPTHS: [u8; 4] = super::TieredSmt::TIER_DEPTHS;
-
-/// Maximum node depth. This is also the bottom tier of the tree.
-const MAX_DEPTH: u8 = super::TieredSmt::MAX_DEPTH;
 
 // NODE STORE
 // ================================================================================================


### PR DESCRIPTION
## Describe your changes

Makes the TSMT generic over the value, instead of requiring a `Word`.

This allow the type to be annotated with the actual content it holds, instead of requiring the user to convert to/from word when using it. This has the nice side effect of using the type itself as a documentation, and also allows the type checker to verify the code.

As an example, I started this modification after adding the `serde` support to the account vault. While doing that, I missed that the vault converted the values manually, and just used the default derivation from serde. This meant the vault is de-serializing is only validating the data to be correct `Word` (i.e. it is a valid field element), but not that the data is encoding a valid asset (not every word is a valid asset).

If instead of using `Word` as part of the API it used the correct type `Asset`, the derive macro would have forced me to implement the derivation for that type, were we could have caught the issue.

Above is the rationale for the change, a few notes about the change itself:

- Instead of using the constant `EMPTY_WORD` the code is using the value from the `Default`. This may, or may not be desirable for all circumstances, but the change should work the same as before.
- I introduced the minimum trait requirement to each method, this means there are multiple `impl`s, were each has different trait bounds. This makes the code more explicit, but at the same time more verbose. I'm not sure if the tradeoff is worth it, since usage become a bit more messy when using the data structure. Let me know if the bounds should use the union of everything instead.

## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
