### PR TITLE
New padding rule for RPX

### DIFF
--- a/src/hash/rescue/rpo/mod.rs
+++ b/src/hash/rescue/rpo/mod.rs
@@ -55,11 +55,11 @@ mod tests;
 pub struct Rpo256();
 
 impl Hasher for Rpo256 {
-    /// Rpo256 collision resistance is the same as the security level, that is 128-bits.
+    /// Rpo256 collision resistance is 127-bits.
     ///
     /// #### Collision resistance
     ///
-    /// However, our setup of the capacity registers might drop it to 126.
+    /// However, our setup of the capacity registers might drop it to 125.
     ///
     /// Related issue: [#69](https://github.com/0xPolygonMiden/crypto/issues/69)
     const COLLISION_RESISTANCE: u32 = 128;

--- a/src/hash/rescue/rpo/mod.rs
+++ b/src/hash/rescue/rpo/mod.rs
@@ -27,12 +27,8 @@ mod tests;
 /// * Number of founds: 7.
 /// * S-Box degree: 7.
 ///
-/// The above parameters target a 128-bit security level for the permutation. However, the hash
-/// function might have less than 128-bit security due to the use of some of the capacity elements
-/// by the padding rule or for the purpose of enforcing domain separation. The amount of security
-/// degradation due to the current padding rule is of 1 bit and for enforcing domain separation is
-/// 2 bits.
-/// The digest consists of four field elements and it can be serialized into 32 bytes (256 bits).
+/// The above parameters target a 128-bit security level. The digest consists of four field elements
+/// and it can be serialized into 32 bytes (256 bits).
 ///
 /// ## Hash output consistency
 /// Functions [hash_elements()](Rpo256::hash_elements), [merge()](Rpo256::merge), and
@@ -59,9 +55,8 @@ mod tests;
 pub struct Rpo256();
 
 impl Hasher for Rpo256 {
-    /// Rpo256 collision resistance is 127-bits. The loss of 1 bit of security is related to
-    /// the use of the first capacity element as a binary flag by the padding rule.
-    const COLLISION_RESISTANCE: u32 = 127;
+    /// Rpo256 collision resistance is 128-bits.
+    const COLLISION_RESISTANCE: u32 = 128;
 
     type Digest = RpoDigest;
 
@@ -272,8 +267,7 @@ impl Rpo256 {
     // DOMAIN IDENTIFIER
     // --------------------------------------------------------------------------------------------
 
-    /// Returns a hash of two digests and a domain identifier. Note that the implementations'
-    /// use of the capacity registers degrades the security of the hash function to 125.
+    /// Returns a hash of two digests and a domain identifier.
     pub fn merge_in_domain(values: &[RpoDigest; 2], domain: Felt) -> RpoDigest {
         // initialize the state by copying the digest elements into the rate portion of the state
         // (8 total elements), and set the capacity elements to 0.

--- a/src/hash/rescue/rpo/mod.rs
+++ b/src/hash/rescue/rpo/mod.rs
@@ -27,8 +27,12 @@ mod tests;
 /// * Number of founds: 7.
 /// * S-Box degree: 7.
 ///
-/// The above parameters target 128-bit security level. The digest consists of four field elements
-/// and it can be serialized into 32 bytes (256 bits).
+/// The above parameters target a 128-bit security level for the permutation. However, the hash
+/// function might have less than 128-bit security due to the use of some of the capacity elements
+/// by the padding rule or for the purpose of enforcing domain separation. The amount of security
+/// degradation due to the current padding rule is of 1 bit and for enforcing domain separation is
+/// 2 bits.
+/// The digest consists of four field elements and it can be serialized into 32 bytes (256 bits).
 ///
 /// ## Hash output consistency
 /// Functions [hash_elements()](Rpo256::hash_elements), [merge()](Rpo256::merge), and
@@ -55,14 +59,9 @@ mod tests;
 pub struct Rpo256();
 
 impl Hasher for Rpo256 {
-    /// Rpo256 collision resistance is 127-bits.
-    ///
-    /// #### Collision resistance
-    ///
-    /// However, our setup of the capacity registers might drop it to 125.
-    ///
-    /// Related issue: [#69](https://github.com/0xPolygonMiden/crypto/issues/69)
-    const COLLISION_RESISTANCE: u32 = 128;
+    /// Rpo256 collision resistance is 127-bits. The loss of 1 bit of security is related to
+    /// the use of the first capacity element as a binary flag by the padding rule.
+    const COLLISION_RESISTANCE: u32 = 127;
 
     type Digest = RpoDigest;
 
@@ -273,7 +272,8 @@ impl Rpo256 {
     // DOMAIN IDENTIFIER
     // --------------------------------------------------------------------------------------------
 
-    /// Returns a hash of two digests and a domain identifier.
+    /// Returns a hash of two digests and a domain identifier. Note that the implementations'
+    /// use of the capacity registers degrades the security of the hash function to 125.
     pub fn merge_in_domain(values: &[RpoDigest; 2], domain: Felt) -> RpoDigest {
         // initialize the state by copying the digest elements into the rate portion of the state
         // (8 total elements), and set the capacity elements to 0.

--- a/src/hash/rescue/rpx/mod.rs
+++ b/src/hash/rescue/rpx/mod.rs
@@ -30,12 +30,8 @@ pub type CubicExtElement = CubeExtension<Felt>;
 /// - (M): `apply_mds` → `add_constants`.
 /// * Permutation: (FB) (E) (FB) (E) (FB) (E) (M).
 ///
-/// The above parameters target a 128-bit security level for the permutation. However, the hash
-/// function might have less than 128-bit security due to the use of some of the capacity elements
-/// by the padding rule or for the purpose of enforcing domain separation. The amount of security
-/// degradation due to the current padding rule is of 3 bits and for enforcing domain separation is
-/// 2 bits.
-/// The digest consists of four field elements and it can be serialized into 32 bytes (256 bits).
+/// The above parameters target a 128-bit security level. The digest consists of four field elements
+/// and it can be serialized into 32 bytes (256 bits).
 ///
 /// ## Hash output consistency
 /// Functions [hash_elements()](Rpx256::hash_elements), [merge()](Rpx256::merge), and
@@ -62,10 +58,8 @@ pub type CubicExtElement = CubeExtension<Felt>;
 pub struct Rpx256();
 
 impl Hasher for Rpx256 {
-    /// Rpx256 collision resistance is 125-bits. The loss of 3 bits of security is related to
-    /// the use of the first capacity element as a flag, with 8 potential values, by the padding
-    /// rule.
-    const COLLISION_RESISTANCE: u32 = 125;
+    /// Rpx256 collision resistance is 128-bits.
+    const COLLISION_RESISTANCE: u32 = 128;
 
     type Digest = RpxDigest;
 
@@ -266,8 +260,7 @@ impl Rpx256 {
     // DOMAIN IDENTIFIER
     // --------------------------------------------------------------------------------------------
 
-    /// Returns a hash of two digests and a domain identifier. Note that the implementations'
-    /// use of the capacity registers degrades the security of the hash function to 123.
+    /// Returns a hash of two digests and a domain identifier.
     pub fn merge_in_domain(values: &[RpxDigest; 2], domain: Felt) -> RpxDigest {
         // initialize the state by copying the digest elements into the rate portion of the state
         // (8 total elements), and set the capacity elements to 0.

--- a/src/hash/rescue/rpx/mod.rs
+++ b/src/hash/rescue/rpx/mod.rs
@@ -30,8 +30,12 @@ pub type CubicExtElement = CubeExtension<Felt>;
 /// - (M): `apply_mds` → `add_constants`.
 /// * Permutation: (FB) (E) (FB) (E) (FB) (E) (M).
 ///
-/// The above parameters target 128-bit security level for the permutation. The digest consists
-/// of four field elements and it can be serialized into 32 bytes (256 bits).
+/// The above parameters target a 128-bit security level for the permutation. However, the hash
+/// function might have less than 128-bit security due to the use of some of the capacity elements
+/// by the padding rule or for the purpose of enforcing domain separation. The amount of security
+/// degradation due to the current padding rule is of 3 bits and for enforcing domain separation is
+/// 2 bits.
+/// The digest consists of four field elements and it can be serialized into 32 bytes (256 bits).
 ///
 /// ## Hash output consistency
 /// Functions [hash_elements()](Rpx256::hash_elements), [merge()](Rpx256::merge), and
@@ -58,14 +62,10 @@ pub type CubicExtElement = CubeExtension<Felt>;
 pub struct Rpx256();
 
 impl Hasher for Rpx256 {
-    /// Rpx256 collision resistance is 125-bits.
-    ///
-    /// #### Collision resistance
-    ///
-    /// However, our setup of the capacity registers might drop it to 123.
-    ///
-    /// Related issue: [#69](https://github.com/0xPolygonMiden/crypto/issues/69)
-    const COLLISION_RESISTANCE: u32 = 128;
+    /// Rpx256 collision resistance is 125-bits. The loss of 3 bits of security is related to
+    /// the use of the first capacity element as a flag, with 8 potential values, by the padding
+    /// rule.
+    const COLLISION_RESISTANCE: u32 = 125;
 
     type Digest = RpxDigest;
 
@@ -266,7 +266,8 @@ impl Rpx256 {
     // DOMAIN IDENTIFIER
     // --------------------------------------------------------------------------------------------
 
-    /// Returns a hash of two digests and a domain identifier.
+    /// Returns a hash of two digests and a domain identifier. Note that the implementations'
+    /// use of the capacity registers degrades the security of the hash function to 123.
     pub fn merge_in_domain(values: &[RpxDigest; 2], domain: Felt) -> RpxDigest {
         // initialize the state by copying the digest elements into the rate portion of the state
         // (8 total elements), and set the capacity elements to 0.

--- a/src/hash/rescue/rpx/mod.rs
+++ b/src/hash/rescue/rpx/mod.rs
@@ -2,7 +2,7 @@ use super::{
     add_constants, add_constants_and_apply_inv_sbox, add_constants_and_apply_sbox, apply_inv_sbox,
     apply_mds, apply_sbox, CubeExtension, Digest, ElementHasher, Felt, FieldElement, Hasher,
     StarkField, ARK1, ARK2, BINARY_CHUNK_SIZE, CAPACITY_RANGE, DIGEST_BYTES, DIGEST_RANGE,
-    DIGEST_SIZE, INPUT1_RANGE, INPUT2_RANGE, MDS, NUM_ROUNDS, ONE, RATE_RANGE, RATE_WIDTH,
+    DIGEST_SIZE, INPUT1_RANGE, INPUT2_RANGE, MDS, NUM_ROUNDS, RATE_RANGE, RATE_WIDTH,
     STATE_WIDTH, ZERO,
 };
 use core::{convert::TryInto, ops::Range};
@@ -157,9 +157,6 @@ impl Hasher for Rpx256 {
             state[INPUT2_RANGE.start + 1] = Felt::new(value / Felt::MODULUS);
             state[CAPACITY_RANGE.start] = Felt::from(6_u8);
         }
-
-        // common padding for both cases
-        state[CAPACITY_RANGE.start] = ONE;
 
         // apply the RPX permutation and return the first four elements of the state
         Self::apply_permutation(&mut state);

--- a/src/hash/rescue/rpx/mod.rs
+++ b/src/hash/rescue/rpx/mod.rs
@@ -75,7 +75,8 @@ impl Hasher for Rpx256 {
         // this to achieve:
         // 1. Domain separating hashing of `[u8]` from hashing of `[Felt]`.
         // 2. Avoiding collisions at the `[Felt]` representation of the encoded bytes.
-        state[CAPACITY_RANGE.start] = Felt::from((RATE_WIDTH + (num_field_elem % RATE_WIDTH)) as u8);
+        state[CAPACITY_RANGE.start] =
+            Felt::from((RATE_WIDTH + (num_field_elem % RATE_WIDTH)) as u8);
 
         // initialize a buffer to receive the little-endian elements.
         let mut buf = [0_u8; 8];

--- a/src/hash/rescue/rpx/mod.rs
+++ b/src/hash/rescue/rpx/mod.rs
@@ -2,8 +2,8 @@ use super::{
     add_constants, add_constants_and_apply_inv_sbox, add_constants_and_apply_sbox, apply_inv_sbox,
     apply_mds, apply_sbox, CubeExtension, Digest, ElementHasher, Felt, FieldElement, Hasher,
     StarkField, ARK1, ARK2, BINARY_CHUNK_SIZE, CAPACITY_RANGE, DIGEST_BYTES, DIGEST_RANGE,
-    DIGEST_SIZE, INPUT1_RANGE, INPUT2_RANGE, MDS, NUM_ROUNDS, RATE_RANGE, RATE_WIDTH,
-    STATE_WIDTH, ZERO,
+    DIGEST_SIZE, INPUT1_RANGE, INPUT2_RANGE, MDS, NUM_ROUNDS, RATE_RANGE, RATE_WIDTH, STATE_WIDTH,
+    ZERO,
 };
 use core::{convert::TryInto, ops::Range};
 


### PR DESCRIPTION
## Describe your changes
Addresses #203 
I have kept the old padding rule when hashing bytes so as to avoid the security degradation. On the other hand, there is also a case for uniformity so maybe we should also change it to the new padding rule.

## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
