### PR TITLE
fix: re-add unintentionally removed re-exported liballoc macros

### DIFF
--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -16,6 +16,7 @@ pub use winter_utils::{
 
 pub mod collections {
     pub use super::kv_map::*;
+    pub use winter_utils::collections::*;
 }
 
 // UTILITY FUNCTIONS


### PR DESCRIPTION
This has to be merged after facebook/winterfell#263.

With the changes in that PR we unintentionally removed the `vec` and `format` macros from the `miden-crypto` public API.