### PR TITLE
Implement `get_size_hint` for `Smt`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1157,9 +1157,9 @@ dependencies = [
 
 [[package]]
 name = "winter-math"
-version = "0.9.0"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "004f85bb051ce986ec0b9a2bd90aaf81b83e3c67464becfdf7db31f14c1019ba"
+checksum = "5b0e685b3b872d82e58a86519294a814b7bc7a4d3cd2c93570a7d80c0c5a1aba"
 dependencies = [
  "serde",
  "winter-utils",

--- a/src/merkle/smt/full/mod.rs
+++ b/src/merkle/smt/full/mod.rs
@@ -314,6 +314,14 @@ impl Serializable for Smt {
             target.write(value);
         }
     }
+
+    fn get_size_hint(&self) -> usize {
+        let entries_count = self.entries().count();
+
+        // Each entry is the size of a digest plus a word.
+        entries_count.get_size_hint()
+            + entries_count * (RpoDigest::SERIALIZED_SIZE + EMPTY_WORD.get_size_hint())
+    }
 }
 
 impl Deserializable for Smt {
@@ -339,6 +347,7 @@ fn test_smt_serialization_deserialization() {
     let smt_default = Smt::default();
     let bytes = smt_default.to_bytes();
     assert_eq!(smt_default, Smt::read_from_bytes(&bytes).unwrap());
+    assert_eq!(bytes.len(), smt_default.get_size_hint());
 
     // Smt with values
     let smt_leaves_2: [(RpoDigest, Word); 2] = [
@@ -355,4 +364,5 @@ fn test_smt_serialization_deserialization() {
 
     let bytes = smt.to_bytes();
     assert_eq!(smt, Smt::read_from_bytes(&bytes).unwrap());
+    assert_eq!(bytes.len(), smt.get_size_hint());
 }


### PR DESCRIPTION
## Describe your changes

Implement `get_size_hint` for `Smt`.

Needed for https://github.com/0xPolygonMiden/miden-base/pull/895.

Non-breaking change targetted at `main` so it can be released in a patch release.

## Checklist before requesting a review

- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
