### PR TITLE
Add `Smt::is_empty`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Added `Smt::compute_mutations()` and `Smt::apply_mutations()` for validation-checked insertions (#327).
 - [BREAKING] Changed return value of the `Mmr::verify()` and `MerklePath::verify()` from `bool` to
   `Result<>` (#).
+- Added `is_empty()` functions to the `SimpleSmt` and `Smt` structures. Added `EMPTY_ROOT` constant to the `SparseMerkleTree` trait (#337).
 
 ## 0.10.1 (2024-09-13)
 

--- a/src/merkle/smt/full/mod.rs
+++ b/src/merkle/smt/full/mod.rs
@@ -130,6 +130,11 @@ impl Smt {
         <Self as SparseMerkleTree<SMT_DEPTH>>::open(self, key)
     }
 
+    /// Returns a boolean value indicating whether the SMT is empty.
+    pub fn is_empty(&self) -> bool {
+        self.leaves.is_empty()
+    }
+
     // ITERATORS
     // --------------------------------------------------------------------------------------------
 
@@ -252,6 +257,7 @@ impl SparseMerkleTree<SMT_DEPTH> for Smt {
     type Opening = SmtProof;
 
     const EMPTY_VALUE: Self::Value = EMPTY_WORD;
+    const EMPTY_ROOT: RpoDigest = *EmptySubtreeRoots::entry(SMT_DEPTH, 0);
 
     fn root(&self) -> RpoDigest {
         self.root

--- a/src/merkle/smt/full/mod.rs
+++ b/src/merkle/smt/full/mod.rs
@@ -132,7 +132,8 @@ impl Smt {
 
     /// Returns a boolean value indicating whether the SMT is empty.
     pub fn is_empty(&self) -> bool {
-        self.leaves.is_empty()
+        debug_assert_eq!(self.leaves.is_empty(), self.root == Self::EMPTY_ROOT);
+        self.root == Self::EMPTY_ROOT
     }
 
     // ITERATORS

--- a/src/merkle/smt/full/tests.rs
+++ b/src/merkle/smt/full/tests.rs
@@ -516,6 +516,16 @@ fn test_smt_entries() {
     assert!(entries.next().is_none());
 }
 
+/// Tests that `EMPTY_ROOT` constant generated in the `Smt` equals to the root of the empty tree of
+/// depth 64
+#[test]
+fn test_smt_check_empty_root_constant() {
+    // get the root of the empty tree of depth 64
+    let empty_root_64_depth = EmptySubtreeRoots::empty_hashes(64)[0];
+
+    assert_eq!(empty_root_64_depth, Smt::EMPTY_ROOT);
+}
+
 // SMT LEAF
 // --------------------------------------------------------------------------------------------
 

--- a/src/merkle/smt/mod.rs
+++ b/src/merkle/smt/mod.rs
@@ -56,6 +56,9 @@ pub(crate) trait SparseMerkleTree<const DEPTH: u8> {
     /// The default value used to compute the hash of empty leaves
     const EMPTY_VALUE: Self::Value;
 
+    /// The root of the empty tree with provided DEPTH
+    const EMPTY_ROOT: RpoDigest;
+
     // PROVIDED METHODS
     // ---------------------------------------------------------------------------------------------
 

--- a/src/merkle/smt/simple/mod.rs
+++ b/src/merkle/smt/simple/mod.rs
@@ -158,6 +158,11 @@ impl<const DEPTH: u8> SimpleSmt<DEPTH> {
         <Self as SparseMerkleTree<DEPTH>>::open(self, key)
     }
 
+    /// Returns a boolean value indicating whether the SMT is empty.
+    pub fn is_empty(&self) -> bool {
+        self.leaves.is_empty()
+    }
+
     // ITERATORS
     // --------------------------------------------------------------------------------------------
 
@@ -298,6 +303,7 @@ impl<const DEPTH: u8> SparseMerkleTree<DEPTH> for SimpleSmt<DEPTH> {
     type Opening = ValuePath;
 
     const EMPTY_VALUE: Self::Value = EMPTY_WORD;
+    const EMPTY_ROOT: RpoDigest = *EmptySubtreeRoots::entry(DEPTH, 0);
 
     fn root(&self) -> RpoDigest {
         self.root

--- a/src/merkle/smt/simple/mod.rs
+++ b/src/merkle/smt/simple/mod.rs
@@ -160,7 +160,8 @@ impl<const DEPTH: u8> SimpleSmt<DEPTH> {
 
     /// Returns a boolean value indicating whether the SMT is empty.
     pub fn is_empty(&self) -> bool {
-        self.leaves.is_empty()
+        debug_assert_eq!(self.leaves.is_empty(), self.root == Self::EMPTY_ROOT);
+        self.root == Self::EMPTY_ROOT
     }
 
     // ITERATORS

--- a/src/merkle/smt/simple/tests.rs
+++ b/src/merkle/smt/simple/tests.rs
@@ -444,6 +444,23 @@ fn test_simplesmt_set_subtree_entire_tree() {
     assert_eq!(tree.root(), *EmptySubtreeRoots::entry(DEPTH, 0));
 }
 
+/// Tests that `EMPTY_ROOT` constant generated in the `SimpleSmt` equals to the root of the empty
+/// tree of depth 64
+#[test]
+fn test_simplesmt_check_empty_root_constant() {
+    // get the root of the empty tree of depth 64
+    let empty_root_64_depth = EmptySubtreeRoots::empty_hashes(64)[0];
+    assert_eq!(empty_root_64_depth, SimpleSmt::<64>::EMPTY_ROOT);
+
+    // get the root of the empty tree of depth 32
+    let empty_root_32_depth = EmptySubtreeRoots::empty_hashes(32)[0];
+    assert_eq!(empty_root_32_depth, SimpleSmt::<32>::EMPTY_ROOT);
+
+    // get the root of the empty tree of depth 0
+    let empty_root_1_depth = EmptySubtreeRoots::empty_hashes(1)[0];
+    assert_eq!(empty_root_1_depth, SimpleSmt::<1>::EMPTY_ROOT);
+}
+
 // HELPER FUNCTIONS
 // --------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
This tiny PR implements the `is_empty()` function for the `SimpleSmt` and `Smt` structures. 
It also provides a new `EMPTY_ROOT` constant to the `SparseMerkleTree` trait, which equals to the root of empty tree with specified depth. 
