### PR TITLE
Implement conversion from `PartialMerkleTree` to `TieredSmt`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ sve = ["std"]
 [dependencies]
 blake3 = { version = "1.5", default-features = false }
 clap = { version = "4.4", features = ["derive"], optional = true }
+itertools = "0.11"
 libc = { version =  "0.2", default-features = false, optional = true }
 rand_utils = { version = "0.7", package = "winter-rand-utils", optional = true }
 serde = { version = "1.0", features = [ "derive" ], default-features = false, optional = true }


### PR DESCRIPTION
There are a few things I don't like about the current implementation. This PR serves to get the conversation going about the best way to implement the PMT -> TSMT conversion.

## Problem statement
It is not possible to convert a `PartialMerkleTree` into a `TieredSmt` because the PMT stores only values (accessed by `NodeIndex`), whereas the `TieredSmt` associates a key to every value. Therefore, to convert PMT -> TSMT, we must provide the key associated with each value in the PMT.

## Current solution
The current solution uses `TryFrom<(PMT, BTreeMap)> for TieredSmt`, where the `BTreeMap` provides the "value -> key" information. 

I also used an iterator-based approach (with a helper from `itertools`), as it is the most efficient approach; for all other solutions I tried, I was forced to create one or more `Vec<>` along the way, or traverse `pmt.leaves()` twice. However, the downside is that the expression in the `try_from()` is a little difficult to parse.

Finally, it is not clear from the type `BTreeMap<Digest, Digest>` what it is supposed to do. The problem I faced was that `Word` (the actual type for values in the tree) doesn't implement `Ord`, and so cannot be used as the key to a `BTreeMap`. The workaround is to store values as `Digest`, and convert them back to `Word` at some point in the process. I think we need a better solution for that.