### PR TITLE
Introduce `SimpleSmt::with_contiguous_leaves()`

### DIFF
--- a/src/merkle/simple_smt/mod.rs
+++ b/src/merkle/simple_smt/mod.rs
@@ -104,6 +104,22 @@ impl SimpleSmt {
         Ok(tree)
     }
 
+    /// Wrapper around [`SimpleSmt::with_leaves`] which inserts leaves at contiguous indices
+    /// starting at index 0.
+    pub fn with_contiguous_leaves<R, I>(depth: u8, entries: R) -> Result<Self, MerkleError>
+    where
+        R: IntoIterator<IntoIter = I>,
+        I: Iterator<Item = Word> + ExactSizeIterator,
+    {
+        Self::with_leaves(
+            depth,
+            entries
+                .into_iter()
+                .enumerate()
+                .map(|(idx, word)| (idx.try_into().expect("tree max depth is 2^8"), word)),
+        )
+    }
+
     // PUBLIC ACCESSORS
     // --------------------------------------------------------------------------------------------
 

--- a/src/merkle/simple_smt/tests.rs
+++ b/src/merkle/simple_smt/tests.rs
@@ -71,6 +71,21 @@ fn build_sparse_tree() {
     assert_eq!(old_value, EMPTY_WORD);
 }
 
+/// Tests that [`SimpleSmt::with_contiguous_leaves`] works as expected
+#[test]
+fn build_contiguous_tree() {
+    let tree_with_leaves = SimpleSmt::with_leaves(
+        2,
+        [0, 1, 2, 3].into_iter().zip(digests_to_words(&VALUES4).into_iter()),
+    )
+    .unwrap();
+
+    let tree_with_contiguous_leaves =
+        SimpleSmt::with_contiguous_leaves(2, digests_to_words(&VALUES4).into_iter()).unwrap();
+
+    assert_eq!(tree_with_leaves, tree_with_contiguous_leaves);
+}
+
 #[test]
 fn test_depth2_tree() {
     let tree =


### PR DESCRIPTION
Introduces `SimpleSmt::with_contiguous_leaves()` which is useful to build a `SimpleSmt` from complex iterator expressions, and where we want to pack all the leaves from index 0 and on.

For example, this is now possible (a pattern needed in `miden-node` to build the created notes tree):

```rust
// simplified
SimpleSmt::with_contiguous_leaves(
    DEPTH,
    note_envelopes
        .flat_map(|note| [note.note_hash(), note.metadata()])
        .collect::<Vec<_>>(),
)
.unwrap();
```
