### PR TITLE
feat: Add size hint for digests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.10.2 (TBD)
+
+* Implement `get_size_hint` for `RpoDigest` and `RpxDigest` and expose constants for their serialized size (#330).
+
 ## 0.10.1 (2024-09-13)
 
 * Added `Serializable` and `Deserializable` implementations for `PartialMmr` and `InOrderIndex` (#329).

--- a/src/hash/rescue/rpo/digest.rs
+++ b/src/hash/rescue/rpo/digest.rs
@@ -19,6 +19,9 @@ use crate::{
 pub struct RpoDigest([Felt; DIGEST_SIZE]);
 
 impl RpoDigest {
+    /// The serialized size of the digest in bytes.
+    pub const SERIALIZED_SIZE: usize = DIGEST_BYTES;
+
     pub const fn new(value: [Felt; DIGEST_SIZE]) -> Self {
         Self(value)
     }

--- a/src/hash/rescue/rpo/digest.rs
+++ b/src/hash/rescue/rpo/digest.rs
@@ -428,7 +428,7 @@ impl Serializable for RpoDigest {
     }
 
     fn get_size_hint(&self) -> usize {
-        self.as_bytes().get_size_hint()
+        Self::SERIALIZED_SIZE
     }
 }
 

--- a/src/hash/rescue/rpo/digest.rs
+++ b/src/hash/rescue/rpo/digest.rs
@@ -423,6 +423,10 @@ impl Serializable for RpoDigest {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
         target.write_bytes(&self.as_bytes());
     }
+
+    fn get_size_hint(&self) -> usize {
+        self.as_bytes().get_size_hint()
+    }
 }
 
 impl Deserializable for RpoDigest {
@@ -476,6 +480,7 @@ mod tests {
         let mut bytes = vec![];
         d1.write_into(&mut bytes);
         assert_eq!(DIGEST_BYTES, bytes.len());
+        assert_eq!(bytes.len(), d1.get_size_hint());
 
         let mut reader = SliceReader::new(&bytes);
         let d2 = RpoDigest::read_from(&mut reader).unwrap();

--- a/src/hash/rescue/rpx/digest.rs
+++ b/src/hash/rescue/rpx/digest.rs
@@ -19,6 +19,9 @@ use crate::{
 pub struct RpxDigest([Felt; DIGEST_SIZE]);
 
 impl RpxDigest {
+    /// The serialized size of the digest in bytes.
+    pub const SERIALIZED_SIZE: usize = DIGEST_BYTES;
+
     pub const fn new(value: [Felt; DIGEST_SIZE]) -> Self {
         Self(value)
     }

--- a/src/hash/rescue/rpx/digest.rs
+++ b/src/hash/rescue/rpx/digest.rs
@@ -428,7 +428,7 @@ impl Serializable for RpxDigest {
     }
 
     fn get_size_hint(&self) -> usize {
-        self.as_bytes().get_size_hint()
+        Self::SERIALIZED_SIZE
     }
 }
 

--- a/src/hash/rescue/rpx/digest.rs
+++ b/src/hash/rescue/rpx/digest.rs
@@ -423,6 +423,10 @@ impl Serializable for RpxDigest {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
         target.write_bytes(&self.as_bytes());
     }
+
+    fn get_size_hint(&self) -> usize {
+        self.as_bytes().get_size_hint()
+    }
 }
 
 impl Deserializable for RpxDigest {
@@ -476,6 +480,7 @@ mod tests {
         let mut bytes = vec![];
         d1.write_into(&mut bytes);
         assert_eq!(DIGEST_BYTES, bytes.len());
+        assert_eq!(bytes.len(), d1.get_size_hint());
 
         let mut reader = SliceReader::new(&bytes);
         let d2 = RpxDigest::read_from(&mut reader).unwrap();


### PR DESCRIPTION
## Describe your changes

Adds a `get_size_hint` implementation for `RpoDigest` and `RpxDigest`. This is required to nicely implement `get_size_hint` for custom types in miden-base, see also: https://github.com/0xPolygonMiden/miden-base/pull/895.

The added tests currently fail, but once https://github.com/facebook/winterfell/pull/332 is merged, they no longer will.

## Checklist before requesting a review

- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
