### PR TITLE
[DO NOT MERGE] benchmarks for hashing single subtrees recursively

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,10 @@ name = "smt-subtree"
 harness = false
 
 [[bench]]
+name = "merkle"
+harness = false
+
+[[bench]]
 name = "store"
 harness = false
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,10 @@ name = "smt"
 harness = false
 
 [[bench]]
+name = "smt-subtree"
+harness = false
+
+[[bench]]
 name = "store"
 harness = false
 

--- a/benches/merkle.rs
+++ b/benches/merkle.rs
@@ -1,0 +1,59 @@
+use std::{hint, mem, time::Duration};
+
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
+use miden_crypto::{merkle::MerkleTree, Felt, Word, ONE};
+use rand_utils::prng_array;
+
+fn balanced_merkle_even(c: &mut Criterion) {
+    c.bench_function("balanced-merkle-even", |b| {
+        b.iter_batched(
+            || {
+                let entries: Vec<Word> =
+                    (0..256).map(|i| [Felt::new(i), ONE, ONE, Felt::new(i)]).collect();
+                assert_eq!(entries.len(), 256);
+                entries
+            },
+            |leaves| {
+                let tree = MerkleTree::new(hint::black_box(leaves)).unwrap();
+                assert_eq!(tree.depth(), 8);
+            },
+            BatchSize::SmallInput,
+        );
+    });
+}
+
+fn balanced_merkle_rand(c: &mut Criterion) {
+    let mut seed = [0u8; 32];
+    c.bench_function("balanced-merkle-rand", |b| {
+        b.iter_batched(
+            || {
+                let entries: Vec<Word> = (0..256).map(|_| generate_word(&mut seed)).collect();
+                assert_eq!(entries.len(), 256);
+                entries
+            },
+            |leaves| {
+                let tree = MerkleTree::new(hint::black_box(leaves)).unwrap();
+                assert_eq!(tree.depth(), 8);
+            },
+            BatchSize::SmallInput,
+        );
+    });
+}
+
+criterion_group! {
+    name = smt_subtree_group;
+    config = Criterion::default()
+        .measurement_time(Duration::from_secs(20))
+        .configure_from_args();
+    targets = balanced_merkle_even, balanced_merkle_rand
+}
+criterion_main!(smt_subtree_group);
+
+// HELPER FUNCTIONS
+// --------------------------------------------------------------------------------------------
+
+fn generate_word(seed: &mut [u8; 32]) -> Word {
+    mem::swap(seed, &mut prng_array(*seed));
+    let nums: [u64; 4] = prng_array(*seed);
+    [Felt::new(nums[0]), Felt::new(nums[1]), Felt::new(nums[2]), Felt::new(nums[3])]
+}

--- a/benches/smt-subtree.rs
+++ b/benches/smt-subtree.rs
@@ -1,0 +1,137 @@
+use std::{fmt::Debug, hint, mem, time::Duration};
+
+use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion};
+use miden_crypto::{
+    hash::rpo::RpoDigest,
+    merkle::{NodeIndex, Smt, SmtLeaf, SMT_DEPTH},
+    Felt, Word, ONE,
+};
+use rand_utils::prng_array;
+use winter_utils::Randomizable;
+
+fn smt_subtree_even(c: &mut Criterion) {
+    let mut seed = [0u8; 32];
+
+    let mut group = c.benchmark_group("subtree8-even");
+
+    for pair_count in (64..=256).step_by(64) {
+        let bench_id = BenchmarkId::from_parameter(pair_count);
+        group.bench_with_input(bench_id, &pair_count, |b, &pair_count| {
+            b.iter_batched(
+                || {
+                    // Setup.
+                    let entries: Vec<(RpoDigest, Word)> = (0..pair_count)
+                        .map(|n| {
+                            // A single depth-8 subtree can have a maximum of 255 leaves.
+                            let leaf_index = (n / pair_count) * 255;
+                            let key = RpoDigest::new([
+                                generate_value(&mut seed),
+                                ONE,
+                                Felt::new(n),
+                                Felt::new(leaf_index),
+                            ]);
+                            let value = generate_word(&mut seed);
+                            (key, value)
+                        })
+                        .collect();
+
+                    let mut leaves: Vec<_> = entries
+                        .iter()
+                        .map(|(key, value)| {
+                            let leaf = SmtLeaf::new_single(*key, *value);
+                            let col = NodeIndex::from(leaf.index()).value();
+                            let hash = leaf.hash();
+                            (col, hash)
+                        })
+                        .collect();
+                    leaves.sort();
+                    leaves
+                },
+                |leaves| {
+                    // Benchmarked function.
+                    let subtree =
+                        Smt::build_subtree(hint::black_box(leaves), hint::black_box(SMT_DEPTH));
+                    assert!(!subtree.is_empty());
+                },
+                BatchSize::SmallInput,
+            );
+        });
+    }
+}
+
+fn smt_subtree_random(c: &mut Criterion) {
+    let mut seed = [0u8; 32];
+
+    let mut group = c.benchmark_group("subtree8-rand");
+
+    for pair_count in (64..=256).step_by(64) {
+        let bench_id = BenchmarkId::from_parameter(pair_count);
+        group.bench_with_input(bench_id, &pair_count, |b, &pair_count| {
+            b.iter_batched(
+                || {
+                    // Setup.
+                    let entries: Vec<(RpoDigest, Word)> = (0..pair_count)
+                        .map(|i| {
+                            let leaf_index: u8 = generate_value(&mut seed);
+                            let key = RpoDigest::new([
+                                ONE,
+                                ONE,
+                                Felt::new(i),
+                                Felt::new(leaf_index as u64),
+                            ]);
+                            let value = generate_word(&mut seed);
+                            (key, value)
+                        })
+                        .collect();
+
+                    let mut leaves: Vec<_> = entries
+                        .iter()
+                        .map(|(key, value)| {
+                            let leaf = SmtLeaf::new_single(*key, *value);
+                            let col = NodeIndex::from(leaf.index()).value();
+                            let hash = leaf.hash();
+                            (col, hash)
+                        })
+                        .collect();
+                    leaves.sort();
+                    let before = leaves.len();
+                    leaves.dedup();
+                    let after = leaves.len();
+                    assert_eq!(before, after);
+                    leaves
+                },
+                |leaves| {
+                    let subtree =
+                        Smt::build_subtree(hint::black_box(leaves), hint::black_box(SMT_DEPTH));
+                    assert!(!subtree.is_empty());
+                },
+                BatchSize::SmallInput,
+            );
+        });
+    }
+}
+
+criterion_group! {
+    name = smt_subtree_group;
+    config = Criterion::default()
+        .measurement_time(Duration::from_secs(40))
+        .sample_size(60)
+        .configure_from_args();
+    targets = smt_subtree_even, smt_subtree_random
+}
+criterion_main!(smt_subtree_group);
+
+// HELPER FUNCTIONS
+// --------------------------------------------------------------------------------------------
+
+fn generate_value<T: Copy + Debug + Randomizable>(seed: &mut [u8; 32]) -> T {
+    mem::swap(seed, &mut prng_array(*seed));
+    let value: [T; 1] = rand_utils::prng_array(*seed);
+    value[0]
+}
+
+fn generate_word(seed: &mut [u8; 32]) -> Word {
+    mem::swap(seed, &mut prng_array(*seed));
+    let nums: [u64; 4] = prng_array(*seed);
+    [Felt::new(nums[0]), Felt::new(nums[1]), Felt::new(nums[2]), Felt::new(nums[3])]
+}

