### PR TITLE
hex: `hex_to_bytes` can be used for data besides RpoDigests

### DIFF
--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -58,13 +58,13 @@ impl Display for HexParseError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             HexParseError::InvalidLength { expected, actual } => {
-                write!(f, "Hex encoded RpoDigest must have length 66, including the 0x prefix. expected {expected} got {actual}")
+                write!(f, "Expected hex data to have length {expected}, including the 0x prefix. Got {actual}")
             }
             HexParseError::MissingPrefix => {
-                write!(f, "Hex encoded RpoDigest must start with 0x prefix")
+                write!(f, "Hex encoded data must start with 0x prefix")
             }
             HexParseError::InvalidChar => {
-                write!(f, "Hex encoded RpoDigest must contain characters [a-zA-Z0-9]")
+                write!(f, "Hex encoded data must contain characters [a-zA-Z0-9]")
             }
             HexParseError::OutOfRange => {
                 write!(f, "Hex encoded values of an RpoDigest must be inside the field modulus")


### PR DESCRIPTION
## Describe your changes

The utility `hex_to_bytes` is also used to decode [the `init_seed`](https://github.com/0xPolygonMiden/miden-node/blob/c4747bb81a8f6037dd634c165958b67ecab9564e/bin/node/src/commands/genesis/mod.rs#L123-L124) in the client. The current error message is confusing when the length of the `init_seed` is incorrect.

## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
