### PR TITLE
Improvements to `PartialMmr::apply_delta()`

### DIFF
--- a/src/merkle/mmr/inorder.rs
+++ b/src/merkle/mmr/inorder.rs
@@ -16,15 +16,17 @@ pub struct InOrderIndex {
 }
 
 impl InOrderIndex {
-    /// Constructor for a new [InOrderIndex].
+    // CONSTRUCTORS
+    // --------------------------------------------------------------------------------------------
+
+    /// Returns a new [InOrderIndex] instantiated from the provided value.
     pub fn new(idx: NonZeroUsize) -> InOrderIndex {
         InOrderIndex { idx: idx.get() }
     }
 
-    /// Constructs an index from a leaf position.
+    /// Return a new [InOrderIndex] instantiated from the specified leaf position.
     ///
-    /// Panics:
-    ///
+    /// # Panics:
     /// If `leaf` is higher than or equal to `usize::MAX / 2`.
     pub fn from_leaf_pos(leaf: usize) -> InOrderIndex {
         // Convert the position from 0-indexed to 1-indexed, since the bit manipulation in this
@@ -33,11 +35,19 @@ impl InOrderIndex {
         InOrderIndex { idx: pos * 2 - 1 }
     }
 
+    // PUBLIC ACCESSORS
+    // --------------------------------------------------------------------------------------------
+
     /// True if the index is pointing at a leaf.
     ///
     /// Every odd number represents a leaf.
     pub fn is_leaf(&self) -> bool {
         self.idx & 1 == 1
+    }
+
+    /// Returns true if this note is a left child of its parent.
+    pub fn is_left_child(&self) -> bool {
+        self.parent().left_child() == *self
     }
 
     /// Returns the level of the index.
@@ -49,8 +59,7 @@ impl InOrderIndex {
 
     /// Returns the index of the left child.
     ///
-    /// Panics:
-    ///
+    /// # Panics:
     /// If the index corresponds to a leaf.
     pub fn left_child(&self) -> InOrderIndex {
         // The left child is itself a parent, with an index that splits its left/right subtrees. To
@@ -62,8 +71,7 @@ impl InOrderIndex {
 
     /// Returns the index of the right child.
     ///
-    /// Panics:
-    ///
+    /// # Panics:
     /// If the index corresponds to a leaf.
     pub fn right_child(&self) -> InOrderIndex {
         // To compute the index of the parent of the right subtree it is sufficient to add the size
@@ -96,6 +104,11 @@ impl InOrderIndex {
         } else {
             parent.right_child()
         }
+    }
+
+    /// Returns the inner value of this [InOrderIndex].
+    pub fn inner(&self) -> u64 {
+        self.idx as u64
     }
 }
 


### PR DESCRIPTION
This PR fixes a bug in `PartialMmr::apply_delta()` and adds tests to test this functionality more thoroughly. The bug was that authentication paths located in the left subtrees would not be extended when the trees would be mreged.

In addition to the above, this PR introduces a couple of small changes:

- `PartialMmr::apply_delta()` now returns a vector of nodes added to the Partial MMR's authentication node set as the result of the update.
- `PartialMmr::nodes()` method was added to return an iterator over all authentication nodes of the partial MMR.