### PR TITLE
refactor: remove sve feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,6 @@ default = ["std"]
 executable = ["dep:clap", "dep:rand_utils", "std"]
 serde = ["dep:serde", "serde?/alloc", "winter_math/serde"]
 std = ["blake3/std", "dep:cc", "dep:libc", "winter_crypto/std", "winter_math/std", "winter_utils/std"]
-sve = ["std"]
 
 [dependencies]
 blake3 = { version = "1.5", default-features = false }

--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@ RUSTFLAGS="-C target-feature=+avx2" cargo build --release
 ```
 
 ### SVE acceleration
-On platforms with [SVE](https://en.wikipedia.org/wiki/AArch64#Scalable_Vector_Extension_(SVE)) support, RPO and RPX hash function can be accelerated by using the vector processing unit. To enable SVE acceleration, the code needs to be compiled with the `sve` feature enabled. This feature has an effect only if the platform exposes `target-feature=sve` flag. On some platforms (e.g., Graviton 3), for this flag to be set, the compilation must be done in "native" mode. For example, to enable SVE acceleration on Graviton 3, we can execute the following:
+On platforms with [SVE](https://en.wikipedia.org/wiki/AArch64#Scalable_Vector_Extension_(SVE)) support, RPO and RPX hash function can be accelerated by using the vector processing unit. To enable SVE acceleration, the code needs to be compiled with the `sve` target feature enabled. For example:
 ```shell
-RUSTFLAGS="-C target-cpu=native" cargo build --release --features sve
+ RUSTFLAGS="-C target-feature=+sve" cargo build --release
 ```
 
 ## Testing

--- a/build.rs
+++ b/build.rs
@@ -2,7 +2,7 @@ fn main() {
     #[cfg(feature = "std")]
     compile_rpo_falcon();
 
-    #[cfg(all(target_feature = "sve", feature = "sve"))]
+    #[cfg(target_feature = "sve")]
     compile_arch_arm64_sve();
 }
 
@@ -34,7 +34,7 @@ fn compile_rpo_falcon() {
         .compile("rpo_falcon512");
 }
 
-#[cfg(all(target_feature = "sve", feature = "sve"))]
+#[cfg(target_feature = "sve")]
 fn compile_arch_arm64_sve() {
     const RPO_SVE_PATH: &str = "arch/arm64-sve/rpo";
 

--- a/src/hash/rescue/arch/mod.rs
+++ b/src/hash/rescue/arch/mod.rs
@@ -1,4 +1,4 @@
-#[cfg(all(target_feature = "sve", feature = "sve"))]
+#[cfg(target_feature = "sve")]
 pub mod optimized {
     use crate::hash::rescue::STATE_WIDTH;
     use crate::Felt;
@@ -78,7 +78,7 @@ pub mod optimized {
     }
 }
 
-#[cfg(not(any(target_feature = "avx2", all(target_feature = "sve", feature = "sve"))))]
+#[cfg(not(any(target_feature = "avx2", target_feature = "sve")))]
 pub mod optimized {
     use crate::hash::rescue::STATE_WIDTH;
     use crate::Felt;


### PR DESCRIPTION
This PR removes a dedicated `sve` feature because we can enable it via `target_feature` flag instead.
