### PR TITLE
Pad bytes with 10*0

### DIFF
--- a/src/hash/rescue/rpx/mod.rs
+++ b/src/hash/rescue/rpx/mod.rs
@@ -88,10 +88,8 @@ impl Hasher for Rpx256 {
         // `i` is not zero, then the chunks count wasn't enough to fill the state range, and an
         // additional permutation must be performed.
         let i = bytes.chunks(BINARY_CHUNK_SIZE).fold(0, |i, chunk| {
-            // the last element of the iteration may or may not be a full chunk. if it's not, then
-            // we need to pad the remainder bytes of the chunk with zeroes, separated by a `1`.
-            // this will avoid collisions at the bytes level.
-            if chunk.len() == BINARY_CHUNK_SIZE {
+            // we always pad `bytes` with a 1 followed by as many 0's to fill up `buf`.
+            if i != num_field_elem - 1 {
                 buf[..BINARY_CHUNK_SIZE].copy_from_slice(chunk);
             } else {
                 buf.fill(0);


### PR DESCRIPTION
## Describe your changes
The intention with the RPX new padding rule was to always pad the bytes with 10*0 but for some reason this wasn't included in the original PR. This one fixes that.

## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
