### PR TITLE
Add `RngCore` supertrait for `FeltRng`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * [BREAKING] Removed deprecated re-exports from liballoc/libstd (#290).
 * [BREAKING] Refactored RpoFalcon512 signature to work with pure Rust (#285).
+* Added `RngCore` as supertrait for `FeltRng` (#299).
 
 # 0.8.4 (2024-03-17)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -518,6 +518,7 @@ dependencies = [
  "num-complex",
  "proptest",
  "rand",
+ "rand_chacha",
  "rand_core",
  "seq-macro",
  "serde",
@@ -755,9 +756,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.3"
+version = "1.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
+checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
 dependencies = [
  "aho-corasick",
  "memchr",

--- a/src/rand/mod.rs
+++ b/src/rand/mod.rs
@@ -1,5 +1,6 @@
 //! Pseudo-random element generation.
 
+use rand::RngCore;
 pub use winter_crypto::{DefaultRandomCoin as WinterRandomCoin, RandomCoin, RandomCoinError};
 pub use winter_utils::Randomizable;
 
@@ -11,7 +12,7 @@ pub use rpo::RpoRandomCoin;
 /// Pseudo-random element generator.
 ///
 /// An instance can be used to draw, uniformly at random, base field elements as well as [Word]s.
-pub trait FeltRng {
+pub trait FeltRng: RngCore {
     /// Draw, uniformly at random, a base field element.
     fn draw_element(&mut self) -> Felt;
 

--- a/src/rand/rpo.rs
+++ b/src/rand/rpo.rs
@@ -1,10 +1,9 @@
-use super::{Felt, FeltRng, FieldElement, RandomCoin, RandomCoinError, Word, ZERO};
+use super::{Felt, FeltRng, FieldElement, RandomCoin, RandomCoinError, RngCore, Word, ZERO};
 use crate::{
     hash::rpo::{Rpo256, RpoDigest},
     utils::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable},
 };
 use alloc::{string::ToString, vec::Vec};
-use rand::RngCore;
 use rand_core::impls;
 
 // CONSTANTS
@@ -22,9 +21,9 @@ const HALF_RATE_WIDTH: usize = (Rpo256::RATE_RANGE.end - Rpo256::RATE_RANGE.star
 ///
 /// The simplification is related to the following facts:
 /// 1. A call to the reseed method implies one and only one call to the permutation function.
-///  This is possible because in our case we never reseed with more than 4 field elements.
+///    This is possible because in our case we never reseed with more than 4 field elements.
 /// 2. As a result of the previous point, we don't make use of an input buffer to accumulate seed
-///  material.
+///    material.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct RpoRandomCoin {
     state: [Felt; STATE_WIDTH],
@@ -61,6 +60,11 @@ impl RpoRandomCoin {
     /// Returns components of this random coin.
     pub fn into_parts(self) -> ([Felt; STATE_WIDTH], usize) {
         (self.state, self.current)
+    }
+
+    /// Fills `dest` with random data.
+    pub fn fill_bytes(&mut self, dest: &mut [u8]) {
+        <Self as RngCore>::fill_bytes(self, dest)
     }
 
     fn draw_basefield(&mut self) -> Felt {


### PR DESCRIPTION
This PR adds `RngCore` as a supertrait for `FeltRng`. This provides an easy way to fill a slice with random bytes for anything that implements `FeltRng`.