### PR TITLE
Implement `SimpleSmt::set_subtree`

### DIFF
--- a/src/merkle/error.rs
+++ b/src/merkle/error.rs
@@ -13,6 +13,7 @@ pub enum MerkleError {
     DuplicateValuesForKey(RpoDigest),
     InvalidIndex { depth: u8, value: u64 },
     InvalidDepth { expected: u8, provided: u8 },
+    InvalidSubtreeDepth { subtree_depth: u8, tree_depth: u8 },
     InvalidPath(MerklePath),
     InvalidNumEntries(usize),
     NodeNotInSet(NodeIndex),
@@ -35,6 +36,9 @@ impl fmt::Display for MerkleError {
             }
             InvalidDepth { expected, provided } => {
                 write!(f, "the provided depth {provided} is not valid for {expected}")
+            }
+            InvalidSubtreeDepth { subtree_depth, tree_depth } => {
+                write!(f, "tried inserting a subtree of depth {subtree_depth} into a tree of depth {tree_depth}")
             }
             InvalidPath(_path) => write!(f, "the provided path is not valid"),
             InvalidNumEntries(max) => write!(f, "number of entries exceeded the maximum: {max}"),

--- a/src/merkle/simple_smt/mod.rs
+++ b/src/merkle/simple_smt/mod.rs
@@ -245,11 +245,13 @@ impl SimpleSmt {
 
     /// Inserts a subtree at the specified index. The depth at which the subtree is inserted is
     /// computed as `self.depth() - subtree.depth()`.
+    ///
+    /// Returns the new root.
     pub fn set_subtree(
         &mut self,
         subtree_insertion_index: u64,
         subtree: SimpleSmt,
-    ) -> Result<(), MerkleError> {
+    ) -> Result<RpoDigest, MerkleError> {
         if subtree.depth() > self.depth() {
             return Err(MerkleError::InvalidSubtreeDepth {
                 subtree_depth: subtree.depth(),
@@ -298,7 +300,7 @@ impl SimpleSmt {
         // --------------
         self.recompute_nodes_from_index_to_root(subtree_root_index, subtree.root);
 
-        Ok(())
+        Ok(self.root)
     }
 
     // HELPER METHODS

--- a/src/merkle/simple_smt/mod.rs
+++ b/src/merkle/simple_smt/mod.rs
@@ -243,6 +243,64 @@ impl SimpleSmt {
         Ok(old_value)
     }
 
+    /// Inserts a subtree at the specified index. The depth at which the subtree is inserted is
+    /// computed as `self.depth() - subtree.depth()`.
+    pub fn set_subtree(
+        &mut self,
+        subtree_insertion_index: u64,
+        subtree: SimpleSmt,
+    ) -> Result<(), MerkleError> {
+        if subtree.depth() > self.depth() {
+            return Err(MerkleError::InvalidSubtreeDepth {
+                subtree_depth: subtree.depth(),
+                tree_depth: self.depth(),
+            });
+        }
+
+        // Verify that `subtree_insertion_index` is valid.
+        let subtree_root_insertion_depth = self.depth() - subtree.depth();
+        let subtree_root_index =
+            NodeIndex::new(subtree_root_insertion_depth, subtree_insertion_index)?;
+
+        // add leaves
+        // --------------
+
+        // The subtree's leaf indices live in their own context - i.e. a subtree of depth `d`. If we
+        // insert the subtree at `subtree_insertion_index = 0`, then the subtree leaf indices are
+        // valid as they are. However, consider what happens when we insert at
+        // `subtree_insertion_index = 1`. The first leaf of our subtree now will have index `2^d`;
+        // you can see it as there's a full subtree sitting on its left. In general, for
+        // `subtree_insertion_index = i`, there are `i` subtrees sitting before the subtree we want
+        // to insert, so we need to adjust all its leaves by `i * 2^d`.
+        let leaf_index_shift: u64 = subtree_insertion_index * 2_u64.pow(subtree.depth().into());
+        for (subtree_leaf_idx, leaf_value) in subtree.leaves() {
+            let new_leaf_idx = leaf_index_shift + subtree_leaf_idx;
+            debug_assert!(new_leaf_idx < 2_u64.pow(self.depth().into()));
+
+            self.insert_leaf_node(new_leaf_idx, *leaf_value);
+        }
+
+        // add subtree's branch nodes (which includes the root)
+        // --------------
+        for (branch_idx, branch_node) in subtree.branches {
+            let new_branch_idx = {
+                let new_depth = subtree_root_insertion_depth + branch_idx.depth();
+                let new_value = subtree_insertion_index * 2_u64.pow(branch_idx.depth().into())
+                    + branch_idx.value();
+
+                NodeIndex::new(new_depth, new_value).expect("index guaranteed to be valid")
+            };
+
+            self.branches.insert(new_branch_idx, branch_node);
+        }
+
+        // recompute nodes starting from subtree root
+        // --------------
+        self.recompute_nodes_from_index_to_root(subtree_root_index, subtree.root);
+
+        Ok(())
+    }
+
     // HELPER METHODS
     // --------------------------------------------------------------------------------------------
 

--- a/src/merkle/simple_smt/tests.rs
+++ b/src/merkle/simple_smt/tests.rs
@@ -404,6 +404,49 @@ fn test_simplesmt_set_subtree() {
     assert_eq!(tree.get_branch_node(&NodeIndex::new_unchecked(2, 2)).parent(), g);
 }
 
+/// Ensures that an invalid input node index into `set_subtree()` incurs no mutation of the tree
+#[test]
+fn test_simplesmt_set_subtree_unchanged_for_wrong_index() {
+    // Final Tree:
+    //
+    //        ____k____
+    //       /         \
+    //     _i_         _j_
+    //    /   \       /   \
+    //   e     f     g     h
+    //  / \   / \   / \   / \
+    // a   b 0   0 c   0 0   d
+
+    let z = EMPTY_WORD;
+
+    let a = Word::from(Rpo256::merge(&[z.into(); 2]));
+    let b = Word::from(Rpo256::merge(&[a.into(); 2]));
+    let c = Word::from(Rpo256::merge(&[b.into(); 2]));
+    let d = Word::from(Rpo256::merge(&[c.into(); 2]));
+
+    // subtree:
+    //   g
+    //  / \
+    // c   0
+    let subtree = {
+        let depth = 1;
+        let entries = vec![(0, c)];
+        SimpleSmt::with_leaves(depth, entries).unwrap()
+    };
+
+    let mut tree = {
+        let depth = 3;
+        let entries = vec![(0, a), (1, b), (7, d)];
+        SimpleSmt::with_leaves(depth, entries).unwrap()
+    };
+    let tree_root_before_insertion = tree.root();
+
+    // insert subtree
+    assert!(tree.set_subtree(500, subtree).is_err());
+
+    assert_eq!(tree.root(), tree_root_before_insertion);
+}
+
 /// We insert an empty subtree that has the same depth as the original tree
 #[test]
 fn test_simplesmt_set_subtree_entire_tree() {


### PR DESCRIPTION
Closes #220 

Note that `set_subtree()` returns `Result<(), MerkleError>` [instead of](https://github.com/0xPolygonMiden/crypto/issues/220#issuecomment-1823911017) `Result<Word, MerkleError>`, because I didn't know which value to return. The hash of the internal node where the subtree root was inserted? Is this relevant information?

I would also suggest we change the interface to

```rust
pub fn set_subtree(&mut self, index: NodeIndex, subtree: SimpleSmt) -> Result<(), MerkleError>
```

This would result in caller code that's easier to read (since the depth of the insertion is determined at the call site). I believe callers should always know the depth at which they want to insert, such as in `miden-node` where we want to insert a subtree of depth 13 at depth 8.