### PR TITLE
Skip using the field element containing the proof-of-work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.11.0 (2024-10-30)
 
 - [BREAKING] Updated Winterfell dependency to v0.10 (#338).
+- Fixed a bug in the implementation of `draw_integers` for `RpoRandomCoin` (#343).
 
 ## 0.11.0 (2024-10-17)
 

--- a/src/rand/rpo.rs
+++ b/src/rand/rpo.rs
@@ -145,7 +145,9 @@ impl RandomCoin for RpoRandomCoin {
         self.state[RATE_START] += nonce;
         Rpo256::apply_permutation(&mut self.state);
 
-        // reset the buffer and skip the element containing the proof-of-work
+        // reset the buffer and move the next random element pointer to the second rate element.
+        // this is done as the first rate element will be "biased" via the provided `nonce` to
+        // contain some number of leading zeros.
         self.current = RATE_START + 1;
 
         // determine how many bits are needed to represent valid values in the domain

--- a/src/rand/rpo.rs
+++ b/src/rand/rpo.rs
@@ -145,8 +145,8 @@ impl RandomCoin for RpoRandomCoin {
         self.state[RATE_START] += nonce;
         Rpo256::apply_permutation(&mut self.state);
 
-        // reset the buffer
-        self.current = RATE_START;
+        // reset the buffer and skip the element containing the proof-of-work
+        self.current = RATE_START + 1;
 
         // determine how many bits are needed to represent valid values in the domain
         let v_mask = (domain_size - 1) as u64;


### PR DESCRIPTION
## Describe your changes
Fixes a bug where we used the element containing the all zero prefix to sample query indices. The previous implementation always sampled index 0.

## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
