### PR TITLE
STARK-based signature scheme

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -539,8 +539,11 @@ dependencies = [
  "sha3",
  "winter-crypto",
  "winter-math",
+ "winter-prover",
  "winter-rand-utils",
  "winter-utils",
+ "winter-verifier",
+ "winterfell",
 ]
 
 [[package]]
@@ -628,6 +631,12 @@ name = "oorandom"
 version = "11.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
 
 [[package]]
 name = "plotters"
@@ -933,6 +942,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing"
+version = "0.1.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+
+[[package]]
 name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1144,6 +1181,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "winter-air"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29bec0b06b741543f43e3a6677b95b200d4cad2daab76e6721e14345345bfd0e"
+dependencies = [
+ "libm",
+ "winter-crypto",
+ "winter-fri",
+ "winter-math",
+ "winter-utils",
+]
+
+[[package]]
 name = "winter-crypto"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1156,12 +1206,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "winter-fri"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b7b394670d68979a4cc21a37a95ef8ef350cf84be9256c53effe3052df50d26"
+dependencies = [
+ "winter-crypto",
+ "winter-math",
+ "winter-utils",
+]
+
+[[package]]
 name = "winter-math"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a8ba832121679e79b004b0003018c85873956d742a39c348c247f680fe15e00"
 dependencies = [
  "serde",
+ "winter-utils",
+]
+
+[[package]]
+name = "winter-maybe-async"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be43529f43f70306437d2c2c9f9e2b3a4d39b42e86702d8d7577f2357ea32fa6"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "winter-prover"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f55f0153d26691caaf969066a13a824bcf3c98719d71b0f569bf8dc40a06fb9"
+dependencies = [
+ "tracing",
+ "winter-air",
+ "winter-crypto",
+ "winter-fri",
+ "winter-math",
+ "winter-maybe-async",
  "winter-utils",
 ]
 
@@ -1180,6 +1266,30 @@ name = "winter-utils"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76b116c8ade0172506f8bda32dc674cf6b230adc8516e5138a0173ae69158a4f"
+
+[[package]]
+name = "winter-verifier"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ae1648768f96f5e6321a48a5bff5cc3101d2e51b23a6a095c6c9c9e133ecb61"
+dependencies = [
+ "winter-air",
+ "winter-crypto",
+ "winter-fri",
+ "winter-math",
+ "winter-utils",
+]
+
+[[package]]
+name = "winterfell"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39c8336dc6a035698780b8cc624f875e479bd6bf6e1846670f3ef4485c125882"
+dependencies = [
+ "winter-air",
+ "winter-prover",
+ "winter-verifier",
+]
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,10 @@ serde = { version = "1.0", default-features = false, optional = true, features =
 sha3 = { version = "0.10", default-features = false }
 winter-crypto = { version = "0.10", default-features = false }
 winter-math = { version = "0.10", default-features = false }
+winter-prover = { version = "0.10", default-features = false }
 winter-utils = { version = "0.10", default-features = false }
+winter-verifier = { version = "0.10", default-features = false }
+winterfell = { version = "0.10", default-features = false }
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/src/dsa/mod.rs
+++ b/src/dsa/mod.rs
@@ -1,3 +1,5 @@
 //! Digital signature schemes supported by default in the Miden VM.
 
 pub mod rpo_falcon512;
+
+pub mod rpo_stark;

--- a/src/dsa/rpo_stark/mod.rs
+++ b/src/dsa/rpo_stark/mod.rs
@@ -1,0 +1,25 @@
+mod signature;
+pub use signature::{PublicKey, SecretKey, Signature};
+
+mod stark;
+
+// TESTS
+// ================================================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::SecretKey;
+
+    #[test]
+    fn test_signature() {
+        use rand_utils::rand_array;
+
+        let sk = SecretKey::new();
+
+        let message = rand_array();
+        let signature = sk.sign(message);
+
+        let pk = sk.compute_public_key();
+        assert!(pk.verify(message, &signature))
+    }
+}

