### PR TITLE
Re-export `SmtProof` and `SmtProofError`

### DIFF
--- a/src/merkle/mod.rs
+++ b/src/merkle/mod.rs
@@ -22,7 +22,10 @@ mod path;
 pub use path::{MerklePath, RootPath, ValuePath};
 
 mod smt;
-pub use smt::{LeafIndex, SimpleSmt, Smt, SmtLeaf, SMT_DEPTH, SMT_MAX_DEPTH, SMT_MIN_DEPTH};
+pub use smt::{
+    LeafIndex, SimpleSmt, Smt, SmtLeaf, SmtLeafError, SmtProof, SmtProofError, SMT_DEPTH,
+    SMT_MAX_DEPTH, SMT_MIN_DEPTH,
+};
 
 mod tiered_smt;
 pub use tiered_smt::{TieredSmt, TieredSmtProof, TieredSmtProofError};

--- a/src/merkle/smt/mod.rs
+++ b/src/merkle/smt/mod.rs
@@ -6,7 +6,7 @@ use crate::{
 use super::{EmptySubtreeRoots, MerkleError, MerklePath, NodeIndex, Vec};
 
 mod full;
-pub use full::{Smt, SmtLeaf, SmtLeafError, SMT_DEPTH};
+pub use full::{Smt, SmtLeaf, SmtLeafError, SmtProof, SmtProofError, SMT_DEPTH};
 
 mod simple;
 pub use simple::SimpleSmt;


### PR DESCRIPTION
Re-exports 2 types that were introduced in #270, and forgotten to be re-exported