### PR TITLE
Derive `Default` for `MmrPeaks`

### DIFF
--- a/src/merkle/mmr/peaks.rs
+++ b/src/merkle/mmr/peaks.rs
@@ -3,7 +3,8 @@ use super::{
     Felt, MmrError, MmrProof, Rpo256, Word,
 };
 
-#[derive(Debug, Clone, PartialEq, Default)]
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(test, derive(Default))]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct MmrPeaks {
     /// The number of leaves is used to differentiate accumulators that have the same number of

--- a/src/merkle/mmr/peaks.rs
+++ b/src/merkle/mmr/peaks.rs
@@ -4,7 +4,6 @@ use super::{
 };
 
 #[derive(Debug, Clone, PartialEq)]
-#[cfg_attr(test, derive(Default))]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct MmrPeaks {
     /// The number of leaves is used to differentiate accumulators that have the same number of
@@ -114,5 +113,13 @@ impl MmrPeaks {
         );
         elements.resize(len, ZERO);
         elements
+    }
+
+    // TEST HELPERS
+    // --------------------------------------------------------------------------------------------
+
+    #[cfg(test)]
+    pub fn empty() -> Self {
+        Self { num_leaves: 0, peaks: Vec::new() }
     }
 }

--- a/src/merkle/mmr/peaks.rs
+++ b/src/merkle/mmr/peaks.rs
@@ -3,7 +3,7 @@ use super::{
     Felt, MmrError, MmrProof, Rpo256, Word,
 };
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct MmrPeaks {
     /// The number of leaves is used to differentiate accumulators that have the same number of


### PR DESCRIPTION
Useful to create a dummy `MmrPeaks` value in tests
