### PR TITLE
Implement `inner_nodes()` iterator for `PartialMmr`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Updated Winterfell dependency to v0.7 (#200)
 * Implemented RPX hash function (#201).
 * Added `FeltRng` and `RpoRandomCoin` (#237).
+* Added `inner_nodes()` method to `PartialMmr` (#238).
 
 ## 0.7.1 (2023-10-10)
 

--- a/src/merkle/mmr/inorder.rs
+++ b/src/merkle/mmr/inorder.rs
@@ -6,6 +6,9 @@
 //! leaves count.
 use core::num::NonZeroUsize;
 
+// IN-ORDER INDEX
+// ================================================================================================
+
 /// Index of nodes in a perfectly balanced binary tree based on an in-order tree walk.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct InOrderIndex {
@@ -95,6 +98,18 @@ impl InOrderIndex {
         }
     }
 }
+
+// CONVERSIONS FROM IN-ORDER INDEX
+// ------------------------------------------------------------------------------------------------
+
+impl From<InOrderIndex> for u64 {
+    fn from(index: InOrderIndex) -> Self {
+        index.idx as u64
+    }
+}
+
+// TESTS
+// ================================================================================================
 
 #[cfg(test)]
 mod test {

--- a/src/merkle/mmr/mod.rs
+++ b/src/merkle/mmr/mod.rs
@@ -40,10 +40,10 @@ const fn leaf_to_corresponding_tree(pos: usize, forest: usize) -> Option<u32> {
         // - each bit in the forest is a unique tree and the bit position its power-of-two size
         // - each tree owns a consecutive range of positions equal to its size from left-to-right
         // - this means the first tree owns from `0` up to the `2^k_0` first positions, where `k_0`
-        // is the highest true bit position, the second tree from `2^k_0 + 1` up to `2^k_1` where
-        // `k_1` is the second higest bit, so on.
+        //   is the highest true bit position, the second tree from `2^k_0 + 1` up to `2^k_1` where
+        //   `k_1` is the second highest bit, so on.
         // - this means the highest bits work as a category marker, and the position is owned by
-        // the first tree which doesn't share a high bit with the position
+        //   the first tree which doesn't share a high bit with the position
         let before = forest & pos;
         let after = forest ^ before;
         let tree = after.ilog2();

--- a/src/merkle/mmr/peaks.rs
+++ b/src/merkle/mmr/peaks.rs
@@ -3,17 +3,20 @@ use super::{
     Felt, MmrError, MmrProof, Rpo256, Word,
 };
 
+// MMR PEAKS
+// ================================================================================================
+
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct MmrPeaks {
-    /// The number of leaves is used to differentiate accumulators that have the same number of
-    /// peaks. This happens because the number of peaks goes up-and-down as the structure is used
-    /// causing existing trees to be merged and new ones to be created. As an example, every time
-    /// the [Mmr] has a power-of-two number of leaves there is a single peak.
+    /// The number of leaves is used to differentiate MMRs that have the same number of peaks. This
+    /// happens because the number of peaks goes up-and-down as the structure is used causing
+    /// existing trees to be merged and new ones to be created. As an example, every time the MMR
+    /// has a power-of-two number of leaves there is a single peak.
     ///
-    /// Every tree in the [Mmr] forest has a distinct power-of-two size, this means only the right
-    /// most tree can have an odd number of elements (e.g. `1`). Additionally this means that the bits in
-    /// `num_leaves` conveniently encode the size of each individual tree.
+    /// Every tree in the MMR forest has a distinct power-of-two size, this means only the right-
+    /// most tree can have an odd number of elements (e.g. `1`). Additionally this means that the
+    /// bits in `num_leaves` conveniently encode the size of each individual tree.
     ///
     /// Examples:
     ///
@@ -25,7 +28,7 @@ pub struct MmrPeaks {
     ///      leftmost tree has `2**3=8` elements, and the right most has `2**2=4` elements.
     num_leaves: usize,
 
-    /// All the peaks of every tree in the [Mmr] forest. The peaks are always ordered by number of
+    /// All the peaks of every tree in the MMR forest. The peaks are always ordered by number of
     /// leaves, starting from the peak with most children, to the one with least.
     ///
     /// Invariant: The length of `peaks` must be equal to the number of true bits in `num_leaves`.
@@ -44,17 +47,17 @@ impl MmrPeaks {
     // ACCESSORS
     // --------------------------------------------------------------------------------------------
 
-    /// Returns a count of the [Mmr]'s leaves.
+    /// Returns a count of the MMR's leaves.
     pub fn num_leaves(&self) -> usize {
         self.num_leaves
     }
 
-    /// Returns the current peaks of the [Mmr].
+    /// Returns the current peaks of the MMR.
     pub fn peaks(&self) -> &[RpoDigest] {
         &self.peaks
     }
 
-    /// Returns the current num_leaves and peaks of the [Mmr].
+    /// Returns the current num_leaves and peaks of the MMR.
     pub fn into_parts(self) -> (usize, Vec<RpoDigest>) {
         (self.num_leaves, self.peaks)
     }

--- a/src/merkle/path.rs
+++ b/src/merkle/path.rs
@@ -191,11 +191,12 @@ pub struct RootPath {
     pub path: MerklePath,
 }
 
-// SERILIZATION
+// SERIALIZATION
 // ================================================================================================
+
 impl Serializable for MerklePath {
     fn write_into<W: winter_utils::ByteWriter>(&self, target: &mut W) {
-        assert!(self.nodes.len() <= u8::MAX.into(), "Length enforced in the construtor");
+        assert!(self.nodes.len() <= u8::MAX.into(), "Length enforced in the constructor");
         target.write_u8(self.nodes.len() as u8);
         self.nodes.write_into(target);
     }


### PR DESCRIPTION
This PR implements `inner_node()` iterator for `PartialMmr` so that we can insert authentication paths from `PartialMmr` into a `MerkleStore`.
