### PR TITLE
Implement `IntoIterator` for `RpoDigest`

### DIFF
--- a/src/hash/rescue/rpo/digest.rs
+++ b/src/hash/rescue/rpo/digest.rs
@@ -302,6 +302,17 @@ impl Deserializable for RpoDigest {
     }
 }
 
+// ITERATORS
+// ================================================================================================
+impl IntoIterator for RpoDigest {
+    type Item = Felt;
+    type IntoIter = <[Felt; 4] as IntoIterator>::IntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
 // TESTS
 // ================================================================================================
 


### PR DESCRIPTION
The primary purpose of this change is to be able to move an `RpoDigest` into a vector (without copy). This is especially useful when loading hashes into the vm's `StackInputs`.

```rust
let digest = Digest::default();
let vec = Vec::new();

vec.extend(digest);
```

Compare with our 2 suboptimal choices prior to this change:

```rust
let digest = Digest::default();
let vec = Vec::new();

// 1. one-liner, but requires a copy
{
    vec.append(digest.as_elements().to_vec());
}

// 2. Require an extra variable to perform a move
{
    let digest: [Felt; 4] = digest.into();
    vec.append(digest);
}
```