### PR TITLE
towards #222: implement transactional Smt insertion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - [BREAKING]: renamed `Mmr::open()` into `Mmr::open_at()` and `Mmr::peaks()` into `Mmr::peaks_at()` (#234).
 - Added `Mmr::open()` and `Mmr::peaks()` which rely on `Mmr::open_at()` and `Mmr::peaks()` respectively (#234).
 - Standardised CI and Makefile across Miden repos (#323).
+- Added `Smt::compute_mutations()` and `Smt::apply_mutations()` for validation-checked insertions (#327).
 
 ## 0.10.0 (2024-08-06)
 

--- a/src/merkle/empty_roots.rs
+++ b/src/merkle/empty_roots.rs
@@ -1,6 +1,6 @@
 use core::slice;
 
-use super::{Felt, RpoDigest, EMPTY_WORD};
+use super::{smt::InnerNode, Felt, RpoDigest, EMPTY_WORD};
 
 // EMPTY NODES SUBTREES
 // ================================================================================================
@@ -24,6 +24,17 @@ impl EmptySubtreeRoots {
         assert!(node_depth <= tree_depth);
         let pos = 255 - tree_depth + node_depth;
         &EMPTY_SUBTREES[pos as usize]
+    }
+
+    /// Returns a sparse Merkle tree [`InnerNode`] with two empty children.
+    ///
+    /// # Note
+    /// `node_depth` is the depth of the **parent** to have empty children. That is, `node_depth`
+    /// and the depth of the returned [`InnerNode`] are the same, and thus the empty hashes are for
+    /// subtrees of depth `node_depth + 1`.
+    pub(crate) const fn get_inner_node(tree_depth: u8, node_depth: u8) -> InnerNode {
+        let &child = Self::entry(tree_depth, node_depth + 1);
+        InnerNode { left: child, right: child }
     }
 }
 

--- a/src/merkle/mod.rs
+++ b/src/merkle/mod.rs
@@ -22,8 +22,8 @@ pub use path::{MerklePath, RootPath, ValuePath};
 
 mod smt;
 pub use smt::{
-    LeafIndex, SimpleSmt, Smt, SmtLeaf, SmtLeafError, SmtProof, SmtProofError, SMT_DEPTH,
-    SMT_MAX_DEPTH, SMT_MIN_DEPTH,
+    LeafIndex, MutationSet, SimpleSmt, Smt, SmtLeaf, SmtLeafError, SmtProof, SmtProofError,
+    SMT_DEPTH, SMT_MAX_DEPTH, SMT_MIN_DEPTH,
 };
 
 mod mmr;

--- a/src/merkle/smt/full/leaf.rs
+++ b/src/merkle/smt/full/leaf.rs
@@ -350,7 +350,7 @@ impl Deserializable for SmtLeaf {
 // ================================================================================================
 
 /// Converts a key-value tuple to an iterator of `Felt`s
-fn kv_to_elements((key, value): (RpoDigest, Word)) -> impl Iterator<Item = Felt> {
+pub(crate) fn kv_to_elements((key, value): (RpoDigest, Word)) -> impl Iterator<Item = Felt> {
     let key_elements = key.into_iter();
     let value_elements = value.into_iter();
 
@@ -359,7 +359,7 @@ fn kv_to_elements((key, value): (RpoDigest, Word)) -> impl Iterator<Item = Felt>
 
 /// Compares two keys, compared element-by-element using their integer representations starting with
 /// the most significant element.
-fn cmp_keys(key_1: RpoDigest, key_2: RpoDigest) -> Ordering {
+pub(crate) fn cmp_keys(key_1: RpoDigest, key_2: RpoDigest) -> Ordering {
     for (v1, v2) in key_1.iter().zip(key_2.iter()).rev() {
         let v1 = v1.as_int();
         let v2 = v2.as_int();

--- a/src/merkle/smt/full/mod.rs
+++ b/src/merkle/smt/full/mod.rs
@@ -121,12 +121,7 @@ impl Smt {
 
     /// Returns the value associated with `key`
     pub fn get_value(&self, key: &RpoDigest) -> Word {
-        let leaf_pos = LeafIndex::<SMT_DEPTH>::from(*key).value();
-
-        match self.leaves.get(&leaf_pos) {
-            Some(leaf) => leaf.get_value(key).unwrap_or_default(),
-            None => EMPTY_WORD,
-        }
+        <Self as SparseMerkleTree<SMT_DEPTH>>::get_value(self, key)
     }
 
     /// Returns an opening of the leaf associated with `key`. Conceptually, an opening is a Merkle
@@ -247,6 +242,15 @@ impl SparseMerkleTree<SMT_DEPTH> for Smt {
             self.perform_insert(key, value)
         } else {
             self.perform_remove(key)
+        }
+    }
+
+    fn get_value(&self, key: &Self::Key) -> Self::Value {
+        let leaf_pos = LeafIndex::<SMT_DEPTH>::from(*key).value();
+
+        match self.leaves.get(&leaf_pos) {
+            Some(leaf) => leaf.get_value(key).unwrap_or_default(),
+            None => EMPTY_WORD,
         }
     }
 

--- a/src/merkle/smt/full/mod.rs
+++ b/src/merkle/smt/full/mod.rs
@@ -263,6 +263,28 @@ impl SparseMerkleTree<SMT_DEPTH> for Smt {
         leaf.hash()
     }
 
+    fn construct_prospective_leaf(
+        &self,
+        mut existing_leaf: SmtLeaf,
+        key: &RpoDigest,
+        value: &Word,
+    ) -> SmtLeaf {
+        debug_assert_eq!(existing_leaf.index(), Self::key_to_leaf_index(key));
+
+        match existing_leaf {
+            SmtLeaf::Empty(_) => SmtLeaf::new_single(*key, *value),
+            _ => {
+                if *value != EMPTY_WORD {
+                    existing_leaf.insert(*key, *value);
+                } else {
+                    existing_leaf.remove(*key);
+                }
+
+                existing_leaf
+            },
+        }
+    }
+
     fn key_to_leaf_index(key: &RpoDigest) -> LeafIndex<SMT_DEPTH> {
         let most_significant_felt = key[3];
         LeafIndex::new_max_depth(most_significant_felt.as_int())

--- a/src/merkle/smt/full/mod.rs
+++ b/src/merkle/smt/full/mod.rs
@@ -262,11 +262,10 @@ impl SparseMerkleTree<SMT_DEPTH> for Smt {
     }
 
     fn get_inner_node(&self, index: NodeIndex) -> InnerNode {
-        self.inner_nodes.get(&index).cloned().unwrap_or_else(|| {
-            let node = EmptySubtreeRoots::entry(SMT_DEPTH, index.depth() + 1);
-
-            InnerNode { left: *node, right: *node }
-        })
+        self.inner_nodes
+            .get(&index)
+            .cloned()
+            .unwrap_or_else(|| EmptySubtreeRoots::get_inner_node(SMT_DEPTH, index.depth()))
     }
 
     fn insert_inner_node(&mut self, index: NodeIndex, inner_node: InnerNode) {

--- a/src/merkle/smt/mod.rs
+++ b/src/merkle/smt/mod.rs
@@ -167,6 +167,24 @@ pub(crate) trait SparseMerkleTree<const DEPTH: u8> {
     /// Returns the hash of a leaf
     fn hash_leaf(leaf: &Self::Leaf) -> RpoDigest;
 
+    /// Returns what a leaf would look like if a key-value pair were inserted into the tree, without
+    /// mutating the tree itself. The existing leaf can be empty.
+    ///
+    /// To get a prospective leaf based on the current state of the tree, use `self.get_leaf(key)`
+    /// as the argument for `existing_leaf`. The return value from this function can be chained back
+    /// into this function as the first argument to continue making prospective changes.
+    ///
+    /// # Invariants
+    /// Because this method is for a prospective key-value insertion into a specific leaf,
+    /// `existing_leaf` must have the same leaf index as `key` (as determined by
+    /// [`SparseMerkleTree::key_to_leaf_index()`]), or the result will be meaningless.
+    fn construct_prospective_leaf(
+        &self,
+        existing_leaf: Self::Leaf,
+        key: &Self::Key,
+        value: &Self::Value,
+    ) -> Self::Leaf;
+
     /// Maps a key to a leaf index
     fn key_to_leaf_index(key: &Self::Key) -> LeafIndex<DEPTH>;
 

--- a/src/merkle/smt/mod.rs
+++ b/src/merkle/smt/mod.rs
@@ -161,6 +161,10 @@ pub(crate) trait SparseMerkleTree<const DEPTH: u8> {
     /// Inserts a leaf node, and returns the value at the key if already exists
     fn insert_value(&mut self, key: Self::Key, value: Self::Value) -> Option<Self::Value>;
 
+    /// Returns the value at the specified key. Recall that by definition, any key that hasn't been
+    /// updated is associated with [`Self::EMPTY_VALUE`].
+    fn get_value(&self, key: &Self::Key) -> Self::Value;
+
     /// Returns the leaf at the specified index.
     fn get_leaf(&self, key: &Self::Key) -> Self::Leaf;
 

--- a/src/merkle/smt/mod.rs
+++ b/src/merkle/smt/mod.rs
@@ -199,10 +199,7 @@ pub(crate) trait SparseMerkleTree<const DEPTH: u8> {
                     .get(&node_index)
                     .map(|mutation| match mutation {
                         Addition(node) => node.clone(),
-                        Removal => {
-                            let &child = EmptySubtreeRoots::entry(DEPTH, node_depth + 1);
-                            InnerNode { left: child, right: child }
-                        },
+                        Removal => EmptySubtreeRoots::get_inner_node(DEPTH, node_depth),
                     })
                     .unwrap_or_else(|| self.get_inner_node(node_index));
 

--- a/src/merkle/smt/mod.rs
+++ b/src/merkle/smt/mod.rs
@@ -1,4 +1,4 @@
-use alloc::vec::Vec;
+use alloc::{collections::BTreeMap, vec::Vec};
 
 use super::{EmptySubtreeRoots, InnerNodeInfo, MerkleError, MerklePath, NodeIndex};
 use crate::{
@@ -45,11 +45,11 @@ pub const SMT_MAX_DEPTH: u8 = 64;
 /// [SparseMerkleTree] currently doesn't support optimizations that compress Merkle proofs.
 pub(crate) trait SparseMerkleTree<const DEPTH: u8> {
     /// The type for a key
-    type Key: Clone;
+    type Key: Clone + Ord;
     /// The type for a value
     type Value: Clone + PartialEq;
     /// The type for a leaf
-    type Leaf;
+    type Leaf: Clone;
     /// The type for an opening (i.e. a "proof") of a leaf
     type Opening;
 
@@ -138,6 +138,152 @@ pub(crate) trait SparseMerkleTree<const DEPTH: u8> {
             }
         }
         self.set_root(node_hash);
+    }
+
+    /// Computes what changes are necessary to insert the specified key-value pairs into this Merkle
+    /// tree, allowing for validation before applying those changes.
+    ///
+    /// This method returns a [`MutationSet`], which contains all the information for inserting
+    /// `kv_pairs` into this Merkle tree already calculated, including the new root hash, which can
+    /// be queried with [`MutationSet::root()`]. Once a mutation set is returned,
+    /// [`SparseMerkleTree::apply_mutations()`] can be called in order to commit these changes to
+    /// the Merkle tree, or [`drop()`] to discard them.
+    fn compute_mutations(
+        &self,
+        kv_pairs: impl IntoIterator<Item = (Self::Key, Self::Value)>,
+    ) -> MutationSet<DEPTH, Self::Key, Self::Value> {
+        use NodeMutation::*;
+
+        let mut new_root = self.root();
+        let mut new_pairs: BTreeMap<Self::Key, Self::Value> = Default::default();
+        let mut node_mutations: BTreeMap<NodeIndex, NodeMutation> = Default::default();
+
+        for (key, value) in kv_pairs {
+            // If the old value and the new value are the same, there is nothing to update.
+            // For the unusual case that kv_pairs has multiple values at the same key, we'll have
+            // to check the key-value pairs we've already seen to get the "effective" old value.
+            let old_value = new_pairs.get(&key).cloned().unwrap_or_else(|| self.get_value(&key));
+            if value == old_value {
+                continue;
+            }
+
+            let leaf_index = Self::key_to_leaf_index(&key);
+            let mut node_index = NodeIndex::from(leaf_index);
+
+            // We need the current leaf's hash to calculate the new leaf, but in the rare case that
+            // `kv_pairs` has multiple pairs that go into the same leaf, then those pairs are also
+            // part of the "current leaf".
+            let old_leaf = {
+                let pairs_at_index = new_pairs
+                    .iter()
+                    .filter(|&(new_key, _)| Self::key_to_leaf_index(new_key) == leaf_index);
+
+                pairs_at_index.fold(self.get_leaf(&key), |acc, (k, v)| {
+                    // Most of the time `pairs_at_index` should only contain a single entry (or
+                    // none at all), as multi-leaves should be really rare.
+                    let existing_leaf = acc.clone();
+                    self.construct_prospective_leaf(existing_leaf, k, v)
+                })
+            };
+
+            let new_leaf = self.construct_prospective_leaf(old_leaf, &key, &value);
+
+            let mut new_child_hash = Self::hash_leaf(&new_leaf);
+
+            for node_depth in (0..node_index.depth()).rev() {
+                // Whether the node we're replacing is the right child or the left child.
+                let is_right = node_index.is_value_odd();
+                node_index.move_up();
+
+                let old_node = node_mutations
+                    .get(&node_index)
+                    .map(|mutation| match mutation {
+                        Addition(node) => node.clone(),
+                        Removal => {
+                            let &child = EmptySubtreeRoots::entry(DEPTH, node_depth + 1);
+                            InnerNode { left: child, right: child }
+                        },
+                    })
+                    .unwrap_or_else(|| self.get_inner_node(node_index));
+
+                let new_node = if is_right {
+                    InnerNode {
+                        left: old_node.left,
+                        right: new_child_hash,
+                    }
+                } else {
+                    InnerNode {
+                        left: new_child_hash,
+                        right: old_node.right,
+                    }
+                };
+
+                // The next iteration will operate on this new node's hash.
+                new_child_hash = new_node.hash();
+
+                let &equivalent_empty_hash = EmptySubtreeRoots::entry(DEPTH, node_depth);
+                let is_removal = new_child_hash == equivalent_empty_hash;
+                let new_entry = if is_removal { Removal } else { Addition(new_node) };
+                node_mutations.insert(node_index, new_entry);
+            }
+
+            // Once we're at depth 0, the last node we made is the new root.
+            new_root = new_child_hash;
+            // And then we're done with this pair; on to the next one.
+            new_pairs.insert(key, value);
+        }
+
+        MutationSet {
+            old_root: self.root(),
+            new_root,
+            node_mutations,
+            new_pairs,
+        }
+    }
+
+    /// Apply the prospective mutations computed with [`SparseMerkleTree::compute_mutations()`] to
+    /// this tree.
+    ///
+    /// # Errors
+    /// If `mutations` was computed on a tree with a different root than this one, returns
+    /// [`MerkleError::ConflictingRoots`] with a two-item [`Vec`]. The first item is the root hash
+    /// the `mutations` were computed against, and the second item is the actual current root of
+    /// this tree.
+    fn apply_mutations(
+        &mut self,
+        mutations: MutationSet<DEPTH, Self::Key, Self::Value>,
+    ) -> Result<(), MerkleError>
+    where
+        Self: Sized,
+    {
+        use NodeMutation::*;
+        let MutationSet {
+            old_root,
+            node_mutations,
+            new_pairs,
+            new_root,
+        } = mutations;
+
+        // Guard against accidentally trying to apply mutations that were computed against a
+        // different tree, including a stale version of this tree.
+        if old_root != self.root() {
+            return Err(MerkleError::ConflictingRoots(vec![old_root, self.root()]));
+        }
+
+        for (index, mutation) in node_mutations {
+            match mutation {
+                Removal => self.remove_inner_node(index),
+                Addition(node) => self.insert_inner_node(index, node),
+            }
+        }
+
+        for (key, value) in new_pairs {
+            self.insert_value(key, value);
+        }
+
+        self.set_root(new_root);
+
+        Ok(())
     }
 
     // REQUIRED METHODS
@@ -264,5 +410,52 @@ impl<const DEPTH: u8> TryFrom<NodeIndex> for LeafIndex<DEPTH> {
         }
 
         Self::new(node_index.value())
+    }
+}
+
+// MUTATIONS
+// ================================================================================================
+
+/// A change to an inner node of a [`SparseMerkleTree`] that hasn't yet been applied.
+/// [`MutationSet`] stores this type in relation to a [`NodeIndex`] to keep track of what changes
+/// need to occur at which node indices.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum NodeMutation {
+    /// Corresponds to [`SparseMerkleTree::remove_inner_node()`].
+    Removal,
+    /// Corresponds to [`SparseMerkleTree::insert_inner_node()`].
+    Addition(InnerNode),
+}
+
+/// Represents a group of prospective mutations to a `SparseMerkleTree`, created by
+/// `SparseMerkleTree::compute_mutations()`, and that can be applied with
+/// `SparseMerkleTree::apply_mutations()`.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct MutationSet<const DEPTH: u8, K, V> {
+    /// The root of the Merkle tree this MutationSet is for, recorded at the time
+    /// [`SparseMerkleTree::compute_mutations()`] was called. Exists to guard against applying
+    /// mutations to the wrong tree or applying stale mutations to a tree that has since changed.
+    old_root: RpoDigest,
+    /// The set of nodes that need to be removed or added. The "effective" node at an index is the
+    /// Merkle tree's existing node at that index, with the [`NodeMutation`] in this map at that
+    /// index overlayed, if any. Each [`NodeMutation::Addition`] corresponds to a
+    /// [`SparseMerkleTree::insert_inner_node()`] call, and each [`NodeMutation::Removal`]
+    /// corresponds to a [`SparseMerkleTree::remove_inner_node()`] call.
+    node_mutations: BTreeMap<NodeIndex, NodeMutation>,
+    /// The set of top-level key-value pairs we're prospectively adding to the tree, including
+    /// adding empty values. The "effective" value for a key is the value in this BTreeMap, falling
+    /// back to the existing value in the Merkle tree. Each entry corresponds to a
+    /// [`SparseMerkleTree::insert_value()`] call.
+    new_pairs: BTreeMap<K, V>,
+    /// The calculated root for the Merkle tree, given these mutations. Publicly retrievable with
+    /// [`MutationSet::root()`]. Corresponds to a [`SparseMerkleTree::set_root()`]. call.
+    new_root: RpoDigest,
+}
+
+impl<const DEPTH: u8, K, V> MutationSet<DEPTH, K, V> {
+    /// Queries the root that was calculated during `SparseMerkleTree::compute_mutations()`. See
+    /// that method for more information.
+    pub fn root(&self) -> RpoDigest {
+        self.new_root
     }
 }

--- a/src/merkle/smt/simple/mod.rs
+++ b/src/merkle/smt/simple/mod.rs
@@ -289,6 +289,10 @@ impl<const DEPTH: u8> SparseMerkleTree<DEPTH> for SimpleSmt<DEPTH> {
         }
     }
 
+    fn get_value(&self, key: &LeafIndex<DEPTH>) -> Word {
+        self.get_leaf(key)
+    }
+
     fn get_leaf(&self, key: &LeafIndex<DEPTH>) -> Word {
         let leaf_pos = key.value();
         match self.leaves.get(&leaf_pos) {

--- a/src/merkle/smt/simple/mod.rs
+++ b/src/merkle/smt/simple/mod.rs
@@ -302,6 +302,15 @@ impl<const DEPTH: u8> SparseMerkleTree<DEPTH> for SimpleSmt<DEPTH> {
         leaf.into()
     }
 
+    fn construct_prospective_leaf(
+        &self,
+        _existing_leaf: Word,
+        _key: &LeafIndex<DEPTH>,
+        value: &Word,
+    ) -> Word {
+        *value
+    }
+
     fn key_to_leaf_index(key: &LeafIndex<DEPTH>) -> LeafIndex<DEPTH> {
         *key
     }

--- a/src/merkle/smt/simple/mod.rs
+++ b/src/merkle/smt/simple/mod.rs
@@ -308,11 +308,10 @@ impl<const DEPTH: u8> SparseMerkleTree<DEPTH> for SimpleSmt<DEPTH> {
     }
 
     fn get_inner_node(&self, index: NodeIndex) -> InnerNode {
-        self.inner_nodes.get(&index).cloned().unwrap_or_else(|| {
-            let node = EmptySubtreeRoots::entry(DEPTH, index.depth() + 1);
-
-            InnerNode { left: *node, right: *node }
-        })
+        self.inner_nodes
+            .get(&index)
+            .cloned()
+            .unwrap_or_else(|| EmptySubtreeRoots::get_inner_node(DEPTH, index.depth()))
     }
 
     fn insert_inner_node(&mut self, index: NodeIndex, inner_node: InnerNode) {

--- a/src/merkle/smt/simple/mod.rs
+++ b/src/merkle/smt/simple/mod.rs
@@ -2,8 +2,8 @@ use alloc::collections::{BTreeMap, BTreeSet};
 
 use super::{
     super::ValuePath, EmptySubtreeRoots, InnerNode, InnerNodeInfo, LeafIndex, MerkleError,
-    MerklePath, NodeIndex, RpoDigest, SparseMerkleTree, Word, EMPTY_WORD, SMT_MAX_DEPTH,
-    SMT_MIN_DEPTH,
+    MerklePath, MutationSet, NodeIndex, RpoDigest, SparseMerkleTree, Word, EMPTY_WORD,
+    SMT_MAX_DEPTH, SMT_MIN_DEPTH,
 };
 
 #[cfg(test)]
@@ -186,6 +186,48 @@ impl<const DEPTH: u8> SimpleSmt<DEPTH> {
     /// updating the root itself.
     pub fn insert(&mut self, key: LeafIndex<DEPTH>, value: Word) -> Word {
         <Self as SparseMerkleTree<DEPTH>>::insert(self, key, value)
+    }
+
+    /// Computes what changes are necessary to insert the specified key-value pairs into this
+    /// Merkle tree, allowing for validation before applying those changes.
+    ///
+    /// This method returns a [`MutationSet`], which contains all the information for inserting
+    /// `kv_pairs` into this Merkle tree already calculated, including the new root hash, which can
+    /// be queried with [`MutationSet::root()`]. Once a mutation set is returned,
+    /// [`SimpleSmt::apply_mutations()`] can be called in order to commit these changes to the
+    /// Merkle tree, or [`drop()`] to discard them.
+
+    /// # Example
+    /// ```
+    /// # use miden_crypto::{hash::rpo::RpoDigest, Felt, Word};
+    /// # use miden_crypto::merkle::{LeafIndex, SimpleSmt, EmptySubtreeRoots, SMT_DEPTH};
+    /// let mut smt: SimpleSmt<3> = SimpleSmt::new().unwrap();
+    /// let pair = (LeafIndex::default(), Word::default());
+    /// let mutations = smt.compute_mutations(vec![pair]);
+    /// assert_eq!(mutations.root(), *EmptySubtreeRoots::entry(3, 0));
+    /// smt.apply_mutations(mutations);
+    /// assert_eq!(smt.root(), *EmptySubtreeRoots::entry(3, 0));
+    /// ```
+    pub fn compute_mutations(
+        &self,
+        kv_pairs: impl IntoIterator<Item = (LeafIndex<DEPTH>, Word)>,
+    ) -> MutationSet<DEPTH, LeafIndex<DEPTH>, Word> {
+        <Self as SparseMerkleTree<DEPTH>>::compute_mutations(self, kv_pairs)
+    }
+
+    /// Apply the prospective mutations computed with [`SimpleSmt::compute_mutations()`] to this
+    /// tree.
+    ///
+    /// # Errors
+    /// If `mutations` was computed on a tree with a different root than this one, returns
+    /// [`MerkleError::ConflictingRoots`] with a two-item [`alloc::vec::Vec`]. The first item is the
+    /// root hash the `mutations` were computed against, and the second item is the actual
+    /// current root of this tree.
+    pub fn apply_mutations(
+        &mut self,
+        mutations: MutationSet<DEPTH, LeafIndex<DEPTH>, Word>,
+    ) -> Result<(), MerkleError> {
+        <Self as SparseMerkleTree<DEPTH>>::apply_mutations(self, mutations)
     }
 
     /// Inserts a subtree at the specified index. The depth at which the subtree is inserted is


### PR DESCRIPTION
This PR is first set for validating modifications to Merkle tree structures before committing the mutations (#222). With this, a key-value insertion with a known expected root can be safely performed without cloning the tree first. Once this is generalized to multiple insertions, tree clones like like https://github.com/0xPolygonMiden/miden-node/blob/72e7a5374fbe78dfe30d6cbbd4b78fff56730171/crates/store/src/state.rs#L235-L245 can be eliminated in an immediate step towards 0xPolygonMiden/miden-node#149. Going forward I will likely generalize this further to a transactional commit/rollback model.

## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.