### PR TITLE
Create empty word constant

### DIFF
--- a/src/hash/rpo/mds_freq.rs
+++ b/src/hash/rpo/mds_freq.rs
@@ -156,14 +156,14 @@ const fn block3(x: [i64; 3], y: [i64; 3]) -> [i64; 3] {
 
 #[cfg(test)]
 mod tests {
-    use super::super::{Felt, FieldElement, Rpo256, MDS};
+    use super::super::{Felt, Rpo256, MDS, ZERO};
     use proptest::prelude::*;
 
     const STATE_WIDTH: usize = 12;
 
     #[inline(always)]
     fn apply_mds_naive(state: &mut [Felt; STATE_WIDTH]) {
-        let mut result = [Felt::ZERO; STATE_WIDTH];
+        let mut result = [ZERO; STATE_WIDTH];
         result.iter_mut().zip(MDS).for_each(|(r, mds_row)| {
             state.iter().zip(mds_row).for_each(|(&s, m)| {
                 *r += m * s;
@@ -174,9 +174,9 @@ mod tests {
 
     proptest! {
         #[test]
-        fn mds_freq_proptest(a in any::<[u64;STATE_WIDTH]>()) {
+        fn mds_freq_proptest(a in any::<[u64; STATE_WIDTH]>()) {
 
-            let mut v1 = [Felt::ZERO;STATE_WIDTH];
+            let mut v1 = [ZERO; STATE_WIDTH];
             let mut v2;
 
             for i in 0..STATE_WIDTH {

--- a/src/hash/rpo/tests.rs
+++ b/src/hash/rpo/tests.rs
@@ -105,7 +105,7 @@ fn hash_elements_vs_merge_with_int() {
 
     let mut elements = seed.as_elements().to_vec();
     elements.push(Felt::new(val));
-    elements.push(Felt::new(1));
+    elements.push(ONE);
     let h_result = Rpo256::hash_elements(&elements);
 
     assert_eq!(m_result, h_result);
@@ -147,8 +147,8 @@ fn hash_elements_padding() {
 #[test]
 fn hash_elements() {
     let elements = [
-        Felt::new(0),
-        Felt::new(1),
+        ZERO,
+        ONE,
         Felt::new(2),
         Felt::new(3),
         Felt::new(4),
@@ -170,8 +170,8 @@ fn hash_elements() {
 #[test]
 fn hash_test_vectors() {
     let elements = [
-        Felt::new(0),
-        Felt::new(1),
+        ZERO,
+        ONE,
         Felt::new(2),
         Felt::new(3),
         Felt::new(4),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,9 @@ pub const ZERO: Felt = Felt::ZERO;
 /// Field element representing ONE in the Miden base filed.
 pub const ONE: Felt = Felt::ONE;
 
+/// Array of field elements representing word of ZEROs in the Miden base field.
+pub const EMPTY_WORD: [Felt; 4] = [ZERO; WORD_SIZE];
+
 // TESTS
 // ================================================================================================
 

--- a/src/merkle/delta.rs
+++ b/src/merkle/delta.rs
@@ -4,7 +4,7 @@ use super::{
 use crate::utils::collections::Diff;
 
 #[cfg(test)]
-use super::{empty_roots::EMPTY_WORD, Felt, SimpleSmt};
+use super::{super::ONE, Felt, SimpleSmt, EMPTY_WORD, ZERO};
 
 // MERKLE STORE DELTA
 // ================================================================================================
@@ -121,7 +121,7 @@ pub struct MerkleTreeDelta {
 #[test]
 fn test_compute_merkle_delta() {
     let entries = vec![
-        (10, [Felt::new(0), Felt::new(1), Felt::new(2), Felt::new(3)]),
+        (10, [ZERO, ONE, Felt::new(2), Felt::new(3)]),
         (15, [Felt::new(4), Felt::new(5), Felt::new(6), Felt::new(7)]),
         (20, [Felt::new(8), Felt::new(9), Felt::new(10), Felt::new(11)]),
         (31, [Felt::new(12), Felt::new(13), Felt::new(14), Felt::new(15)]),

--- a/src/merkle/empty_roots.rs
+++ b/src/merkle/empty_roots.rs
@@ -1,11 +1,5 @@
-use super::{Felt, RpoDigest, Word, WORD_SIZE, ZERO};
+use super::{Felt, RpoDigest, EMPTY_WORD};
 use core::slice;
-
-// CONSTANTS
-// ================================================================================================
-
-/// A word consisting of 4 ZERO elements.
-pub const EMPTY_WORD: Word = [ZERO; WORD_SIZE];
 
 // EMPTY NODES SUBTREES
 // ================================================================================================
@@ -1556,7 +1550,7 @@ const EMPTY_SUBTREES: [RpoDigest; 256] = [
         Felt::new(0xd3ad9fb0cea61624),
         Felt::new(0x66ab5c684fbb8597),
     ]),
-    RpoDigest::new([ZERO; WORD_SIZE]),
+    RpoDigest::new(EMPTY_WORD),
 ];
 
 #[test]

--- a/src/merkle/mod.rs
+++ b/src/merkle/mod.rs
@@ -1,7 +1,7 @@
 use super::{
     hash::rpo::{Rpo256, RpoDigest},
     utils::collections::{vec, BTreeMap, BTreeSet, KvMap, RecordingMap, TryApplyDiff, Vec},
-    Felt, StarkField, Word, WORD_SIZE, ZERO,
+    Felt, StarkField, Word, EMPTY_WORD, ZERO,
 };
 
 // REEXPORTS

--- a/src/merkle/partial_mt/mod.rs
+++ b/src/merkle/partial_mt/mod.rs
@@ -1,6 +1,6 @@
 use super::{
     BTreeMap, BTreeSet, InnerNodeInfo, MerkleError, MerklePath, NodeIndex, Rpo256, RpoDigest,
-    ValuePath, Vec, Word, ZERO,
+    ValuePath, Vec, Word, EMPTY_WORD,
 };
 use crate::utils::{
     format, string::String, vec, word_to_hex, ByteReader, ByteWriter, Deserializable,
@@ -18,7 +18,7 @@ mod tests;
 const ROOT_INDEX: NodeIndex = NodeIndex::root();
 
 /// An RpoDigest consisting of 4 ZERO elements.
-const EMPTY_DIGEST: RpoDigest = RpoDigest::new([ZERO; 4]);
+const EMPTY_DIGEST: RpoDigest = RpoDigest::new(EMPTY_WORD);
 
 // PARTIAL MERKLE TREE
 // ================================================================================================

--- a/src/merkle/simple_smt/mod.rs
+++ b/src/merkle/simple_smt/mod.rs
@@ -33,7 +33,7 @@ impl SimpleSmt {
     pub const MAX_DEPTH: u8 = 64;
 
     /// Value of an empty leaf.
-    pub const EMPTY_VALUE: Word = super::empty_roots::EMPTY_WORD;
+    pub const EMPTY_VALUE: Word = super::EMPTY_WORD;
 
     // CONSTRUCTORS
     // --------------------------------------------------------------------------------------------

--- a/src/merkle/simple_smt/tests.rs
+++ b/src/merkle/simple_smt/tests.rs
@@ -1,9 +1,9 @@
 use super::{
-    super::{InnerNodeInfo, MerkleError, MerkleTree, RpoDigest, SimpleSmt},
+    super::{InnerNodeInfo, MerkleError, MerkleTree, RpoDigest, SimpleSmt, EMPTY_WORD},
     NodeIndex, Rpo256, Vec,
 };
 use crate::{
-    merkle::{digests_to_words, empty_roots::EMPTY_WORD, int_to_leaf, int_to_node},
+    merkle::{digests_to_words, int_to_leaf, int_to_node},
     Word,
 };
 

--- a/src/merkle/store/mod.rs
+++ b/src/merkle/store/mod.rs
@@ -1,7 +1,7 @@
 use super::{
-    empty_roots::EMPTY_WORD, mmr::Mmr, BTreeMap, EmptySubtreeRoots, InnerNodeInfo, KvMap,
-    MerkleError, MerklePath, MerkleStoreDelta, MerkleTree, NodeIndex, PartialMerkleTree,
-    RecordingMap, RootPath, Rpo256, RpoDigest, SimpleSmt, TieredSmt, TryApplyDiff, ValuePath, Vec,
+    mmr::Mmr, BTreeMap, EmptySubtreeRoots, InnerNodeInfo, KvMap, MerkleError, MerklePath,
+    MerkleStoreDelta, MerkleTree, NodeIndex, PartialMerkleTree, RecordingMap, RootPath, Rpo256,
+    RpoDigest, SimpleSmt, TieredSmt, TryApplyDiff, ValuePath, Vec, EMPTY_WORD,
 };
 use crate::utils::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable};
 use core::borrow::Borrow;

--- a/src/merkle/store/tests.rs
+++ b/src/merkle/store/tests.rs
@@ -478,7 +478,7 @@ fn test_add_merkle_paths() -> Result<(), MerkleError> {
 #[test]
 fn wont_open_to_different_depth_root() {
     let empty = EmptySubtreeRoots::empty_hashes(64);
-    let a = [Felt::new(1); 4];
+    let a = [ONE; 4];
     let b = [Felt::new(2); 4];
 
     // Compute the root for a different depth. We cherry-pick this specific depth to prevent a
@@ -501,7 +501,7 @@ fn wont_open_to_different_depth_root() {
 
 #[test]
 fn store_path_opens_from_leaf() {
-    let a = [Felt::new(1); 4];
+    let a = [ONE; 4];
     let b = [Felt::new(2); 4];
     let c = [Felt::new(3); 4];
     let d = [Felt::new(4); 4];

--- a/src/merkle/tiered_smt/mod.rs
+++ b/src/merkle/tiered_smt/mod.rs
@@ -64,7 +64,7 @@ impl TieredSmt {
     pub const MAX_DEPTH: u8 = 64;
 
     /// Value of an empty leaf.
-    pub const EMPTY_VALUE: Word = super::empty_roots::EMPTY_WORD;
+    pub const EMPTY_VALUE: Word = super::EMPTY_WORD;
 
     // CONSTRUCTORS
     // --------------------------------------------------------------------------------------------

--- a/src/merkle/tiered_smt/tests.rs
+++ b/src/merkle/tiered_smt/tests.rs
@@ -1,5 +1,5 @@
 use super::{
-    super::{super::ONE, empty_roots::EMPTY_WORD, Felt, MerkleStore, WORD_SIZE, ZERO},
+    super::{super::ONE, super::WORD_SIZE, Felt, MerkleStore, EMPTY_WORD, ZERO},
     EmptySubtreeRoots, InnerNodeInfo, NodeIndex, Rpo256, RpoDigest, TieredSmt, Vec, Word,
 };
 
@@ -279,11 +279,11 @@ fn tsmt_delete_16() {
     smt.insert(key_b, value_b);
 
     // --- delete the last inserted value -------------------------------------
-    assert_eq!(smt.insert(key_b, [ZERO; 4]), value_b);
+    assert_eq!(smt.insert(key_b, EMPTY_WORD), value_b);
     assert_eq!(smt, smt1);
 
     // --- delete the first inserted value ------------------------------------
-    assert_eq!(smt.insert(key_a, [ZERO; 4]), value_a);
+    assert_eq!(smt.insert(key_a, EMPTY_WORD), value_a);
     assert_eq!(smt, smt0);
 }
 
@@ -313,15 +313,15 @@ fn tsmt_delete_32() {
     smt.insert(key_c, value_c);
 
     // --- delete the last inserted value -------------------------------------
-    assert_eq!(smt.insert(key_c, [ZERO; 4]), value_c);
+    assert_eq!(smt.insert(key_c, EMPTY_WORD), value_c);
     assert_eq!(smt, smt2);
 
     // --- delete the last inserted value -------------------------------------
-    assert_eq!(smt.insert(key_b, [ZERO; 4]), value_b);
+    assert_eq!(smt.insert(key_b, EMPTY_WORD), value_b);
     assert_eq!(smt, smt1);
 
     // --- delete the first inserted value ------------------------------------
-    assert_eq!(smt.insert(key_a, [ZERO; 4]), value_a);
+    assert_eq!(smt.insert(key_a, EMPTY_WORD), value_a);
     assert_eq!(smt, smt0);
 }
 
@@ -353,15 +353,15 @@ fn tsmt_delete_48_same_32_bit_prefix() {
     smt.insert(key_c, value_c);
 
     // --- delete the last inserted value -------------------------------------
-    assert_eq!(smt.insert(key_c, [ZERO; 4]), value_c);
+    assert_eq!(smt.insert(key_c, EMPTY_WORD), value_c);
     assert_eq!(smt, smt2);
 
     // --- delete the last inserted value -------------------------------------
-    assert_eq!(smt.insert(key_b, [ZERO; 4]), value_b);
+    assert_eq!(smt.insert(key_b, EMPTY_WORD), value_b);
     assert_eq!(smt, smt1);
 
     // --- delete the first inserted value ------------------------------------
-    assert_eq!(smt.insert(key_a, [ZERO; 4]), value_a);
+    assert_eq!(smt.insert(key_a, EMPTY_WORD), value_a);
     assert_eq!(smt, smt0);
 }
 
@@ -400,16 +400,16 @@ fn tsmt_delete_48_mixed_prefix() {
     smt.insert(key_d, value_d);
 
     // --- delete the inserted values one-by-one ------------------------------
-    assert_eq!(smt.insert(key_d, [ZERO; 4]), value_d);
+    assert_eq!(smt.insert(key_d, EMPTY_WORD), value_d);
     assert_eq!(smt, smt3);
 
-    assert_eq!(smt.insert(key_c, [ZERO; 4]), value_c);
+    assert_eq!(smt.insert(key_c, EMPTY_WORD), value_c);
     assert_eq!(smt, smt2);
 
-    assert_eq!(smt.insert(key_b, [ZERO; 4]), value_b);
+    assert_eq!(smt.insert(key_b, EMPTY_WORD), value_b);
     assert_eq!(smt, smt1);
 
-    assert_eq!(smt.insert(key_a, [ZERO; 4]), value_a);
+    assert_eq!(smt.insert(key_a, EMPTY_WORD), value_a);
     assert_eq!(smt, smt0);
 }
 
@@ -447,16 +447,16 @@ fn tsmt_delete_64() {
     smt.insert(key_d, value_d);
 
     // --- delete the last inserted value -------------------------------------
-    assert_eq!(smt.insert(key_d, [ZERO; 4]), value_d);
+    assert_eq!(smt.insert(key_d, EMPTY_WORD), value_d);
     assert_eq!(smt, smt3);
 
-    assert_eq!(smt.insert(key_c, [ZERO; 4]), value_c);
+    assert_eq!(smt.insert(key_c, EMPTY_WORD), value_c);
     assert_eq!(smt, smt2);
 
-    assert_eq!(smt.insert(key_b, [ZERO; 4]), value_b);
+    assert_eq!(smt.insert(key_b, EMPTY_WORD), value_b);
     assert_eq!(smt, smt1);
 
-    assert_eq!(smt.insert(key_a, [ZERO; 4]), value_a);
+    assert_eq!(smt.insert(key_a, EMPTY_WORD), value_a);
     assert_eq!(smt, smt0);
 }
 
@@ -577,7 +577,7 @@ fn test_order_sensitivity() {
 
     smt_1.insert(key_1, value);
     smt_1.insert(key_2, value);
-    smt_1.insert(key_2, [ZERO; WORD_SIZE]);
+    smt_1.insert(key_2, EMPTY_WORD);
 
     let mut smt_2 = TieredSmt::default();
     smt_2.insert(key_1, value);


### PR DESCRIPTION
This PR adds a new `EMPTY_WORD` constant replacing with it all usages of `[ZERO; 4]`, `[ZERO, ZERO, ZERO, ZERO]` and `[ZERO; WORD_SIZE]`, along with replacing `Felt::ZERO` and `Felt::new(0)` with `ZERO`, `Felt::ONE` and `Felt::new(1)` with ONE. 
