### PR TITLE
feat: add de/serialization to InOrderIndex and PartialMmr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.11.0 (TBD)
 
+- Added `Serializable` and `Deserializable` implementations for `PartialMmr` and `InOrderIndex` (#???).
 - [BREAKING]: renamed `Mmr::open()` into `Mmr::open_at()` and `Mmr::peaks()` into `Mmr::peaks_at()` (#234).
 - Added `Mmr::open()` and `Mmr::peaks()` which rely on `Mmr::open_at()` and `Mmr::peaks()` respectively (#234).
 - Standardised CI and Makefile across Miden repos (#323).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.11.0 (TBD)
 
-- Added `Serializable` and `Deserializable` implementations for `PartialMmr` and `InOrderIndex` (#???).
+- Added `Serializable` and `Deserializable` implementations for `PartialMmr` and `InOrderIndex` (#328).
 - [BREAKING]: renamed `Mmr::open()` into `Mmr::open_at()` and `Mmr::peaks()` into `Mmr::peaks_at()` (#234).
 - Added `Mmr::open()` and `Mmr::peaks()` which rely on `Mmr::open_at()` and `Mmr::peaks()` respectively (#234).
 - Standardised CI and Makefile across Miden repos (#323).

--- a/src/merkle/mmr/inorder.rs
+++ b/src/merkle/mmr/inorder.rs
@@ -6,6 +6,8 @@
 //! leaves count.
 use core::num::NonZeroUsize;
 
+use winter_utils::{Deserializable, Serializable};
+
 // IN-ORDER INDEX
 // ================================================================================================
 
@@ -112,6 +114,21 @@ impl InOrderIndex {
     }
 }
 
+impl Serializable for InOrderIndex {
+    fn write_into<W: winter_utils::ByteWriter>(&self, target: &mut W) {
+        target.write_usize(self.idx);
+    }
+}
+
+impl Deserializable for InOrderIndex {
+    fn read_from<R: winter_utils::ByteReader>(
+        source: &mut R,
+    ) -> Result<Self, winter_utils::DeserializationError> {
+        let idx = source.read_usize()?;
+        Ok(InOrderIndex { idx })
+    }
+}
+
 // CONVERSIONS FROM IN-ORDER INDEX
 // ------------------------------------------------------------------------------------------------
 
@@ -127,6 +144,7 @@ impl From<InOrderIndex> for u64 {
 #[cfg(test)]
 mod test {
     use proptest::prelude::*;
+    use winter_utils::{Deserializable, Serializable};
 
     use super::InOrderIndex;
 
@@ -161,5 +179,13 @@ mod test {
         assert_eq!(left, right.parent().left_child());
         assert_eq!(left.sibling(), right);
         assert_eq!(left, right.sibling());
+    }
+
+    #[test]
+    fn test_inorder_index_serialization() {
+        let index = InOrderIndex::from_leaf_pos(5);
+        let bytes = index.to_bytes();
+        let index2 = InOrderIndex::read_from_bytes(&bytes).unwrap();
+        assert_eq!(index, index2);
     }
 }

--- a/src/merkle/mmr/partial.rs
+++ b/src/merkle/mmr/partial.rs
@@ -3,6 +3,8 @@ use alloc::{
     vec::Vec,
 };
 
+use winter_utils::{Deserializable, Serializable};
+
 use super::{MmrDelta, MmrProof, Rpo256, RpoDigest};
 use crate::merkle::{
     mmr::{leaf_to_corresponding_tree, nodes_in_forest},
@@ -573,6 +575,28 @@ impl<'a, I: Iterator<Item = (usize, RpoDigest)>> Iterator for InnerNodeIterator<
     }
 }
 
+impl Serializable for PartialMmr {
+    fn write_into<W: winter_utils::ByteWriter>(&self, target: &mut W) {
+        self.forest.write_into(target);
+        self.peaks.write_into(target);
+        self.nodes.write_into(target);
+        target.write_bool(self.track_latest);
+    }
+}
+
+impl Deserializable for PartialMmr {
+    fn read_from<R: winter_utils::ByteReader>(
+        source: &mut R,
+    ) -> Result<Self, winter_utils::DeserializationError> {
+        let forest = usize::read_from(source)?;
+        let peaks = Vec::<RpoDigest>::read_from(source)?;
+        let nodes = NodeMap::read_from(source)?;
+        let track_latest = source.read_bool()?;
+
+        Ok(Self { forest, peaks, nodes, track_latest })
+    }
+}
+
 // UTILS
 // ================================================================================================
 
@@ -615,6 +639,8 @@ fn forest_to_rightmost_index(forest: usize) -> InOrderIndex {
 #[cfg(test)]
 mod tests {
     use alloc::{collections::BTreeSet, vec::Vec};
+
+    use winter_utils::{Deserializable, Serializable};
 
     use super::{
         forest_to_rightmost_index, forest_to_root_index, InOrderIndex, MmrPeaks, PartialMmr,
@@ -906,5 +932,16 @@ mod tests {
 
         // the openings should be the same
         assert_eq!(mmr.open(5).unwrap(), partial_mmr.open(5).unwrap().unwrap());
+    }
+
+    #[test]
+    fn test_partial_mmr_serialization() {
+        let mmr = Mmr::from((0..7).map(int_to_node));
+        let partial_mmr = PartialMmr::from_peaks(mmr.peaks());
+
+        let bytes = partial_mmr.to_bytes();
+        let decoded = PartialMmr::read_from_bytes(&bytes).unwrap();
+
+        assert_eq!(partial_mmr, decoded);
     }
 }


### PR DESCRIPTION
This PR adds de-serialization for `PartialMmr` and `InOrderIndex`, with the corresponding tests.

This feature is needed for https://github.com/0xPolygonMiden/miden-base/issues/860 .