### PR TITLE
chore: handle deprecations in winterfell 0.8.3 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,6 @@ serde = ["dep:serde", "serde?/alloc", "winter_math/serde"]
 std = [
     "blake3/std",
     "dep:cc",
-    "dep:libc",
     "winter_crypto/std",
     "winter_math/std",
     "winter_utils/std",
@@ -47,9 +46,10 @@ std = [
 [dependencies]
 blake3 = { version = "1.5", default-features = false }
 clap = { version = "4.5", features = ["derive"], optional = true }
-libc = { version = "0.2", default-features = false, optional = true }
 rand_utils = { version = "0.8", package = "winter-rand-utils", optional = true }
-serde = { version = "1.0", features = ["derive"], default-features = false, optional = true }
+serde = { version = "1.0", features = [
+    "derive",
+], default-features = false, optional = true }
 winter_crypto = { version = "0.8", package = "winter-crypto", default-features = false }
 winter_math = { version = "0.8", package = "winter-math", default-features = false }
 winter_utils = { version = "0.8", package = "winter-utils", default-features = false }

--- a/src/dsa/rpo_falcon512/ffi.rs
+++ b/src/dsa/rpo_falcon512/ffi.rs
@@ -1,4 +1,4 @@
-use libc::c_int;
+use core::ffi::c_int;
 
 // C IMPLEMENTATION INTERFACE
 // ================================================================================================
@@ -77,8 +77,11 @@ extern "C" {
     #[cfg(test)]
     pub fn rpo128_absorb(
         sc: *mut Rpo128Context,
-        data: *const ::std::os::raw::c_void,
-        len: libc::size_t,
+        data: *const core::ffi::c_void,
+        // TODO: When #![feature(c_size_t)] stabilizes, switch this to `core::ffi::size_t` to be
+        // more accurate. Currently, however, all Rust targets as of this writing are such that
+        // `core::ffi::size_t` and `usize` are the same size.
+        len: usize,
     );
 
     #[cfg(test)]
@@ -96,6 +99,7 @@ pub struct Rpo128Context {
 
 #[cfg(all(test, feature = "std"))]
 mod tests {
+    use alloc::vec::Vec;
     use rand_utils::{rand_array, rand_value, rand_vector};
 
     use super::*;

--- a/src/dsa/rpo_falcon512/keys.rs
+++ b/src/dsa/rpo_falcon512/keys.rs
@@ -1,8 +1,11 @@
-#[cfg(feature = "std")]
-use super::{ffi, NonceBytes, NONCE_LEN, PK_LEN, SIG_LEN, SK_LEN};
 use super::{
     ByteReader, ByteWriter, Deserializable, DeserializationError, FalconError, Polynomial,
     PublicKeyBytes, Rpo256, SecretKeyBytes, Serializable, Signature, Word,
+};
+#[cfg(feature = "std")]
+use {
+    super::{ffi, NonceBytes, NONCE_LEN, PK_LEN, SIG_LEN, SK_LEN},
+    alloc::vec::Vec,
 };
 
 // PUBLIC KEY

--- a/src/dsa/rpo_falcon512/polynomial.rs
+++ b/src/dsa/rpo_falcon512/polynomial.rs
@@ -1,7 +1,7 @@
+use alloc::vec::Vec;
 use core::ops::{Add, Mul, Sub};
 
 use super::{FalconError, Felt, LOG_N, MODULUS, MODULUS_MINUS_1_OVER_TWO, N, PK_LEN};
-use crate::utils::collections::*;
 
 // FALCON POLYNOMIAL
 // ================================================================================================

--- a/src/dsa/rpo_falcon512/signature.rs
+++ b/src/dsa/rpo_falcon512/signature.rs
@@ -1,3 +1,4 @@
+use alloc::string::ToString;
 use core::cell::OnceCell;
 
 use super::{
@@ -5,7 +6,6 @@ use super::{
     Polynomial, PublicKeyBytes, Rpo256, Serializable, SignatureBytes, Word, MODULUS, N,
     SIG_L2_BOUND, ZERO,
 };
-use crate::utils::string::*;
 
 // FALCON SIGNATURE
 // ================================================================================================
@@ -196,7 +196,7 @@ fn decode_nonce(nonce: &NonceBytes) -> NonceElements {
 
 #[cfg(all(test, feature = "std"))]
 mod tests {
-    use libc::c_void;
+    use core::ffi::c_void;
     use rand_utils::rand_vector;
 
     use super::{
@@ -236,7 +236,10 @@ mod tests {
     fn test_hash_to_point() {
         // Create a random message and transform it into a u8 vector
         let msg_felts: Word = rand_vector::<Felt>(4).try_into().unwrap();
-        let msg_bytes = msg_felts.iter().flat_map(|e| e.as_int().to_le_bytes()).collect::<Vec<_>>();
+        let msg_bytes = msg_felts
+            .iter()
+            .flat_map(|e| e.as_int().to_le_bytes())
+            .collect::<alloc::vec::Vec<_>>();
 
         // Create a nonce i.e. a [u8; 40] array and pack into a [Felt; 8] array.
         let nonce: [u8; 40] = rand_vector::<u8>(40).try_into().unwrap();

--- a/src/hash/blake/mod.rs
+++ b/src/hash/blake/mod.rs
@@ -1,3 +1,4 @@
+use alloc::string::String;
 use core::{
     mem::{size_of, transmute, transmute_copy},
     ops::Deref,
@@ -6,7 +7,7 @@ use core::{
 
 use super::{Digest, ElementHasher, Felt, FieldElement, Hasher};
 use crate::utils::{
-    bytes_to_hex_string, hex_to_bytes, string::*, ByteReader, ByteWriter, Deserializable,
+    bytes_to_hex_string, hex_to_bytes, ByteReader, ByteWriter, Deserializable,
     DeserializationError, HexParseError, Serializable,
 };
 

--- a/src/hash/blake/tests.rs
+++ b/src/hash/blake/tests.rs
@@ -2,7 +2,7 @@ use proptest::prelude::*;
 use rand_utils::rand_vector;
 
 use super::*;
-use crate::utils::collections::*;
+use alloc::vec::Vec;
 
 #[test]
 fn blake3_hash_elements() {

--- a/src/hash/rescue/rpo/digest.rs
+++ b/src/hash/rescue/rpo/digest.rs
@@ -1,10 +1,11 @@
+use alloc::string::String;
 use core::{cmp::Ordering, fmt::Display, ops::Deref};
 
 use super::{Digest, Felt, StarkField, DIGEST_BYTES, DIGEST_SIZE, ZERO};
 use crate::{
     rand::Randomizable,
     utils::{
-        bytes_to_hex_string, hex_to_bytes, string::*, ByteReader, ByteWriter, Deserializable,
+        bytes_to_hex_string, hex_to_bytes, ByteReader, ByteWriter, Deserializable,
         DeserializationError, HexParseError, Serializable,
     },
 };
@@ -323,10 +324,11 @@ impl IntoIterator for RpoDigest {
 
 #[cfg(test)]
 mod tests {
+    use alloc::string::String;
     use rand_utils::rand_value;
 
     use super::{Deserializable, Felt, RpoDigest, Serializable, DIGEST_BYTES, DIGEST_SIZE};
-    use crate::utils::{string::*, SliceReader};
+    use crate::utils::SliceReader;
 
     #[test]
     fn digest_serialization() {

--- a/src/hash/rescue/rpo/tests.rs
+++ b/src/hash/rescue/rpo/tests.rs
@@ -5,7 +5,8 @@ use super::{
     super::{apply_inv_sbox, apply_sbox, ALPHA, INV_ALPHA},
     Felt, FieldElement, Hasher, Rpo256, RpoDigest, StarkField, ONE, STATE_WIDTH, ZERO,
 };
-use crate::{utils::collections::*, Word};
+use crate::Word;
+use alloc::{collections::BTreeSet, vec::Vec};
 
 #[test]
 fn test_sbox() {

--- a/src/hash/rescue/rpx/digest.rs
+++ b/src/hash/rescue/rpx/digest.rs
@@ -1,10 +1,11 @@
+use alloc::string::String;
 use core::{cmp::Ordering, fmt::Display, ops::Deref};
 
 use super::{Digest, Felt, StarkField, DIGEST_BYTES, DIGEST_SIZE, ZERO};
 use crate::{
     rand::Randomizable,
     utils::{
-        bytes_to_hex_string, hex_to_bytes, string::*, ByteReader, ByteWriter, Deserializable,
+        bytes_to_hex_string, hex_to_bytes, ByteReader, ByteWriter, Deserializable,
         DeserializationError, HexParseError, Serializable,
     },
 };
@@ -312,10 +313,11 @@ impl Deserializable for RpxDigest {
 
 #[cfg(test)]
 mod tests {
+    use alloc::string::String;
     use rand_utils::rand_value;
 
     use super::{Deserializable, Felt, RpxDigest, Serializable, DIGEST_BYTES, DIGEST_SIZE};
-    use crate::utils::{string::*, SliceReader};
+    use crate::utils::SliceReader;
 
     #[test]
     fn digest_serialization() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,10 @@
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 
-#[cfg(not(feature = "std"))]
-#[cfg_attr(test, macro_use)]
+#[macro_use]
 extern crate alloc;
+
+#[cfg(feature = "std")]
+extern crate std;
 
 pub mod dsa;
 pub mod hash;

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,7 +74,7 @@ pub fn insertion(tree: &mut Smt, size: u64) -> Result<(), MerkleError> {
     println!(
         "An average insertion time measured by 20 inserts into a SMT with {} key-value pairs is {:.3} milliseconds\n",
         size,
-        // calculate the average by dividing by 20 and convert to milliseconds by multiplying by 
+        // calculate the average by dividing by 20 and convert to milliseconds by multiplying by
         // 1000. As a result, we can only multiply by 50
         insertion_times.iter().sum::<f32>() * 50f32,
     );

--- a/src/merkle/error.rs
+++ b/src/merkle/error.rs
@@ -1,7 +1,7 @@
+use alloc::vec::Vec;
 use core::fmt;
 
 use super::{smt::SmtLeafError, MerklePath, NodeIndex, RpoDigest};
-use crate::utils::collections::*;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum MerkleError {

--- a/src/merkle/merkle_tree.rs
+++ b/src/merkle/merkle_tree.rs
@@ -1,9 +1,10 @@
+use alloc::{string::String, vec::Vec};
 use core::{fmt, ops::Deref, slice};
 
 use winter_math::log2;
 
 use super::{InnerNodeInfo, MerkleError, MerklePath, NodeIndex, Rpo256, RpoDigest, Word};
-use crate::utils::{collections::*, string::*, uninit_vector, word_to_hex};
+use crate::utils::{uninit_vector, word_to_hex};
 
 // MERKLE TREE
 // ================================================================================================

--- a/src/merkle/mmr/delta.rs
+++ b/src/merkle/mmr/delta.rs
@@ -1,5 +1,5 @@
 use super::super::RpoDigest;
-use crate::utils::collections::*;
+use alloc::vec::Vec;
 
 /// Container for the update data of a [super::PartialMmr]
 #[derive(Debug)]

--- a/src/merkle/mmr/full.rs
+++ b/src/merkle/mmr/full.rs
@@ -16,7 +16,7 @@ use super::{
     leaf_to_corresponding_tree, nodes_in_forest, MmrDelta, MmrError, MmrPeaks, MmrProof, Rpo256,
     RpoDigest,
 };
-use crate::utils::collections::*;
+use alloc::vec::Vec;
 
 // MMR
 // ===============================================================================================

--- a/src/merkle/mmr/partial.rs
+++ b/src/merkle/mmr/partial.rs
@@ -1,10 +1,11 @@
 use super::{MmrDelta, MmrProof, Rpo256, RpoDigest};
-use crate::{
-    merkle::{
-        mmr::{leaf_to_corresponding_tree, nodes_in_forest},
-        InOrderIndex, InnerNodeInfo, MerklePath, MmrError, MmrPeaks,
-    },
-    utils::{collections::*, vec},
+use crate::merkle::{
+    mmr::{leaf_to_corresponding_tree, nodes_in_forest},
+    InOrderIndex, InnerNodeInfo, MerklePath, MmrError, MmrPeaks,
+};
+use alloc::{
+    collections::{BTreeMap, BTreeSet},
+    vec::Vec,
 };
 
 // TYPE ALIASES
@@ -616,10 +617,8 @@ mod tests {
         forest_to_rightmost_index, forest_to_root_index, InOrderIndex, MmrPeaks, PartialMmr,
         RpoDigest,
     };
-    use crate::{
-        merkle::{int_to_node, MerkleStore, Mmr, NodeIndex},
-        utils::collections::*,
-    };
+    use crate::merkle::{int_to_node, MerkleStore, Mmr, NodeIndex};
+    use alloc::{collections::BTreeSet, vec::Vec};
 
     const LEAVES: [RpoDigest; 7] = [
         int_to_node(0),

--- a/src/merkle/mmr/peaks.rs
+++ b/src/merkle/mmr/peaks.rs
@@ -1,5 +1,5 @@
 use super::{super::ZERO, Felt, MmrError, MmrProof, Rpo256, RpoDigest, Word};
-use crate::utils::collections::*;
+use alloc::vec::Vec;
 
 // MMR PEAKS
 // ================================================================================================

--- a/src/merkle/mmr/tests.rs
+++ b/src/merkle/mmr/tests.rs
@@ -6,9 +6,9 @@ use super::{
 };
 use crate::{
     merkle::{int_to_node, InOrderIndex, MerklePath, MerkleTree, MmrProof, NodeIndex},
-    utils::collections::*,
     Felt, Word,
 };
+use alloc::vec::Vec;
 
 #[test]
 fn test_position_equal_or_higher_than_leafs_is_never_contained() {

--- a/src/merkle/mod.rs
+++ b/src/merkle/mod.rs
@@ -45,9 +45,6 @@ pub use error::MerkleError;
 // ================================================================================================
 
 #[cfg(test)]
-use crate::utils::collections::*;
-
-#[cfg(test)]
 const fn int_to_node(value: u64) -> RpoDigest {
     RpoDigest::new([Felt::new(value), ZERO, ZERO, ZERO])
 }
@@ -58,6 +55,6 @@ const fn int_to_leaf(value: u64) -> Word {
 }
 
 #[cfg(test)]
-fn digests_to_words(digests: &[RpoDigest]) -> Vec<Word> {
+fn digests_to_words(digests: &[RpoDigest]) -> alloc::vec::Vec<Word> {
     digests.iter().map(|d| d.into()).collect()
 }

--- a/src/merkle/partial_mt/mod.rs
+++ b/src/merkle/partial_mt/mod.rs
@@ -1,3 +1,8 @@
+use alloc::{
+    collections::{BTreeMap, BTreeSet},
+    string::String,
+    vec::Vec,
+};
 use core::fmt;
 
 use super::{
@@ -5,8 +10,7 @@ use super::{
     EMPTY_WORD,
 };
 use crate::utils::{
-    collections::*, format, string::*, vec, word_to_hex, ByteReader, ByteWriter, Deserializable,
-    DeserializationError, Serializable,
+    word_to_hex, ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable,
 };
 
 #[cfg(test)]

--- a/src/merkle/partial_mt/tests.rs
+++ b/src/merkle/partial_mt/tests.rs
@@ -5,7 +5,7 @@ use super::{
     },
     Deserializable, InnerNodeInfo, RpoDigest, Serializable, ValuePath,
 };
-use crate::utils::collections::*;
+use alloc::{collections::BTreeMap, vec::Vec};
 
 // TEST DATA
 // ================================================================================================

--- a/src/merkle/path.rs
+++ b/src/merkle/path.rs
@@ -1,8 +1,9 @@
+use alloc::vec::Vec;
 use core::ops::{Deref, DerefMut};
 
 use super::{InnerNodeInfo, MerkleError, NodeIndex, Rpo256, RpoDigest};
 use crate::{
-    utils::{collections::*, ByteReader, Deserializable, DeserializationError, Serializable},
+    utils::{ByteReader, Deserializable, DeserializationError, Serializable},
     Word,
 };
 
@@ -128,7 +129,7 @@ impl FromIterator<RpoDigest> for MerklePath {
 
 impl IntoIterator for MerklePath {
     type Item = RpoDigest;
-    type IntoIter = vec::IntoIter<RpoDigest>;
+    type IntoIter = alloc::vec::IntoIter<RpoDigest>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.nodes.into_iter()

--- a/src/merkle/smt/full/error.rs
+++ b/src/merkle/smt/full/error.rs
@@ -1,9 +1,9 @@
+use alloc::vec::Vec;
 use core::fmt;
 
 use crate::{
     hash::rpo::RpoDigest,
     merkle::{LeafIndex, SMT_DEPTH},
-    utils::collections::*,
     Word,
 };
 

--- a/src/merkle/smt/full/leaf.rs
+++ b/src/merkle/smt/full/leaf.rs
@@ -1,10 +1,8 @@
+use alloc::{string::ToString, vec::Vec};
 use core::cmp::Ordering;
 
 use super::{Felt, LeafIndex, Rpo256, RpoDigest, SmtLeafError, Word, EMPTY_WORD, SMT_DEPTH};
-use crate::utils::{
-    collections::*, string::*, vec, ByteReader, ByteWriter, Deserializable, DeserializationError,
-    Serializable,
-};
+use crate::utils::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]

--- a/src/merkle/smt/full/mod.rs
+++ b/src/merkle/smt/full/mod.rs
@@ -2,7 +2,7 @@ use super::{
     EmptySubtreeRoots, Felt, InnerNode, InnerNodeInfo, LeafIndex, MerkleError, MerklePath,
     NodeIndex, Rpo256, RpoDigest, SparseMerkleTree, Word, EMPTY_WORD,
 };
-use crate::utils::collections::*;
+use alloc::collections::{BTreeMap, BTreeSet};
 
 mod error;
 pub use error::{SmtLeafError, SmtProofError};

--- a/src/merkle/smt/full/proof.rs
+++ b/src/merkle/smt/full/proof.rs
@@ -1,7 +1,6 @@
 use super::{MerklePath, RpoDigest, SmtLeaf, SmtProofError, Word, SMT_DEPTH};
-use crate::utils::{
-    string::*, ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable,
-};
+use crate::utils::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable};
+use alloc::string::ToString;
 
 /// A proof which can be used to assert membership (or non-membership) of key-value pairs in a
 /// [`super::Smt`].

--- a/src/merkle/smt/full/tests.rs
+++ b/src/merkle/smt/full/tests.rs
@@ -1,9 +1,10 @@
 use super::{Felt, LeafIndex, NodeIndex, Rpo256, RpoDigest, Smt, SmtLeaf, EMPTY_WORD, SMT_DEPTH};
 use crate::{
     merkle::{EmptySubtreeRoots, MerkleStore},
-    utils::{collections::*, Deserializable, Serializable},
+    utils::{Deserializable, Serializable},
     Word, ONE, WORD_SIZE,
 };
+use alloc::vec::Vec;
 
 // SMT
 // --------------------------------------------------------------------------------------------

--- a/src/merkle/smt/mod.rs
+++ b/src/merkle/smt/mod.rs
@@ -1,9 +1,9 @@
 use super::{EmptySubtreeRoots, InnerNodeInfo, MerkleError, MerklePath, NodeIndex};
 use crate::{
     hash::rpo::{Rpo256, RpoDigest},
-    utils::collections::*,
     Felt, Word, EMPTY_WORD,
 };
+use alloc::vec::Vec;
 
 mod full;
 pub use full::{Smt, SmtLeaf, SmtLeafError, SmtProof, SmtProofError, SMT_DEPTH};

--- a/src/merkle/smt/simple/mod.rs
+++ b/src/merkle/smt/simple/mod.rs
@@ -3,7 +3,7 @@ use super::{
     MerklePath, NodeIndex, RpoDigest, SparseMerkleTree, Word, EMPTY_WORD, SMT_MAX_DEPTH,
     SMT_MIN_DEPTH,
 };
-use crate::utils::collections::*;
+use alloc::collections::{BTreeMap, BTreeSet};
 
 #[cfg(test)]
 mod tests;

--- a/src/merkle/smt/simple/tests.rs
+++ b/src/merkle/smt/simple/tests.rs
@@ -8,9 +8,9 @@ use crate::{
         digests_to_words, int_to_leaf, int_to_node, smt::SparseMerkleTree, EmptySubtreeRoots,
         InnerNodeInfo, LeafIndex, MerkleTree,
     },
-    utils::collections::*,
     Word, EMPTY_WORD,
 };
+use alloc::vec::Vec;
 
 // TEST DATA
 // ================================================================================================

--- a/src/merkle/store/mod.rs
+++ b/src/merkle/store/mod.rs
@@ -1,3 +1,4 @@
+use alloc::{collections::BTreeMap, vec::Vec};
 use core::borrow::Borrow;
 
 use super::{
@@ -5,7 +6,8 @@ use super::{
     PartialMerkleTree, RootPath, Rpo256, RpoDigest, SimpleSmt, Smt, ValuePath,
 };
 use crate::utils::{
-    collections::*, ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable,
+    collections::{KvMap, RecordingMap},
+    ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable,
 };
 
 #[cfg(test)]

--- a/src/merkle/store/tests.rs
+++ b/src/merkle/store/tests.rs
@@ -14,6 +14,7 @@ use crate::{
 #[cfg(feature = "std")]
 use {
     super::{Deserializable, Serializable},
+    alloc::boxed::Box,
     std::error::Error,
 };
 

--- a/src/rand/rpo.rs
+++ b/src/rand/rpo.rs
@@ -1,11 +1,9 @@
 use super::{Felt, FeltRng, FieldElement, RandomCoin, RandomCoinError, Word, ZERO};
 use crate::{
     hash::rpo::{Rpo256, RpoDigest},
-    utils::{
-        collections::*, string::*, vec, ByteReader, ByteWriter, Deserializable,
-        DeserializationError, Serializable,
-    },
+    utils::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable},
 };
+use alloc::{string::ToString, vec::Vec};
 
 // CONSTANTS
 // ================================================================================================

--- a/src/utils/kv_map.rs
+++ b/src/utils/kv_map.rs
@@ -1,9 +1,8 @@
-use core::cell::RefCell;
-
-use super::{
-    boxed::*,
-    collections::{btree_map::*, *},
+use alloc::{
+    boxed::Box,
+    collections::{BTreeMap, BTreeSet},
 };
+use core::cell::RefCell;
 
 // KEY-VALUE MAP TRAIT
 // ================================================================================================
@@ -202,7 +201,7 @@ impl<K: Clone + Ord, V: Clone> FromIterator<(K, V)> for RecordingMap<K, V> {
 
 impl<K: Clone + Ord, V: Clone> IntoIterator for RecordingMap<K, V> {
     type Item = (K, V);
-    type IntoIter = IntoIter<K, V>;
+    type IntoIter = alloc::collections::btree_map::IntoIter<K, V>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.data.into_iter()

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,15 +1,9 @@
 //! Utilities used in this crate which can also be generally useful downstream.
 
+use alloc::string::String;
 use core::fmt::{self, Display, Write};
 
-#[cfg(feature = "std")]
-pub use std::{format, vec};
-
-#[cfg(not(feature = "std"))]
-pub use alloc::{format, vec};
-
 use super::Word;
-use crate::utils::string::*;
 
 mod kv_map;
 
@@ -21,8 +15,6 @@ pub use winter_utils::{
 };
 
 pub mod collections {
-    pub use winter_utils::collections::*;
-
     pub use super::kv_map::*;
 }
 
@@ -102,12 +94,11 @@ pub fn hex_to_bytes<const N: usize>(value: &str) -> Result<[u8; N], HexParseErro
     });
 
     let mut decoded = [0u8; N];
-    #[allow(clippy::needless_range_loop)]
-    for pos in 0..N {
+    for byte in decoded.iter_mut() {
         // These `unwrap` calls are okay because the length was checked above
         let high: u8 = data.next().unwrap()?;
         let low: u8 = data.next().unwrap()?;
-        decoded[pos] = (high << 4) + low;
+        *byte = (high << 4) + low;
     }
 
     Ok(decoded)


### PR DESCRIPTION
This PR handles the deprecations in the winterfell 0.8.3 release, and makes the same kind of changes made in facebook/winterfell#262 and in the corresponding commits of 0xPolygonMiden/miden-vm#1277 related to the upgrade.

I'm opening this against `main` and not next since I believe we'll want to do a patch release for this, but I can also open this against `next`, I have both staged locally, just let me know.

NOTE: I couldn't create a branch in this repo, so had to open the PR from a fork, may want to add me as a contributor, but I don't know how often I'll be pushing code here, so I'm fine working off a fork.
