### PR TITLE
`MmrPeaks::hash_peaks()` returns `RpoDigest`

### DIFF
--- a/src/merkle/mmr/peaks.rs
+++ b/src/merkle/mmr/peaks.rs
@@ -64,8 +64,8 @@ impl MmrPeaks {
     /// The procedure will:
     /// - Flatten and pad the peaks to a vector of Felts.
     /// - Hash the vector of Felts.
-    pub fn hash_peaks(&self) -> Word {
-        Rpo256::hash_elements(&self.flatten_and_pad_peaks()).into()
+    pub fn hash_peaks(&self) -> RpoDigest {
+        Rpo256::hash_elements(&self.flatten_and_pad_peaks())
     }
 
     pub fn verify(&self, value: RpoDigest, opening: MmrProof) -> bool {

--- a/src/merkle/mmr/tests.rs
+++ b/src/merkle/mmr/tests.rs
@@ -613,10 +613,7 @@ fn test_mmr_hash_peaks() {
     // minimum length is 16
     let mut expected_peaks = [first_peak, second_peak, third_peak].to_vec();
     expected_peaks.resize(16, RpoDigest::default());
-    assert_eq!(
-        peaks.hash_peaks(),
-        *Rpo256::hash_elements(&digests_to_elements(&expected_peaks))
-    );
+    assert_eq!(peaks.hash_peaks(), Rpo256::hash_elements(&digests_to_elements(&expected_peaks)));
 }
 
 #[test]
@@ -634,7 +631,7 @@ fn test_mmr_peaks_hash_less_than_16() {
         expected_peaks.resize(16, RpoDigest::default());
         assert_eq!(
             accumulator.hash_peaks(),
-            *Rpo256::hash_elements(&digests_to_elements(&expected_peaks))
+            Rpo256::hash_elements(&digests_to_elements(&expected_peaks))
         );
     }
 }
@@ -651,7 +648,7 @@ fn test_mmr_peaks_hash_odd() {
     expected_peaks.resize(18, RpoDigest::default());
     assert_eq!(
         accumulator.hash_peaks(),
-        *Rpo256::hash_elements(&digests_to_elements(&expected_peaks))
+        Rpo256::hash_elements(&digests_to_elements(&expected_peaks))
     );
 }
 


### PR DESCRIPTION
`RpoDigest` is more flexible than `Word`. Specifically, I need the [conversion](https://github.com/0xPolygonMiden/crypto/blob/a7791b4b7efd76c71054174ba736bba8cb1bf58a/src/hash/rescue/rpo/digest.rs#L152) to `[u8; 32]` from `RpoDigest` when using `AdviceInputs.map`.