--- a/src/dsa/rpo_stark/mod.rs
+++ b/src/dsa/rpo_stark/mod.rs
@@ -8,13 +8,18 @@ mod stark;
 
 #[cfg(test)]
 mod tests {
+    use rand::SeedableRng;
+    use rand_chacha::ChaCha20Rng;
+
     use super::SecretKey;
 
     #[test]
     fn test_signature() {
         use rand_utils::rand_array;
 
-        let sk = SecretKey::new();
+        let seed = [0_u8; 32];
+        let mut rng = ChaCha20Rng::from_seed(seed);
+        let sk = SecretKey::with_rng(&mut rng);
 
         let message = rand_array();
         let signature = sk.sign(message);

--- a/src/dsa/rpo_stark/signature/mod.rs
+++ b/src/dsa/rpo_stark/signature/mod.rs
@@ -1,0 +1,156 @@
+use rand::Rng;
+use winter_math::fields::f64::BaseElement;
+use winter_prover::Proof;
+use winter_utils::{
+    ByteReader, ByteWriter, Deserializable, DeserializationError, Randomizable, Serializable,
+};
+use winterfell::{FieldExtension, ProofOptions};
+
+use super::stark::compute_rpo_image;
+use crate::{dsa::rpo_stark::stark::RpoSignatureScheme, hash::rpo::Rpo256, Word, ZERO};
+
+// CONSTANTS
+// ================================================================================================
+
+/// Specifies the parameters of the STARK underlying the signature scheme.
+///
+/// TODO: The number of queries needs to be updated so that it matches the one given in
+/// the specification. The reason for choosing such a low number for the number of FRI queries is
+/// due to the fact that the number of FRI queries should be smaller than the size of the LDE
+/// domain. Since the PR enabling zero-knowledge in Winterfell is yet to be merged, this not
+/// case.
+pub const PROOF_OPTIONS: ProofOptions =
+    ProofOptions::new(63, 8, 0, FieldExtension::Quadratic, 8, 31);
+
+// PUBLIC KEY
+// ================================================================================================
+
+/// A public key for verifying signatures.
+///
+/// The public key is a [Word] (i.e., 4 field elements) that is the hash of the secret key.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PublicKey(Word);
+
+impl PublicKey {
+    /// Verifies the provided signature against provided message and this public key.
+    pub fn verify(&self, message: Word, signature: &Signature) -> bool {
+        signature.verify(message, self.0)
+    }
+}
+
+// SECRET KEY
+// ================================================================================================
+
+/// A secret key for generating signatures.
+///
+/// The secret key is a [Word] (i.e., 4 field elements).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SecretKey(Word);
+
+impl SecretKey {
+    /// Generates a secret key from OS-provided randomness.
+    #[cfg(feature = "std")]
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> Self {
+        use rand::{rngs::StdRng, SeedableRng};
+
+        let mut rng = StdRng::from_entropy();
+        Self::with_rng(&mut rng)
+    }
+
+    /// Generates a secret_key using the provided random number generator `Rng`.
+    pub fn with_rng<R: Rng>(rng: &mut R) -> Self {
+        let mut sk = [ZERO; 4];
+
+        let mut dest = vec![0_u8; 8];
+        for s in sk.iter_mut() {
+            rng.fill_bytes(&mut dest);
+            *s = BaseElement::from_random_bytes(&dest).expect("");
+        }
+
+        Self(sk)
+    }
+
+    /// Computes the public key corresponding to this secret key.
+    pub fn compute_public_key(&self) -> PublicKey {
+        let pk = compute_rpo_image(self.0);
+        PublicKey(pk)
+    }
+
+    /// Signs a message with this secret key.
+    pub fn sign(&self, message: Word) -> Signature {
+        let signature: RpoSignatureScheme<Rpo256> = RpoSignatureScheme::new(PROOF_OPTIONS);
+        let proof = signature.sign(self.0, message);
+        Signature { proof }
+    }
+}
+
+// SIGNATURE
+// ================================================================================================
+
+/// An RPO STARK-based signature over a message.
+///
+/// The signature is a STARK proof of knowledge of a pre-image given an image where the map is
+/// the RPO permutation, the pre-image is the secret key and the image is the public key.
+/// The current implementation follows the description in [1] in the unique decoding regime where
+/// it is argued that for the parameter set [PROOF_OPTIONS] the signature achieves $113$ bits of
+/// average-case existential unforgeability security against $2^{113}$-query bound adversaries
+/// that can obtain up to $2^{64}$ signatures under the same public key.
+///
+/// [1]: https://eprint.iacr.org/2024/1553
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Signature {
+    proof: Proof,
+}
+
+impl Signature {
+    /// Returns true if this signature is a valid signature for the specified message generated
+    /// against the secret key matching the specified public key commitment.
+    pub fn verify(&self, message: Word, pk: Word) -> bool {
+        let signature: RpoSignatureScheme<Rpo256> = RpoSignatureScheme::new(PROOF_OPTIONS);
+
+        signature.verify(pk, message, self.proof.clone()).is_ok()
+    }
+}
+
+// SERIALIZATION / DESERIALIZATION
+// ================================================================================================
+
+impl Serializable for PublicKey {
+    fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        self.0.write_into(target);
+    }
+}
+
+impl Deserializable for PublicKey {
+    fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
+        let pk = <Word>::read_from(source)?;
+        Ok(Self(pk))
+    }
+}
+
+impl Serializable for SecretKey {
+    fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        self.0.write_into(target);
+    }
+}
+
+impl Deserializable for SecretKey {
+    fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
+        let sk = <Word>::read_from(source)?;
+        Ok(Self(sk))
+    }
+}
+
+impl Serializable for Signature {
+    fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        self.proof.write_into(target);
+    }
+}
+
+impl Deserializable for Signature {
+    fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
+        let proof = Proof::read_from(source)?;
+        Ok(Self { proof })
+    }
+}

