### PR TITLE
[WIP] smt: implement parallel mutation computations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,21 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -83,6 +98,21 @@ name = "autocfg"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+
+[[package]]
+name = "backtrace"
+version = "0.3.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
 
 [[package]]
 name = "bit-set"
@@ -261,7 +291,7 @@ dependencies = [
  "clap",
  "criterion-plot",
  "is-terminal",
- "itertools",
+ "itertools 0.10.5",
  "num-traits",
  "once_cell",
  "oorandom",
@@ -282,7 +312,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
- "itertools",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -365,6 +395,95 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "futures"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
+
+[[package]]
+name = "futures-task"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+
+[[package]]
+name = "futures-util"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -386,6 +505,12 @@ dependencies = [
  "wasi",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
 
 [[package]]
 name = "glob"
@@ -443,6 +568,15 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -524,22 +658,35 @@ dependencies = [
  "cc",
  "clap",
  "criterion",
+ "futures",
  "getrandom",
  "glob",
  "hex",
+ "itertools 0.13.0",
  "num",
  "num-complex",
  "proptest",
  "rand",
  "rand_chacha",
  "rand_core",
+ "rayon",
  "seq-macro",
  "serde",
  "sha3",
+ "tokio",
  "winter-crypto",
  "winter-math",
  "winter-rand-utils",
  "winter-utils",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
+dependencies = [
+ "adler",
 ]
 
 [[package]]
@@ -617,6 +764,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.36.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "084f1a5821ac4c651660a94a7153d27ac9d8a53736203f58b31945ded098070a"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -627,6 +783,18 @@ name = "oorandom"
 version = "11.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "plotters"
@@ -798,6 +966,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+
+[[package]]
 name = "rustix"
 version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -886,6 +1060,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "slab"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -923,6 +1106,28 @@ checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "tokio"
+version = "1.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2b070231665d27ad9ec9b8df639893f46727666c6767db40317fbe920a5d998"
+dependencies = [
+ "backtrace",
+ "pin-project-lite",
+ "tokio-macros",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ name = "store"
 harness = false
 
 [features]
-default = ["std"]
+default = ["std", "async"]
 executable = ["dep:clap", "dep:rand-utils", "std"]
 serde = ["dep:serde", "serde?/alloc", "winter-math/serde"]
 std = [
@@ -44,6 +44,7 @@ std = [
     "winter-math/std",
     "winter-utils/std",
 ]
+async = ["serde?/rc"]
 
 [dependencies]
 blake3 = { version = "1.5", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,21 +44,25 @@ std = [
     "winter-math/std",
     "winter-utils/std",
 ]
-async = ["serde?/rc"]
+async = ["std", "dep:tokio", "dep:rayon", "dep:futures", "serde?/rc"]
 
 [dependencies]
 blake3 = { version = "1.5", default-features = false }
 clap = { version = "4.5", optional = true, features = ["derive"] }
+futures = { version = "0.3.30", optional = true }
 num = { version = "0.4", default-features = false, features = ["alloc", "libm"] }
 num-complex = { version = "0.4", default-features = false }
 rand = { version = "0.8", default-features = false }
 rand_core = { version = "0.6", default-features = false }
 rand-utils = { version = "0.9", package = "winter-rand-utils", optional = true }
+rayon = { version = "1.10.0", optional = true }
 serde = { version = "1.0", default-features = false, optional = true, features = ["derive"] }
 sha3 = { version = "0.10", default-features = false }
+tokio = { version = "1.40", features = ["rt-multi-thread", "macros", "sync"], optional = true }
 winter-crypto = { version = "0.9", default-features = false }
 winter-math = { version = "0.9", default-features = false }
 winter-utils = { version = "0.9", default-features = false }
+itertools = { version = "0.13.0", default-features = false, features = ["use_alloc"] }
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/src/merkle/index.rs
+++ b/src/merkle/index.rs
@@ -193,26 +193,22 @@ impl NodeIndex {
                 return false;
             }
 
+            if other.depth < self.depth {
+                return false;
+            }
+
             other = other.parent();
         }
     }
 
-    /// Returns the right-most descendent of the current node for a tree of `DEPTH` depth.
-    pub const fn rightmost_descendent<const DEPTH: u8>(mut self) -> Self {
-        while self.depth() < DEPTH {
-            self = self.right_child();
-        }
-
-        self
+    /// The inverse of [`NodeIndex::is_ancestor_of`], except that it does not include itself.
+    pub fn is_descendent_of(self, other: Self) -> bool {
+        self.depth != other.depth && self.value != other.value && other.contains(self)
     }
 
-    /// Returns the left-most descendent of the current node for a tree of `DEPTH` depth.
-    pub const fn leftmost_descendent<const DEPTH: u8>(mut self) -> Self {
-        while self.depth() < DEPTH {
-            self = self.left_child();
-        }
-
-        self
+    /// Returns `true` if and only if `other` is an ancestor of the current node.
+    pub fn is_ancestor_of(self, other: Self) -> bool {
+        self.depth != other.depth && self.value != other.value && self.contains(other)
     }
 
     // PROVIDERS

--- a/src/merkle/index.rs
+++ b/src/merkle/index.rs
@@ -294,6 +294,27 @@ impl Deserializable for NodeIndex {
     }
 }
 
+#[derive(Debug, Default, Copy, Clone, Eq, PartialEq, PartialOrd, Ord, Hash)]
+pub struct SubtreeIndex {
+    pub root: NodeIndex,
+    pub depth: u8,
+}
+
+#[allow(dead_code)]
+impl SubtreeIndex {
+    pub const fn new(root: NodeIndex, depth: u8) -> Self {
+        Self { root, depth }
+    }
+
+    pub const fn left_bound(&self) -> NodeIndex {
+        self.root.left_ancestor_n(self.depth)
+    }
+
+    pub const fn right_bound(&self) -> NodeIndex {
+        self.root.right_ancestor_n(self.depth)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use proptest::prelude::*;

--- a/src/merkle/index.rs
+++ b/src/merkle/index.rs
@@ -114,8 +114,8 @@ impl NodeIndex {
     /// Returns the scalar representation of the depth/value pair.
     ///
     /// It is computed as `2^depth + value`.
-    pub const fn to_scalar_index(&self) -> u64 {
-        (1 << self.depth as u64) + self.value
+    pub const fn to_scalar_index(&self) -> u128 {
+        (1 << self.depth as u64) + (self.value as u128)
     }
 
     /// Returns the depth of the current instance.

--- a/src/merkle/smt/parallel.rs
+++ b/src/merkle/smt/parallel.rs
@@ -1,0 +1,62 @@
+use std::{
+    cmp::Ordering,
+    collections::BTreeMap,
+    sync::{Arc, LazyLock},
+    thread,
+};
+
+use crate::merkle::smt::{InnerNode, MutationSet, NodeIndex, SparseMerkleTree};
+
+static TASK_COUNT: LazyLock<usize> = LazyLock::new(|| {
+    // FIXME: error handling?
+    thread::available_parallelism().unwrap().get()
+});
+
+#[allow(dead_code)]
+pub(crate) trait ParallelSparseMerkleTree<const DEPTH: u8>
+where
+    // Note: these type bounds need to be specified this way or we'll have to duplicate them
+    // everywhere.
+    // https://github.com/rust-lang/rust/issues/130805.
+    Self: SparseMerkleTree<
+        DEPTH,
+        Key: Send + Sync + 'static,
+        Value: Send + Sync + 'static,
+        Leaf: Send + Sync + 'static,
+    >,
+{
+    /// Shortcut for [`ParallelSparseMerkleTree::compute_mutations_parallel_n()`] with an
+    /// automatically determined number of tasks.
+    ///
+    /// Currently, the default number of tasks is the return value of
+    /// [`std::thread::available_parallelism()`], but this may be subject to change in the future.
+    async fn compute_mutations_parallel<I>(
+        &self,
+        kv_pairs: I,
+    ) -> MutationSet<DEPTH, Self::Key, Self::Value>
+    where
+        I: IntoIterator<Item = (Self::Key, Self::Value)>,
+    {
+        self.compute_mutations_parallel_n(kv_pairs, *TASK_COUNT).await
+    }
+
+    async fn compute_mutations_parallel_n<I>(
+        &self,
+        _kv_pairs: I,
+        _tasks: usize,
+    ) -> MutationSet<DEPTH, Self::Key, Self::Value>
+    where
+        I: IntoIterator<Item = (Self::Key, Self::Value)>,
+    {
+        todo!();
+    }
+
+    fn get_inner_nodes(&self) -> Arc<BTreeMap<NodeIndex, InnerNode>>;
+    fn get_leaves(&self) -> Arc<BTreeMap<u64, Self::Leaf>>;
+    fn get_leaf_value(_leaf: &Self::Leaf, _key: &Self::Key) -> Option<Self::Value> {
+        todo!();
+    }
+    fn cmp_keys(_lhs: &Self::Key, _rhs: &Self::Key) -> Ordering {
+        todo!();
+    }
+}

--- a/src/merkle/smt/simple/mod.rs
+++ b/src/merkle/smt/simple/mod.rs
@@ -395,3 +395,19 @@ impl<const DEPTH: u8> SparseMerkleTree<DEPTH> for SimpleSmt<DEPTH> {
         (path, leaf).into()
     }
 }
+
+//#[cfg(feature = "async")]
+////impl<const DEPTH: u8> super::ParallelSparseMerkleTree<DEPTH, LeafIndex<DEPTH>, Word, Word>
+//impl<const DEPTH: u8> super::ParallelSparseMerkleTree<DEPTH> for SimpleSmt<DEPTH> {
+//    fn get_inner_nodes(&self) -> Arc<BTreeMap<NodeIndex, InnerNode>> {
+//        Arc::clone(&self.inner_nodes)
+//    }
+//
+//    fn get_leaf_value(leaf: &Word, _key: &LeafIndex<DEPTH>) -> Option<Word> {
+//        Some(*leaf)
+//    }
+//
+//    fn cmp_keys(lhs: &LeafIndex<DEPTH>, rhs: &LeafIndex<DEPTH>) -> Ordering {
+//        LeafIndex::cmp(lhs, rhs)
+//    }
+//}


### PR DESCRIPTION
## Describe your changes

This is a *draft* providing a cursory implementation of recomputing SMT nodes in parallel, by splitting the tree into depth-8 subtree tasks which each recursively process their nodes.

Some benchmark results on my Ryzen 7950X:

| Pairs | Parallel Construction Time |
| -------- | -------------------------------------- |
|  500 | 6.206 seconds |
| 1000 | 25.065 seconds |
| 2000 | 11.60 seconds |
| 3000 | 369.465 seconds |

The total time increases exponentially as the number of key-value pairs being inserted increases. With some added `eprintln!()`s, we can also see each individual task's time *also* increases as we move up the tree:
```
$ cargo run --all-features --release -- --size 1000
Running a parallel construction benchmark:
joined 500 tasks for depth 56 in 4.606 milliseconds
joined 500 tasks for depth 48 in 18.616 milliseconds
joined 500 tasks for depth 40 in 41.756 milliseconds
joined 500 tasks for depth 32 in 63.146 milliseconds
joined 500 tasks for depth 24 in 109.348 milliseconds
joined 380 tasks for depth 16 in 154.977 milliseconds
joined 30 tasks for depth 8 in 1572.014 milliseconds
joined 1 tasks for depth 0 in 4205.459 milliseconds

assertion checks complete
Constructed an SMT in parallel with 1000 key-value pairs in 25.219 seconds
```

A [profile](https://github.com/user-attachments/files/17403681/callgrind.out.3989543.txt) indicates that we're spending almost half our time just determining if a node needs to be recomputed or not, in `is_index_dirty()`. I'm not sure how to mitigate this and still compute fixed subtrees. We could walk up from each modified leaf and mark each node in the path as dirty, upfront. However, a similar up-front computation to identify node indices of note was a considerable bottleneck in the previous approach to this parallelization. There may also be some heuristic we could apply to node indices to quickly estimate if they are ancestors of a modified index and sink a few duplicate calculations for when it fails.