### PR TITLE
v0.7 release prep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/miden-crypto/0.7.0"
 categories = ["cryptography", "no-std"]
 keywords = ["miden", "crypto", "hash", "merkle"]
 edition = "2021"
-rust-version = "1.67"
+rust-version = "1.73"
 
 [[bin]]
 name = "miden-crypto"
@@ -39,8 +39,8 @@ std = ["blake3/std", "dep:cc", "dep:libc", "winter_crypto/std", "winter_math/std
 sve = ["std"]
 
 [dependencies]
-blake3 = { version = "1.4", default-features = false }
-clap = { version = "4.3", features = ["derive"], optional = true }
+blake3 = { version = "1.5", default-features = false }
+clap = { version = "4.4", features = ["derive"], optional = true }
 libc = { version =  "0.2", default-features = false, optional = true }
 rand_utils = { version = "0.6", package = "winter-rand-utils", optional = true }
 serde = { version = "1.0", features = [ "derive" ], default-features = false, optional = true }
@@ -50,7 +50,7 @@ winter_utils = { version = "0.6", package = "winter-utils", default-features = f
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }
-proptest = "1.1.0"
+proptest = "1.3"
 rand_utils = { version = "0.6", package = "winter-rand-utils" }
 
 [build-dependencies]

--- a/README.md
+++ b/README.md
@@ -21,6 +21,13 @@ For performance benchmarks of these hash functions and their comparison to other
 
 The module also contains additional supporting components such as `NodeIndex`, `MerklePath`,  and `MerkleError`  to assist with tree indexation, opening proofs, and reporting inconsistent arguments/state.
 
+## Signatures
+[DAS module](./src/dsa) provides a set of digital signature schemes supported by default in Miden VM. Currently, these schemes are:
+
+* `RPO Falcon512`: a variant of the [Falcon](https://falcon-sign.info/) signature scheme. This variant differs from the standard in that instead of using SHAKE256 hash function in the *hash-to-point* algorithm we use RPO256. This makes the signature more efficient to verify in Miden VM.
+
+For the above signatures, key generation and signing is available only in the `std` context (see [crate features](#crate-features) below), while signature verification is available in `no_std` context as well.
+
 ## Crate features
 This crate can be compiled with the following features:
 


### PR DESCRIPTION
This PR prepares `miden-crypto` crate for v0.7 release. Specifically:

- I added a section about signature schemes to the main readme.
- I bumped up dependency versions and min Rust version (to 1.73).