--- a/src/dsa/rpo_stark/signature/mod.rs
+++ b/src/dsa/rpo_stark/signature/mod.rs
@@ -93,7 +93,7 @@ impl SecretKey {
 /// The signature is a STARK proof of knowledge of a pre-image given an image where the map is
 /// the RPO permutation, the pre-image is the secret key and the image is the public key.
 /// The current implementation follows the description in [1] in the unique decoding regime where
-/// it is argued that for the parameter set [PROOF_OPTIONS] the signature achieves $113$ bits of
+/// it is argued that for the parameter set `PROOF_OPTIONS` the signature achieves $113$ bits of
 /// average-case existential unforgeability security against $2^{113}$-query bound adversaries
 /// that can obtain up to $2^{64}$ signatures under the same public key.
 ///

--- a/src/dsa/rpo_stark/stark/air.rs
+++ b/src/dsa/rpo_stark/stark/air.rs
@@ -1,0 +1,217 @@
+use std::vec::Vec;
+
+use winter_math::{fields::f64::BaseElement, FieldElement, ToElements};
+use winter_prover::{
+    Air, AirContext, Assertion, EvaluationFrame, ProofOptions, TraceInfo,
+    TransitionConstraintDegree,
+};
+
+use crate::{
+    hash::rpo::{ARK1, ARK2, MDS, STATE_WIDTH},
+    Word, ZERO,
+};
+
+// CONSTANTS
+// ================================================================================================
+
+pub const HASH_CYCLE_LEN: usize = 8;
+pub const TRACE_WIDTH: usize = 12;
+
+// AIR
+// ================================================================================================
+
+pub struct RescueAir {
+    context: AirContext<BaseElement>,
+    pub_key: Word,
+}
+
+impl Air for RescueAir {
+    type BaseField = BaseElement;
+    type PublicInputs = PublicInputs;
+
+    type GkrProof = ();
+    type GkrVerifier = ();
+
+    // CONSTRUCTOR
+    // --------------------------------------------------------------------------------------------
+    fn new(trace_info: TraceInfo, pub_inputs: PublicInputs, options: ProofOptions) -> Self {
+        let degrees = vec![
+            // Apply RPO rounds.
+            TransitionConstraintDegree::new(7),
+            TransitionConstraintDegree::new(7),
+            TransitionConstraintDegree::new(7),
+            TransitionConstraintDegree::new(7),
+            TransitionConstraintDegree::new(7),
+            TransitionConstraintDegree::new(7),
+            TransitionConstraintDegree::new(7),
+            TransitionConstraintDegree::new(7),
+            TransitionConstraintDegree::new(7),
+            TransitionConstraintDegree::new(7),
+            TransitionConstraintDegree::new(7),
+            TransitionConstraintDegree::new(7),
+        ];
+        assert_eq!(TRACE_WIDTH, trace_info.width());
+        let context = AirContext::new(trace_info, degrees, 12, options);
+        let context = context.set_num_transition_exemptions(1);
+        RescueAir { context, pub_key: pub_inputs.pub_key }
+    }
+
+    fn context(&self) -> &AirContext<Self::BaseField> {
+        &self.context
+    }
+
+    fn evaluate_transition<E: FieldElement + From<Self::BaseField>>(
+        &self,
+        frame: &EvaluationFrame<E>,
+        periodic_values: &[E],
+        result: &mut [E],
+    ) {
+        let current = frame.current();
+        let next = frame.next();
+        // expected state width is 12 field elements
+        debug_assert_eq!(TRACE_WIDTH, current.len());
+        debug_assert_eq!(TRACE_WIDTH, next.len());
+
+        enforce_rpo_round(frame, result, periodic_values);
+    }
+
+    fn get_assertions(&self) -> Vec<Assertion<Self::BaseField>> {
+        // Assert that the public key is the correct one
+        let initial_step = 0;
+        let last_step = self.trace_length() - 1;
+        vec![
+            Assertion::single(0, initial_step, Self::BaseField::ZERO),
+            Assertion::single(1, initial_step, Self::BaseField::ZERO),
+            Assertion::single(2, initial_step, Self::BaseField::ZERO),
+            Assertion::single(3, initial_step, Self::BaseField::ZERO),
+            Assertion::single(8, initial_step, Self::BaseField::ZERO),
+            Assertion::single(9, initial_step, Self::BaseField::ZERO),
+            Assertion::single(10, initial_step, Self::BaseField::ZERO),
+            Assertion::single(11, initial_step, Self::BaseField::ZERO),
+            Assertion::single(4, last_step, self.pub_key[0]),
+            Assertion::single(5, last_step, self.pub_key[1]),
+            Assertion::single(6, last_step, self.pub_key[2]),
+            Assertion::single(7, last_step, self.pub_key[3]),
+        ]
+    }
+
+    fn get_periodic_column_values(&self) -> Vec<Vec<Self::BaseField>> {
+        get_round_constants()
+    }
+}
+
+pub struct PublicInputs {
+    pub(crate) pub_key: Word,
+    pub(crate) msg: Word,
+}
+
+impl ToElements<BaseElement> for PublicInputs {
+    fn to_elements(&self) -> Vec<BaseElement> {
+        let mut res = self.pub_key.to_vec();
+        res.extend_from_slice(self.msg.as_ref());
+        res
+    }
+}
+
+// HELPER EVALUATORS
+// ------------------------------------------------------------------------------------------------
+
+/// Enforces constraints for a single round of the Rescue Prime Optimized hash functions.
+pub fn enforce_rpo_round<E: FieldElement + From<BaseElement>>(
+    frame: &EvaluationFrame<E>,
+    result: &mut [E],
+    ark: &[E],
+) {
+    // compute the state that should result from applying the first 5 operations of the RPO round to
+    // the current hash state.
+    let mut step1 = [E::ZERO; STATE_WIDTH];
+    step1.copy_from_slice(frame.current());
+
+    apply_mds(&mut step1);
+    // add constants
+    for i in 0..STATE_WIDTH {
+        step1[i] += ark[i];
+    }
+    apply_sbox(&mut step1);
+    apply_mds(&mut step1);
+    // add constants
+    for i in 0..STATE_WIDTH {
+        step1[i] += ark[STATE_WIDTH + i];
+    }
+
+    // compute the state that should result from applying the inverse of the last operation of the
+    // RPO round to the next step of the computation.
+    let mut step2 = [E::ZERO; STATE_WIDTH];
+    step2.copy_from_slice(frame.next());
+    apply_sbox(&mut step2);
+
+    // make sure that the results are equal.
+    for i in 0..STATE_WIDTH {
+        result.agg_constraint(i, are_equal(step2[i], step1[i]));
+    }
+}
+
+#[inline(always)]
+fn apply_sbox<E: FieldElement + From<BaseElement>>(state: &mut [E; STATE_WIDTH]) {
+    state.iter_mut().for_each(|v| {
+        let t2 = v.square();
+        let t4 = t2.square();
+        *v *= t2 * t4;
+    });
+}
+
+#[inline(always)]
+fn apply_mds<E: FieldElement + From<BaseElement>>(state: &mut [E; STATE_WIDTH]) {
+    let mut result = [E::ZERO; STATE_WIDTH];
+    result.iter_mut().zip(MDS).for_each(|(r, mds_row)| {
+        state.iter().zip(mds_row).for_each(|(&s, m)| {
+            *r += E::from(m) * s;
+        });
+    });
+    *state = result
+}
+
+/// Returns RPO round constants arranged in column-major form.
+pub fn get_round_constants() -> Vec<Vec<BaseElement>> {
+    let mut constants = Vec::new();
+    for _ in 0..(STATE_WIDTH * 2) {
+        constants.push(vec![ZERO; HASH_CYCLE_LEN]);
+    }
+
+    #[allow(clippy::needless_range_loop)]
+    for i in 0..HASH_CYCLE_LEN - 1 {
+        for j in 0..STATE_WIDTH {
+            constants[j][i] = ARK1[i][j];
+            constants[j + STATE_WIDTH][i] = ARK2[i][j];
+        }
+    }
+
+    constants
+}
+
+// CONSTRAINT EVALUATION HELPERS
+// ================================================================================================
+
+/// Returns zero only when a == b.
+pub fn are_equal<E: FieldElement>(a: E, b: E) -> E {
+    a - b
+}
+
+// TRAIT TO SIMPLIFY CONSTRAINT AGGREGATION
+// ================================================================================================
+
+pub trait EvaluationResult<E> {
+    fn agg_constraint(&mut self, index: usize, value: E);
+}
+
+impl<E: FieldElement> EvaluationResult<E> for [E] {
+    fn agg_constraint(&mut self, index: usize, value: E) {
+        self[index] += value;
+    }
+}
+
+impl<E: FieldElement> EvaluationResult<E> for Vec<E> {
+    fn agg_constraint(&mut self, index: usize, value: E) {
+        self[index] += value;
+    }
+}

--- a/src/dsa/rpo_stark/stark/air.rs
+++ b/src/dsa/rpo_stark/stark/air.rs
@@ -1,4 +1,4 @@
-use std::vec::Vec;
+use alloc::vec::Vec;
 
 use winter_math::{fields::f64::BaseElement, FieldElement, ToElements};
 use winter_prover::{

--- a/src/dsa/rpo_stark/stark/mod.rs
+++ b/src/dsa/rpo_stark/stark/mod.rs
@@ -1,0 +1,67 @@
+use core::marker::PhantomData;
+
+use air::{PublicInputs, RescueAir};
+use prover::RpoSignatureProver;
+use winter_crypto::{DefaultRandomCoin, ElementHasher, MerkleTree};
+use winter_math::{fields::f64::BaseElement, FieldElement};
+use winter_prover::{Proof, ProofOptions};
+use winter_verifier::{verify, AcceptableOptions, VerifierError};
+use winterfell::Prover;
+
+use crate::hash::rpo::{Rpo256, DIGEST_RANGE, DIGEST_SIZE, NUM_ROUNDS, STATE_WIDTH};
+
+mod air;
+mod prover;
+
+/// Represents an abstract STARK-based signature scheme with knowledge of RPO pre-image as
+/// the hard relation.
+pub struct RpoSignatureScheme<H: ElementHasher> {
+    options: ProofOptions,
+    _h: PhantomData<H>,
+}
+
+impl<H: ElementHasher<BaseField = BaseElement> + Sync> RpoSignatureScheme<H> {
+    pub fn new(options: ProofOptions) -> Self {
+        RpoSignatureScheme { options, _h: PhantomData }
+    }
+
+    pub fn sign(&self, sk: [BaseElement; DIGEST_SIZE], msg: [BaseElement; DIGEST_SIZE]) -> Proof {
+        // create a prover
+        let prover = RpoSignatureProver::<H>::new(self.options.clone());
+
+        // generate execution trace
+        let trace = prover.build_trace(sk, msg);
+
+        // generate the proof
+        prover.prove(trace).expect("failed to generate the signature")
+    }
+
+    pub fn verify(
+        &self,
+        pub_key: [BaseElement; DIGEST_SIZE],
+        msg: [BaseElement; DIGEST_SIZE],
+        proof: Proof,
+    ) -> Result<(), VerifierError> {
+        let pub_inputs = PublicInputs { pub_key, msg };
+        let acceptable_options = AcceptableOptions::OptionSet(vec![proof.options().clone()]);
+        verify::<RescueAir, H, DefaultRandomCoin<H>, MerkleTree<H>>(
+            proof,
+            pub_inputs,
+            &acceptable_options,
+        )
+    }
+}
+
+// HELPER FUNCTIONS
+// ================================================================================================
+
+pub fn compute_rpo_image(pre_image: [BaseElement; DIGEST_SIZE]) -> [BaseElement; DIGEST_SIZE] {
+    let mut state = [BaseElement::ZERO; STATE_WIDTH];
+    state[DIGEST_RANGE].copy_from_slice(&pre_image);
+    for i in 0..NUM_ROUNDS {
+        Rpo256::apply_round(&mut state, i);
+    }
+    state[DIGEST_RANGE]
+        .try_into()
+        .expect("should not fail given the size of the array")
+}

--- a/src/dsa/rpo_stark/stark/prover.rs
+++ b/src/dsa/rpo_stark/stark/prover.rs
@@ -1,0 +1,116 @@
+use core::marker::PhantomData;
+
+use winter_crypto::{DefaultRandomCoin, ElementHasher, MerkleTree};
+use winter_math::{fields::f64::BaseElement, FieldElement};
+use winter_prover::{
+    matrix::ColMatrix, DefaultConstraintEvaluator, DefaultTraceLde, ProofOptions, Prover,
+    StarkDomain, Trace, TraceInfo, TracePolyTable, TraceTable,
+};
+use winter_utils::{Deserializable, Serializable};
+use winterfell::{AuxRandElements, ConstraintCompositionCoefficients, PartitionOptions};
+
+use super::air::{PublicInputs, RescueAir, HASH_CYCLE_LEN};
+use crate::{hash::rpo::Rpo256, Word, ZERO};
+
+// PROVER
+// ================================================================================================
+
+pub struct RpoSignatureProver<H: ElementHasher>
+where
+    H: Sync,
+{
+    options: ProofOptions,
+    _hasher: PhantomData<H>,
+}
+
+impl<H: ElementHasher + Sync> RpoSignatureProver<H> {
+    pub fn new(options: ProofOptions) -> Self {
+        Self { options, _hasher: PhantomData }
+    }
+
+    pub fn build_trace(&self, sk: Word, msg: Word) -> TraceTable<BaseElement> {
+        let trace_length = HASH_CYCLE_LEN;
+        let mut target = vec![];
+        msg.write_into(&mut target);
+        let mut trace = TraceTable::with_meta(12, trace_length, target);
+
+        trace.fill(
+            |state| {
+                // initialize first state of the computation
+                state[0] = ZERO;
+                state[1] = ZERO;
+                state[2] = ZERO;
+                state[3] = ZERO;
+                state[4] = sk[0];
+                state[5] = sk[1];
+                state[6] = sk[2];
+                state[7] = sk[3];
+                state[8] = ZERO;
+                state[9] = ZERO;
+                state[10] = ZERO;
+                state[11] = ZERO;
+            },
+            |step, state| {
+                Rpo256::apply_round(
+                    state.try_into().expect("should not fail given the size of the array"),
+                    step,
+                );
+            },
+        );
+        trace
+    }
+}
+
+impl<H: ElementHasher> Prover for RpoSignatureProver<H>
+where
+    H: ElementHasher<BaseField = BaseElement> + Sync,
+{
+    type BaseField = BaseElement;
+    type Air = RescueAir;
+    type Trace = TraceTable<BaseElement>;
+    type HashFn = H;
+    type VC = MerkleTree<H>;
+    type RandomCoin = DefaultRandomCoin<Self::HashFn>;
+    type TraceLde<E: FieldElement<BaseField = Self::BaseField>> =
+        DefaultTraceLde<E, Self::HashFn, Self::VC>;
+    type ConstraintEvaluator<'a, E: FieldElement<BaseField = Self::BaseField>> =
+        DefaultConstraintEvaluator<'a, Self::Air, E>;
+
+    fn get_pub_inputs(&self, trace: &Self::Trace) -> PublicInputs {
+        let last_step = trace.length() - 1;
+        let source = trace.info().meta();
+        let msg = <Word>::read_from_bytes(source).expect("the message should be a Word");
+        PublicInputs {
+            pub_key: [
+                trace.get(4, last_step),
+                trace.get(5, last_step),
+                trace.get(6, last_step),
+                trace.get(7, last_step),
+            ],
+            msg,
+        }
+    }
+
+    fn options(&self) -> &ProofOptions {
+        &self.options
+    }
+
+    fn new_trace_lde<E: FieldElement<BaseField = Self::BaseField>>(
+        &self,
+        trace_info: &TraceInfo,
+        main_trace: &ColMatrix<Self::BaseField>,
+        domain: &StarkDomain<Self::BaseField>,
+        partition_option: PartitionOptions,
+    ) -> (Self::TraceLde<E>, TracePolyTable<E>) {
+        DefaultTraceLde::new(trace_info, main_trace, domain, partition_option)
+    }
+
+    fn new_evaluator<'a, E: FieldElement<BaseField = Self::BaseField>>(
+        &self,
+        air: &'a Self::Air,
+        aux_rand_elements: Option<AuxRandElements<E>>,
+        composition_coefficients: ConstraintCompositionCoefficients<E>,
+    ) -> Self::ConstraintEvaluator<'a, E> {
+        DefaultConstraintEvaluator::new(air, aux_rand_elements, composition_coefficients)
+    }
+}