--- a/benches/smt-subtree.rs
+++ b/benches/smt-subtree.rs
@@ -9,12 +9,14 @@ use miden_crypto::{
 use rand_utils::prng_array;
 use winter_utils::Randomizable;
 
+const PAIR_COUNTS: [u64; 5] = [1, 64, 128, 192, 256];
+
 fn smt_subtree_even(c: &mut Criterion) {
     let mut seed = [0u8; 32];
 
     let mut group = c.benchmark_group("subtree8-even");
 
-    for pair_count in (64..=256).step_by(64) {
+    for pair_count in PAIR_COUNTS {
         let bench_id = BenchmarkId::from_parameter(pair_count);
         group.bench_with_input(bench_id, &pair_count, |b, &pair_count| {
             b.iter_batched(
@@ -64,7 +66,7 @@ fn smt_subtree_random(c: &mut Criterion) {
 
     let mut group = c.benchmark_group("subtree8-rand");
 
-    for pair_count in (64..=256).step_by(64) {
+    for pair_count in PAIR_COUNTS {
         let bench_id = BenchmarkId::from_parameter(pair_count);
         group.bench_with_input(bench_id, &pair_count, |b, &pair_count| {
             b.iter_batched(
@@ -94,10 +96,6 @@ fn smt_subtree_random(c: &mut Criterion) {
                         })
                         .collect();
                     leaves.sort();
-                    let before = leaves.len();
-                    leaves.dedup();
-                    let after = leaves.len();
-                    assert_eq!(before, after);
                     leaves
                 },
                 |leaves| {

--- a/src/merkle/index.rs
+++ b/src/merkle/index.rs
@@ -97,6 +97,14 @@ impl NodeIndex {
         self
     }
 
+    /// Returns the parent of the current node. This is the same as [`Self::move_up()`], but returns
+    /// a new value instead of mutating `self`.
+    pub const fn parent(mut self) -> Self {
+        self.depth = self.depth.saturating_sub(1);
+        self.value >>= 1;
+        self
+    }
+
     // PROVIDERS
     // --------------------------------------------------------------------------------------------
 

--- a/src/merkle/smt/full/mod.rs
+++ b/src/merkle/smt/full/mod.rs
@@ -243,6 +243,13 @@ impl Smt {
             None
         }
     }
+
+    pub fn build_subtree(
+        leaves: Vec<(u64, RpoDigest)>,
+        bottom_depth: u8,
+    ) -> BTreeMap<NodeIndex, InnerNode> {
+        <Self as SparseMerkleTree<SMT_DEPTH>>::build_subtree(leaves, bottom_depth)
+    }
 }
 
 impl SparseMerkleTree<SMT_DEPTH> for Smt {


### PR DESCRIPTION
This code is a benchmark for hashing a single, depth-8 subtree of a sparse Merkle tree by recursively establishing child hashes, adapted from work in progress code using this method to compute subtrees in parallel.

Raw results, the number of the left indicating the number of new key-value pairs:
```
subtree8/32             time:   [72.467 µs 75.138 µs 77.577 µs]
subtree8/128            time:   [76.635 µs 78.540 µs 80.337 µs]
subtree8/512            time:   [104.26 µs 107.99 µs 111.24 µs]
subtree8/1024           time:   [137.81 µs 142.94 µs 148.87 µs]
subtree8/8192           time:   [629.44 µs 708.05 µs 797.79 µs]
```
---

The time it takes to hash a subtree increases linearly with respect to the amount of key-value pairs being added to the tree as a whole.