### PR TITLE
Added leaf count to `SimpleSmt`

### DIFF
--- a/src/merkle/smt/simple/mod.rs
+++ b/src/merkle/smt/simple/mod.rs
@@ -152,6 +152,11 @@ impl<const DEPTH: u8> SimpleSmt<DEPTH> {
         <Self as SparseMerkleTree<DEPTH>>::open(self, key)
     }
 
+    /// Returns a count of non-empty leaves.
+    pub fn leaf_count(&self) -> usize {
+        self.leaves.len()
+    }
+
     // ITERATORS
     // --------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
Implemented leaf count to `SimpleSmt`. It's needed for serialization of the notes tree.