### PR TITLE
Remove `ExactSizeIterator` constraint from `SimpleSmt::with_leaves()`

### DIFF
--- a/src/merkle/error.rs
+++ b/src/merkle/error.rs
@@ -14,7 +14,7 @@ pub enum MerkleError {
     InvalidIndex { depth: u8, value: u64 },
     InvalidDepth { expected: u8, provided: u8 },
     InvalidPath(MerklePath),
-    InvalidNumEntries(usize, usize),
+    InvalidNumEntries(usize),
     NodeNotInSet(NodeIndex),
     NodeNotInStore(RpoDigest, NodeIndex),
     NumLeavesNotPowerOfTwo(usize),
@@ -30,18 +30,18 @@ impl fmt::Display for MerkleError {
             DepthTooBig(depth) => write!(f, "the provided depth {depth} is too big"),
             DuplicateValuesForIndex(key) => write!(f, "multiple values provided for key {key}"),
             DuplicateValuesForKey(key) => write!(f, "multiple values provided for key {key}"),
-            InvalidIndex{ depth, value} => write!(
-                f,
-                "the index value {value} is not valid for the depth {depth}"
-            ),
-            InvalidDepth { expected, provided } => write!(
-                f,
-                "the provided depth {provided} is not valid for {expected}"
-            ),
+            InvalidIndex { depth, value } => {
+                write!(f, "the index value {value} is not valid for the depth {depth}")
+            }
+            InvalidDepth { expected, provided } => {
+                write!(f, "the provided depth {provided} is not valid for {expected}")
+            }
             InvalidPath(_path) => write!(f, "the provided path is not valid"),
-            InvalidNumEntries(max, provided) => write!(f, "the provided number of entries is {provided}, but the maximum for the given depth is {max}"),
+            InvalidNumEntries(max) => write!(f, "number of entries exceeded the maximum: {max}"),
             NodeNotInSet(index) => write!(f, "the node with index ({index}) is not in the set"),
-            NodeNotInStore(hash, index) => write!(f, "the node {hash:?} with index ({index}) is not in the store"),
+            NodeNotInStore(hash, index) => {
+                write!(f, "the node {hash:?} with index ({index}) is not in the store")
+            }
             NumLeavesNotPowerOfTwo(leaves) => {
                 write!(f, "the leaves count {leaves} is not a power of 2")
             }

--- a/src/merkle/partial_mt/mod.rs
+++ b/src/merkle/partial_mt/mod.rs
@@ -111,7 +111,7 @@ impl PartialMerkleTree {
         // depth of 63 because we consider passing in a vector of size 2^64 infeasible.
         let max = (1_u64 << 63) as usize;
         if layers.len() > max {
-            return Err(MerkleError::InvalidNumEntries(max, layers.len()));
+            return Err(MerkleError::InvalidNumEntries(max));
         }
 
         // Get maximum depth

--- a/src/merkle/partial_mt/mod.rs
+++ b/src/merkle/partial_mt/mod.rs
@@ -109,7 +109,7 @@ impl PartialMerkleTree {
 
         // check if the number of leaves can be accommodated by the tree's depth; we use a min
         // depth of 63 because we consider passing in a vector of size 2^64 infeasible.
-        let max = (1_u64 << 63) as usize;
+        let max = 2usize.pow(63);
         if layers.len() > max {
             return Err(MerkleError::InvalidNumEntries(max));
         }

--- a/src/merkle/simple_smt/mod.rs
+++ b/src/merkle/simple_smt/mod.rs
@@ -71,11 +71,10 @@ impl SimpleSmt {
     /// - If the depth is 0 or is greater than 64.
     /// - The number of entries exceeds the maximum tree capacity, that is 2^{depth}.
     /// - The provided entries contain multiple values for the same key.
-    pub fn with_leaves<R, I>(depth: u8, entries: R) -> Result<Self, MerkleError>
-    where
-        R: IntoIterator<IntoIter = I>,
-        I: Iterator<Item = (u64, Word)> + ExactSizeIterator,
-    {
+    pub fn with_leaves(
+        depth: u8,
+        entries: impl IntoIterator<Item = (u64, Word)>,
+    ) -> Result<Self, MerkleError> {
         // create an empty tree
         let mut tree = Self::new(depth)?;
 
@@ -105,11 +104,10 @@ impl SimpleSmt {
 
     /// Wrapper around [`SimpleSmt::with_leaves`] which inserts leaves at contiguous indices
     /// starting at index 0.
-    pub fn with_contiguous_leaves<R, I>(depth: u8, entries: R) -> Result<Self, MerkleError>
-    where
-        R: IntoIterator<IntoIter = I>,
-        I: Iterator<Item = Word> + ExactSizeIterator,
-    {
+    pub fn with_contiguous_leaves(
+        depth: u8,
+        entries: impl IntoIterator<Item = Word>,
+    ) -> Result<Self, MerkleError> {
         Self::with_leaves(
             depth,
             entries

--- a/src/merkle/simple_smt/mod.rs
+++ b/src/merkle/simple_smt/mod.rs
@@ -80,7 +80,7 @@ impl SimpleSmt {
 
         // compute the max number of entries. We use an upper bound of depth 63 because we consider
         // passing in a vector of size 2^64 infeasible.
-        let max_num_entries = 2usize.pow(tree.depth.min(63).into());
+        let max_num_entries = 2_usize.pow(tree.depth.min(63).into());
 
         // This being a sparse data structure, the EMPTY_WORD is not assigned to the `BTreeMap`, so
         // entries with the empty value need additional tracking.

--- a/src/merkle/simple_smt/mod.rs
+++ b/src/merkle/simple_smt/mod.rs
@@ -82,7 +82,7 @@ impl SimpleSmt {
         // check if the number of leaves can be accommodated by the tree's depth; we use a min
         // depth of 63 because we consider passing in a vector of size 2^64 infeasible.
         let entries = entries.into_iter();
-        let max = 1 << tree.depth.min(63);
+        let max = 2usize.pow(tree.depth.min(63).into());
         if entries.len() > max {
             return Err(MerkleError::InvalidNumEntries(max));
         }

--- a/src/merkle/simple_smt/mod.rs
+++ b/src/merkle/simple_smt/mod.rs
@@ -84,7 +84,7 @@ impl SimpleSmt {
         let entries = entries.into_iter();
         let max = 1 << tree.depth.min(63);
         if entries.len() > max {
-            return Err(MerkleError::InvalidNumEntries(max, entries.len()));
+            return Err(MerkleError::InvalidNumEntries(max));
         }
 
         // append leaves to the tree returning an error if a duplicate entry for the same key

--- a/src/merkle/simple_smt/mod.rs
+++ b/src/merkle/simple_smt/mod.rs
@@ -85,10 +85,12 @@ impl SimpleSmt {
         // append leaves to the tree returning an error if a duplicate entry for the same key
         // is found
         let mut empty_entries = BTreeSet::new();
-        for (key, value) in entries {
-            let old_value = tree
-                .update_leaf(key, value)
-                .map_err(|_| MerkleError::InvalidNumEntries(max_num_entries))?;
+        for (idx, (key, value)) in entries.into_iter().enumerate() {
+            if idx >= max_num_entries {
+                return Err(MerkleError::InvalidNumEntries(max_num_entries));
+            }
+
+            let old_value = tree.update_leaf(key, value)?;
 
             if old_value != Self::EMPTY_VALUE || empty_entries.contains(&key) {
                 return Err(MerkleError::DuplicateValuesForIndex(key));


### PR DESCRIPTION
The `ExactSizeIterator` constraint forces the caller to instantiate iterators into, say, a `Vec`, which leads to useless memory allocations. The signature of the function is now cleaner as well.

The one downside of this approach is that in the unlikely case that the collection indeed has more than 2^63 elements, then we will do a lot of processing before figuring that out. However, this will almost never happen, and we should optimize for the case where the iterator doesn't have too many elements.