### PR TITLE
fix: restore re-exports but using alloc

### DIFF
--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,6 +1,7 @@
 //! Utilities used in this crate which can also be generally useful downstream.
 
 use alloc::string::String;
+pub use alloc::{format, vec};
 use core::fmt::{self, Display, Write};
 
 use super::Word;
@@ -16,6 +17,10 @@ pub use winter_utils::{
 
 pub mod collections {
     pub use super::kv_map::*;
+    pub use alloc::{
+        collections::{btree_map, BTreeMap, BTreeSet},
+        vec::{self, Vec},
+    };
 }
 
 // UTILITY FUNCTIONS


### PR DESCRIPTION
## Describe your changes

On #290, with part of those changes we removed the re-exports of `Vec`, `BTreeMap`, `BTreeSet`, among others which breaks compilation of crates like `miden-vm`. Here we restore the re-exports (but using `alloc`), and in a future PR we should remove those as well (maybe for 0.9?)

Also, I tried marking those re-exports as deprecated but I couldn't make them appear (might be related to [this issue](https://github.com/rust-lang/rust/issues/30827))

Also: should I change the crate's version for the release in this PR or in a separate one?

## Checklist before requesting a review
- [X] Repo forked and branch created from `next` according to naming convention.
- [X] Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- [X] Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
