### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+# Documentation available at editorconfig.org
+
+root=true
+
+[*]
+ident_style = space
+ident_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.rs]
+max_line_length = 100
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.yml]
+ident_size = 2


### PR DESCRIPTION
## Describe your changes

Codified the `100` characters line-width describe [here](https://github.com/0xPolygonMiden/miden-base/discussions/257)

This configuration is picked up automatically by [several editors](https://editorconfig.org/#pre-installed).

The setting for [`max_line_length`](https://github.com/editorconfig/editorconfig/wiki/EditorConfig-Properties#max_line_length) is not as widely supported. But it does include some major tools (emacs/vim/atom/intelij/prettier).

I have not verified the above claims.

Examples from the rust community:

https://github.com/rust-lang/rust-clippy/blob/master/.editorconfig
https://github.com/rust-lang/rust/blob/master/.editorconfig

If this is accepted I can add to the other repos too