--- a/src/hash/mod.rs
+++ b/src/hash/mod.rs
@@ -6,7 +6,10 @@ pub mod blake;
 
 mod rescue;
 pub mod rpo {
-    pub use super::rescue::{Rpo256, RpoDigest, RpoDigestError};
+    pub use super::rescue::{
+        Rpo256, RpoDigest, RpoDigestError, ARK1, ARK2, DIGEST_RANGE, DIGEST_SIZE, MDS, NUM_ROUNDS,
+        STATE_WIDTH,
+    };
 }
 
 pub mod rpx {

--- a/src/hash/rescue/mod.rs
+++ b/src/hash/rescue/mod.rs
@@ -6,7 +6,7 @@ mod arch;
 pub use arch::optimized::{add_constants_and_apply_inv_sbox, add_constants_and_apply_sbox};
 
 mod mds;
-use mds::{apply_mds, MDS};
+pub use mds::{apply_mds, MDS};
 
 mod rpo;
 pub use rpo::{Rpo256, RpoDigest, RpoDigestError};
@@ -22,11 +22,11 @@ mod tests;
 
 /// The number of rounds is set to 7. For the RPO hash functions all rounds are uniform. For the
 /// RPX hash function, there are 3 different types of rounds.
-const NUM_ROUNDS: usize = 7;
+pub const NUM_ROUNDS: usize = 7;
 
 /// Sponge state is set to 12 field elements or 96 bytes; 8 elements are reserved for rate and
 /// the remaining 4 elements are reserved for capacity.
-const STATE_WIDTH: usize = 12;
+pub const STATE_WIDTH: usize = 12;
 
 /// The rate portion of the state is located in elements 4 through 11.
 const RATE_RANGE: Range<usize> = 4..12;
@@ -42,8 +42,8 @@ const CAPACITY_RANGE: Range<usize> = 0..4;
 ///
 /// The digest is returned from state elements 4, 5, 6, and 7 (the first four elements of the
 /// rate portion).
-const DIGEST_RANGE: Range<usize> = 4..8;
-const DIGEST_SIZE: usize = DIGEST_RANGE.end - DIGEST_RANGE.start;
+pub const DIGEST_RANGE: Range<usize> = 4..8;
+pub const DIGEST_SIZE: usize = DIGEST_RANGE.end - DIGEST_RANGE.start;
 
 /// The number of bytes needed to encoded a digest
 const DIGEST_BYTES: usize = 32;
@@ -83,7 +83,7 @@ fn apply_sbox(state: &mut [Felt; STATE_WIDTH]) {
 // ================================================================================================
 
 #[inline(always)]
-fn apply_inv_sbox(state: &mut [Felt; STATE_WIDTH]) {
+pub fn apply_inv_sbox(state: &mut [Felt; STATE_WIDTH]) {
     // compute base^10540996611094048183 using 72 multiplications per array element
     // 10540996611094048183 = b1001001001001001001001001001000110110110110110110110110110110111
 
@@ -132,7 +132,7 @@ fn apply_inv_sbox(state: &mut [Felt; STATE_WIDTH]) {
 }
 
 #[inline(always)]
-fn add_constants(state: &mut [Felt; STATE_WIDTH], ark: &[Felt; STATE_WIDTH]) {
+pub fn add_constants(state: &mut [Felt; STATE_WIDTH], ark: &[Felt; STATE_WIDTH]) {
     state.iter_mut().zip(ark).for_each(|(s, &k)| *s += k);
 }
 
@@ -144,7 +144,7 @@ fn add_constants(state: &mut [Felt; STATE_WIDTH], ark: &[Felt; STATE_WIDTH]) {
 ///
 /// The constants are broken up into two arrays ARK1 and ARK2; ARK1 contains the constants for the
 /// first half of RPO round, and ARK2 contains constants for the second half of RPO round.
-const ARK1: [[Felt; STATE_WIDTH]; NUM_ROUNDS] = [
+pub const ARK1: [[Felt; STATE_WIDTH]; NUM_ROUNDS] = [
     [
         Felt::new(5789762306288267392),
         Felt::new(6522564764413701783),
@@ -245,7 +245,7 @@ const ARK1: [[Felt; STATE_WIDTH]; NUM_ROUNDS] = [
     ],
 ];
 
-const ARK2: [[Felt; STATE_WIDTH]; NUM_ROUNDS] = [
+pub const ARK2: [[Felt; STATE_WIDTH]; NUM_ROUNDS] = [
     [
         Felt::new(6077062762357204287),
         Felt::new(15277620170502011191),


### PR DESCRIPTION
## Describe your changes
Implements a STARK-based signature scheme using RPO permutation as a hard-relation as described [here](https://eprint.iacr.org/2024/1553.pdf).
Putting it in draft until zero-knowledge support is enabled in Winterfell.

## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
