### PR TITLE
Add more leaf traversal methods for `MerkleStore`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 ## 0.7.0 (TBD)
 
 * Replaced `MerklePathSet` with `PartialMerkleTree` (#165).
+* Implemented clearing of nodes in `TieredSmt` (#173).
+* Added ability to generate inclusion proofs for `TieredSmt` (#174).
+* Added conditional `serde`` support for various structs (#180).
+* Implemented benchmarking for `TieredSmt` (#182).
+* Added more leaf traversal methods for `MerkleStore` (#185).
 
 ## 0.6.0 (2023-06-25)
 

--- a/src/merkle/path.rs
+++ b/src/merkle/path.rs
@@ -160,6 +160,16 @@ pub struct ValuePath {
     pub path: MerklePath,
 }
 
+impl ValuePath {
+    /// Returns a new [ValuePath] instantiated from the specified value and path.
+    pub fn new(value: RpoDigest, path: Vec<RpoDigest>) -> Self {
+        Self {
+            value,
+            path: MerklePath::new(path),
+        }
+    }
+}
+
 /// A container for a [MerklePath] and its [Word] root.
 ///
 /// This structure does not provide any guarantees regarding the correctness of the path to the

--- a/src/merkle/tiered_smt/mod.rs
+++ b/src/merkle/tiered_smt/mod.rs
@@ -55,13 +55,13 @@ impl TieredSmt {
     // --------------------------------------------------------------------------------------------
 
     /// The number of levels between tiers.
-    const TIER_SIZE: u8 = 16;
+    pub const TIER_SIZE: u8 = 16;
 
     /// Depths at which leaves can exist in a tiered SMT.
-    const TIER_DEPTHS: [u8; 4] = [16, 32, 48, 64];
+    pub const TIER_DEPTHS: [u8; 4] = [16, 32, 48, 64];
 
     /// Maximum node depth. This is also the bottom tier of the tree.
-    const MAX_DEPTH: u8 = 64;
+    pub const MAX_DEPTH: u8 = 64;
 
     /// Value of an empty leaf.
     pub const EMPTY_VALUE: Word = super::empty_roots::EMPTY_WORD;


### PR DESCRIPTION
This PR adds a couple of leaf traversal methods to `MerkleStore` needed to support deletion functionality in MASM implementation of TSMT.

Specifically, the following methods were added:
- ~`get_leaf_path` - which returns a path to the first leaf or an empty node for the specified index.~
- `find_lone_leaf` - which can be used to determine if a given subtree contains just a single leaf node.

~Also, as a part of this PR `get_leaf_depth` was refactored and renamed into `find_first_leaf` to align better with the needs of the advice injectors which currently use this method.~