### PR TITLE
Refactor error messages and use `thiserror` to derive errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
-## 0.11.0 (2024-10-30)
+## 0.13.0 (TBD)
+
+- Fixed a bug in the implementation of `draw_integers` for `RpoRandomCoin` (#343).
+- [BREAKING] Refactor error messages and use `thiserror` to derive errors (#344).
+
+## 0.12.0 (2024-10-30)
 
 - [BREAKING] Updated Winterfell dependency to v0.10 (#338).
-- Fixed a bug in the implementation of `draw_integers` for `RpoRandomCoin` (#343).
 
 ## 0.11.0 (2024-10-17)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,6 +79,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "assert_matches"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -521,6 +527,7 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 name = "miden-crypto"
 version = "0.12.0"
 dependencies = [
+ "assert_matches",
  "blake3",
  "cc",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -537,6 +537,7 @@ dependencies = [
  "seq-macro",
  "serde",
  "sha3",
+ "thiserror",
  "winter-crypto",
  "winter-math",
  "winter-rand-utils",
@@ -668,9 +669,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.89"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
+checksum = "307e3004becf10f5a6e0d59d20f3cd28231b0e0827a96cd3e0ce6d14bc1e4bb3"
 dependencies = [
  "unicode-ident",
 ]
@@ -900,9 +901,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.85"
+version = "2.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5023162dfcd14ef8f32034d8bcd4cc5ddc61ef7a247c024a33e24e1f24d21b56"
+checksum = "44d46482f1c1c87acd84dea20c1bf5ebff4c757009ed6bf19cfd36fb10e92c4e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -920,6 +921,26 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c006c85c7651b3cf2ada4584faa36773bd07bac24acfb39f3c431b36d7e667aa"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f077553d607adc1caf65430528a576c757a71ed73944b66ebb58ef2bbd243568"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ rand_core = { version = "0.6", default-features = false }
 rand-utils = { version = "0.10", package = "winter-rand-utils", optional = true }
 serde = { version = "1.0", default-features = false, optional = true, features = ["derive"] }
 sha3 = { version = "0.10", default-features = false }
+thiserror = { version = "2.0", default-features = false }
 winter-crypto = { version = "0.10", default-features = false }
 winter-math = { version = "0.10", default-features = false }
 winter-utils = { version = "0.10", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ winter-math = { version = "0.10", default-features = false }
 winter-utils = { version = "0.10", default-features = false }
 
 [dev-dependencies]
+assert_matches = { version = "1.5.0", default-features = false }
 criterion = { version = "0.5", features = ["html_reports"] }
 getrandom = { version = "0.2", features = ["js"] }
 hex = { version = "0.4", default-features = false, features = ["alloc"] }

--- a/src/hash/rescue/rpo/digest.rs
+++ b/src/hash/rescue/rpo/digest.rs
@@ -1,6 +1,8 @@
 use alloc::string::String;
 use core::{cmp::Ordering, fmt::Display, ops::Deref, slice};
 
+use thiserror::Error;
+
 use super::{Digest, Felt, StarkField, DIGEST_BYTES, DIGEST_SIZE, ZERO};
 use crate::{
     rand::Randomizable,
@@ -127,9 +129,12 @@ impl Randomizable for RpoDigest {
 // CONVERSIONS: FROM RPO DIGEST
 // ================================================================================================
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Debug, Error)]
 pub enum RpoDigestError {
-    InvalidInteger,
+    #[error("failed to convert digest field element to {0}")]
+    TypeConversion(&'static str),
+    #[error("failed to convert to field element: {0}")]
+    InvalidFieldElement(String),
 }
 
 impl TryFrom<&RpoDigest> for [bool; DIGEST_SIZE] {
@@ -153,10 +158,10 @@ impl TryFrom<RpoDigest> for [bool; DIGEST_SIZE] {
         }
 
         Ok([
-            to_bool(value.0[0].as_int()).ok_or(RpoDigestError::InvalidInteger)?,
-            to_bool(value.0[1].as_int()).ok_or(RpoDigestError::InvalidInteger)?,
-            to_bool(value.0[2].as_int()).ok_or(RpoDigestError::InvalidInteger)?,
-            to_bool(value.0[3].as_int()).ok_or(RpoDigestError::InvalidInteger)?,
+            to_bool(value.0[0].as_int()).ok_or(RpoDigestError::TypeConversion("bool"))?,
+            to_bool(value.0[1].as_int()).ok_or(RpoDigestError::TypeConversion("bool"))?,
+            to_bool(value.0[2].as_int()).ok_or(RpoDigestError::TypeConversion("bool"))?,
+            to_bool(value.0[3].as_int()).ok_or(RpoDigestError::TypeConversion("bool"))?,
         ])
     }
 }
@@ -174,10 +179,22 @@ impl TryFrom<RpoDigest> for [u8; DIGEST_SIZE] {
 
     fn try_from(value: RpoDigest) -> Result<Self, Self::Error> {
         Ok([
-            value.0[0].as_int().try_into().map_err(|_| RpoDigestError::InvalidInteger)?,
-            value.0[1].as_int().try_into().map_err(|_| RpoDigestError::InvalidInteger)?,
-            value.0[2].as_int().try_into().map_err(|_| RpoDigestError::InvalidInteger)?,
-            value.0[3].as_int().try_into().map_err(|_| RpoDigestError::InvalidInteger)?,
+            value.0[0]
+                .as_int()
+                .try_into()
+                .map_err(|_| RpoDigestError::TypeConversion("u8"))?,
+            value.0[1]
+                .as_int()
+                .try_into()
+                .map_err(|_| RpoDigestError::TypeConversion("u8"))?,
+            value.0[2]
+                .as_int()
+                .try_into()
+                .map_err(|_| RpoDigestError::TypeConversion("u8"))?,
+            value.0[3]
+                .as_int()
+                .try_into()
+                .map_err(|_| RpoDigestError::TypeConversion("u8"))?,
         ])
     }
 }
@@ -195,10 +212,22 @@ impl TryFrom<RpoDigest> for [u16; DIGEST_SIZE] {
 
     fn try_from(value: RpoDigest) -> Result<Self, Self::Error> {
         Ok([
-            value.0[0].as_int().try_into().map_err(|_| RpoDigestError::InvalidInteger)?,
-            value.0[1].as_int().try_into().map_err(|_| RpoDigestError::InvalidInteger)?,
-            value.0[2].as_int().try_into().map_err(|_| RpoDigestError::InvalidInteger)?,
-            value.0[3].as_int().try_into().map_err(|_| RpoDigestError::InvalidInteger)?,
+            value.0[0]
+                .as_int()
+                .try_into()
+                .map_err(|_| RpoDigestError::TypeConversion("u16"))?,
+            value.0[1]
+                .as_int()
+                .try_into()
+                .map_err(|_| RpoDigestError::TypeConversion("u16"))?,
+            value.0[2]
+                .as_int()
+                .try_into()
+                .map_err(|_| RpoDigestError::TypeConversion("u16"))?,
+            value.0[3]
+                .as_int()
+                .try_into()
+                .map_err(|_| RpoDigestError::TypeConversion("u16"))?,
         ])
     }
 }
@@ -216,10 +245,22 @@ impl TryFrom<RpoDigest> for [u32; DIGEST_SIZE] {
 
     fn try_from(value: RpoDigest) -> Result<Self, Self::Error> {
         Ok([
-            value.0[0].as_int().try_into().map_err(|_| RpoDigestError::InvalidInteger)?,
-            value.0[1].as_int().try_into().map_err(|_| RpoDigestError::InvalidInteger)?,
-            value.0[2].as_int().try_into().map_err(|_| RpoDigestError::InvalidInteger)?,
-            value.0[3].as_int().try_into().map_err(|_| RpoDigestError::InvalidInteger)?,
+            value.0[0]
+                .as_int()
+                .try_into()
+                .map_err(|_| RpoDigestError::TypeConversion("u32"))?,
+            value.0[1]
+                .as_int()
+                .try_into()
+                .map_err(|_| RpoDigestError::TypeConversion("u32"))?,
+            value.0[2]
+                .as_int()
+                .try_into()
+                .map_err(|_| RpoDigestError::TypeConversion("u32"))?,
+            value.0[3]
+                .as_int()
+                .try_into()
+                .map_err(|_| RpoDigestError::TypeConversion("u32"))?,
         ])
     }
 }
@@ -343,10 +384,10 @@ impl TryFrom<[u64; DIGEST_SIZE]> for RpoDigest {
 
     fn try_from(value: [u64; DIGEST_SIZE]) -> Result<Self, RpoDigestError> {
         Ok(Self([
-            value[0].try_into().map_err(|_| RpoDigestError::InvalidInteger)?,
-            value[1].try_into().map_err(|_| RpoDigestError::InvalidInteger)?,
-            value[2].try_into().map_err(|_| RpoDigestError::InvalidInteger)?,
-            value[3].try_into().map_err(|_| RpoDigestError::InvalidInteger)?,
+            value[0].try_into().map_err(RpoDigestError::InvalidFieldElement)?,
+            value[1].try_into().map_err(RpoDigestError::InvalidFieldElement)?,
+            value[2].try_into().map_err(RpoDigestError::InvalidFieldElement)?,
+            value[3].try_into().map_err(RpoDigestError::InvalidFieldElement)?,
         ]))
     }
 }

--- a/src/hash/rescue/rpx/digest.rs
+++ b/src/hash/rescue/rpx/digest.rs
@@ -1,6 +1,8 @@
 use alloc::string::String;
 use core::{cmp::Ordering, fmt::Display, ops::Deref, slice};
 
+use thiserror::Error;
+
 use super::{Digest, Felt, StarkField, DIGEST_BYTES, DIGEST_SIZE, ZERO};
 use crate::{
     rand::Randomizable,
@@ -127,9 +129,12 @@ impl Randomizable for RpxDigest {
 // CONVERSIONS: FROM RPX DIGEST
 // ================================================================================================
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Debug, Error)]
 pub enum RpxDigestError {
-    InvalidInteger,
+    #[error("failed to convert digest field element to {0}")]
+    TypeConversion(&'static str),
+    #[error("failed to convert to field element: {0}")]
+    InvalidFieldElement(String),
 }
 
 impl TryFrom<&RpxDigest> for [bool; DIGEST_SIZE] {
@@ -153,10 +158,10 @@ impl TryFrom<RpxDigest> for [bool; DIGEST_SIZE] {
         }
 
         Ok([
-            to_bool(value.0[0].as_int()).ok_or(RpxDigestError::InvalidInteger)?,
-            to_bool(value.0[1].as_int()).ok_or(RpxDigestError::InvalidInteger)?,
-            to_bool(value.0[2].as_int()).ok_or(RpxDigestError::InvalidInteger)?,
-            to_bool(value.0[3].as_int()).ok_or(RpxDigestError::InvalidInteger)?,
+            to_bool(value.0[0].as_int()).ok_or(RpxDigestError::TypeConversion("bool"))?,
+            to_bool(value.0[1].as_int()).ok_or(RpxDigestError::TypeConversion("bool"))?,
+            to_bool(value.0[2].as_int()).ok_or(RpxDigestError::TypeConversion("bool"))?,
+            to_bool(value.0[3].as_int()).ok_or(RpxDigestError::TypeConversion("bool"))?,
         ])
     }
 }
@@ -174,10 +179,22 @@ impl TryFrom<RpxDigest> for [u8; DIGEST_SIZE] {
 
     fn try_from(value: RpxDigest) -> Result<Self, Self::Error> {
         Ok([
-            value.0[0].as_int().try_into().map_err(|_| RpxDigestError::InvalidInteger)?,
-            value.0[1].as_int().try_into().map_err(|_| RpxDigestError::InvalidInteger)?,
-            value.0[2].as_int().try_into().map_err(|_| RpxDigestError::InvalidInteger)?,
-            value.0[3].as_int().try_into().map_err(|_| RpxDigestError::InvalidInteger)?,
+            value.0[0]
+                .as_int()
+                .try_into()
+                .map_err(|_| RpxDigestError::TypeConversion("u8"))?,
+            value.0[1]
+                .as_int()
+                .try_into()
+                .map_err(|_| RpxDigestError::TypeConversion("u8"))?,
+            value.0[2]
+                .as_int()
+                .try_into()
+                .map_err(|_| RpxDigestError::TypeConversion("u8"))?,
+            value.0[3]
+                .as_int()
+                .try_into()
+                .map_err(|_| RpxDigestError::TypeConversion("u8"))?,
         ])
     }
 }
@@ -195,10 +212,22 @@ impl TryFrom<RpxDigest> for [u16; DIGEST_SIZE] {
 
     fn try_from(value: RpxDigest) -> Result<Self, Self::Error> {
         Ok([
-            value.0[0].as_int().try_into().map_err(|_| RpxDigestError::InvalidInteger)?,
-            value.0[1].as_int().try_into().map_err(|_| RpxDigestError::InvalidInteger)?,
-            value.0[2].as_int().try_into().map_err(|_| RpxDigestError::InvalidInteger)?,
-            value.0[3].as_int().try_into().map_err(|_| RpxDigestError::InvalidInteger)?,
+            value.0[0]
+                .as_int()
+                .try_into()
+                .map_err(|_| RpxDigestError::TypeConversion("u16"))?,
+            value.0[1]
+                .as_int()
+                .try_into()
+                .map_err(|_| RpxDigestError::TypeConversion("u16"))?,
+            value.0[2]
+                .as_int()
+                .try_into()
+                .map_err(|_| RpxDigestError::TypeConversion("u16"))?,
+            value.0[3]
+                .as_int()
+                .try_into()
+                .map_err(|_| RpxDigestError::TypeConversion("u16"))?,
         ])
     }
 }
@@ -216,10 +245,22 @@ impl TryFrom<RpxDigest> for [u32; DIGEST_SIZE] {
 
     fn try_from(value: RpxDigest) -> Result<Self, Self::Error> {
         Ok([
-            value.0[0].as_int().try_into().map_err(|_| RpxDigestError::InvalidInteger)?,
-            value.0[1].as_int().try_into().map_err(|_| RpxDigestError::InvalidInteger)?,
-            value.0[2].as_int().try_into().map_err(|_| RpxDigestError::InvalidInteger)?,
-            value.0[3].as_int().try_into().map_err(|_| RpxDigestError::InvalidInteger)?,
+            value.0[0]
+                .as_int()
+                .try_into()
+                .map_err(|_| RpxDigestError::TypeConversion("u32"))?,
+            value.0[1]
+                .as_int()
+                .try_into()
+                .map_err(|_| RpxDigestError::TypeConversion("u32"))?,
+            value.0[2]
+                .as_int()
+                .try_into()
+                .map_err(|_| RpxDigestError::TypeConversion("u32"))?,
+            value.0[3]
+                .as_int()
+                .try_into()
+                .map_err(|_| RpxDigestError::TypeConversion("u32"))?,
         ])
     }
 }
@@ -343,10 +384,10 @@ impl TryFrom<[u64; DIGEST_SIZE]> for RpxDigest {
 
     fn try_from(value: [u64; DIGEST_SIZE]) -> Result<Self, RpxDigestError> {
         Ok(Self([
-            value[0].try_into().map_err(|_| RpxDigestError::InvalidInteger)?,
-            value[1].try_into().map_err(|_| RpxDigestError::InvalidInteger)?,
-            value[2].try_into().map_err(|_| RpxDigestError::InvalidInteger)?,
-            value[3].try_into().map_err(|_| RpxDigestError::InvalidInteger)?,
+            value[0].try_into().map_err(RpxDigestError::InvalidFieldElement)?,
+            value[1].try_into().map_err(RpxDigestError::InvalidFieldElement)?,
+            value[2].try_into().map_err(RpxDigestError::InvalidFieldElement)?,
+            value[3].try_into().map_err(RpxDigestError::InvalidFieldElement)?,
         ]))
     }
 }

--- a/src/merkle/error.rs
+++ b/src/merkle/error.rs
@@ -1,65 +1,34 @@
-use alloc::vec::Vec;
-use core::fmt;
+use thiserror::Error;
 
-use super::{smt::SmtLeafError, MerklePath, NodeIndex, RpoDigest};
+use super::{NodeIndex, RpoDigest};
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Debug, Error)]
 pub enum MerkleError {
-    ConflictingRoots(Vec<RpoDigest>),
+    #[error("expected merkle root {expected_root} found {actual_root}")]
+    ConflictingRoots {
+        expected_root: RpoDigest,
+        actual_root: RpoDigest,
+    },
+    #[error("provided merkle tree depth {0} is too small")]
     DepthTooSmall(u8),
+    #[error("provided merkle tree depth {0} is too big")]
     DepthTooBig(u64),
+    #[error("multiple values provided for merkle tree index {0}")]
     DuplicateValuesForIndex(u64),
-    DuplicateValuesForKey(RpoDigest),
-    InvalidIndex { depth: u8, value: u64 },
-    InvalidDepth { expected: u8, provided: u8 },
-    InvalidSubtreeDepth { subtree_depth: u8, tree_depth: u8 },
-    InvalidPath(MerklePath),
-    InvalidNumEntries(usize),
-    NodeNotInSet(NodeIndex),
-    NodeNotInStore(RpoDigest, NodeIndex),
+    #[error("node index value {value} is not valid for depth {depth}")]
+    InvalidNodeIndex { depth: u8, value: u64 },
+    #[error("provided node index depth {provided} does not match expected depth {expected}")]
+    InvalidNodeIndexDepth { expected: u8, provided: u8 },
+    #[error("merkle subtree depth {subtree_depth} exceeds merkle tree depth {tree_depth}")]
+    SubtreeDepthExceedsDepth { subtree_depth: u8, tree_depth: u8 },
+    #[error("number of entries in the merkle tree exceeds the maximum of {0}")]
+    TooManyEntries(usize),
+    #[error("node index `{0}` not found in the tree")]
+    NodeIndexNotFoundInTree(NodeIndex),
+    #[error("node {0:?} with index `{1}` not found in the store")]
+    NodeIndexNotFoundInStore(RpoDigest, NodeIndex),
+    #[error("number of provided merkle tree leaves {0} is not a power of two")]
     NumLeavesNotPowerOfTwo(usize),
+    #[error("root {0:?} is not in the store")]
     RootNotInStore(RpoDigest),
-    SmtLeaf(SmtLeafError),
-}
-
-impl fmt::Display for MerkleError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        use MerkleError::*;
-        match self {
-            ConflictingRoots(roots) => write!(f, "the merkle paths roots do not match {roots:?}"),
-            DepthTooSmall(depth) => write!(f, "the provided depth {depth} is too small"),
-            DepthTooBig(depth) => write!(f, "the provided depth {depth} is too big"),
-            DuplicateValuesForIndex(key) => write!(f, "multiple values provided for key {key}"),
-            DuplicateValuesForKey(key) => write!(f, "multiple values provided for key {key}"),
-            InvalidIndex { depth, value } => {
-                write!(f, "the index value {value} is not valid for the depth {depth}")
-            },
-            InvalidDepth { expected, provided } => {
-                write!(f, "the provided depth {provided} is not valid for {expected}")
-            },
-            InvalidSubtreeDepth { subtree_depth, tree_depth } => {
-                write!(f, "tried inserting a subtree of depth {subtree_depth} into a tree of depth {tree_depth}")
-            },
-            InvalidPath(_path) => write!(f, "the provided path is not valid"),
-            InvalidNumEntries(max) => write!(f, "number of entries exceeded the maximum: {max}"),
-            NodeNotInSet(index) => write!(f, "the node with index ({index}) is not in the set"),
-            NodeNotInStore(hash, index) => {
-                write!(f, "the node {hash:?} with index ({index}) is not in the store")
-            },
-            NumLeavesNotPowerOfTwo(leaves) => {
-                write!(f, "the leaves count {leaves} is not a power of 2")
-            },
-            RootNotInStore(root) => write!(f, "the root {:?} is not in the store", root),
-            SmtLeaf(smt_leaf_error) => write!(f, "smt leaf error: {smt_leaf_error}"),
-        }
-    }
-}
-
-#[cfg(feature = "std")]
-impl std::error::Error for MerkleError {}
-
-impl From<SmtLeafError> for MerkleError {
-    fn from(value: SmtLeafError) -> Self {
-        Self::SmtLeaf(value)
-    }
 }

--- a/src/merkle/index.rs
+++ b/src/merkle/index.rs
@@ -38,7 +38,7 @@ impl NodeIndex {
     /// Returns an error if the `value` is greater than or equal to 2^{depth}.
     pub const fn new(depth: u8, value: u64) -> Result<Self, MerkleError> {
         if (64 - value.leading_zeros()) > depth as u32 {
-            Err(MerkleError::InvalidIndex { depth, value })
+            Err(MerkleError::InvalidNodeIndex { depth, value })
         } else {
             Ok(Self { depth, value })
         }
@@ -182,6 +182,7 @@ impl Deserializable for NodeIndex {
 
 #[cfg(test)]
 mod tests {
+    use assert_matches::assert_matches;
     use proptest::prelude::*;
 
     use super::*;
@@ -190,19 +191,19 @@ mod tests {
     fn test_node_index_value_too_high() {
         assert_eq!(NodeIndex::new(0, 0).unwrap(), NodeIndex { depth: 0, value: 0 });
         let err = NodeIndex::new(0, 1).unwrap_err();
-        assert_eq!(err, MerkleError::InvalidIndex { depth: 0, value: 1 });
+        assert_matches!(err, MerkleError::InvalidNodeIndex { depth: 0, value: 1 });
 
         assert_eq!(NodeIndex::new(1, 1).unwrap(), NodeIndex { depth: 1, value: 1 });
         let err = NodeIndex::new(1, 2).unwrap_err();
-        assert_eq!(err, MerkleError::InvalidIndex { depth: 1, value: 2 });
+        assert_matches!(err, MerkleError::InvalidNodeIndex { depth: 1, value: 2 });
 
         assert_eq!(NodeIndex::new(2, 3).unwrap(), NodeIndex { depth: 2, value: 3 });
         let err = NodeIndex::new(2, 4).unwrap_err();
-        assert_eq!(err, MerkleError::InvalidIndex { depth: 2, value: 4 });
+        assert_matches!(err, MerkleError::InvalidNodeIndex { depth: 2, value: 4 });
 
         assert_eq!(NodeIndex::new(3, 7).unwrap(), NodeIndex { depth: 3, value: 7 });
         let err = NodeIndex::new(3, 8).unwrap_err();
-        assert_eq!(err, MerkleError::InvalidIndex { depth: 3, value: 8 });
+        assert_matches!(err, MerkleError::InvalidNodeIndex { depth: 3, value: 8 });
     }
 
     #[test]

--- a/src/merkle/mmr/error.rs
+++ b/src/merkle/mmr/error.rs
@@ -1,41 +1,27 @@
-use core::fmt::{Display, Formatter};
-#[cfg(feature = "std")]
-use std::error::Error;
+use alloc::string::String;
+
+use thiserror::Error;
 
 use crate::merkle::MerkleError;
 
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub enum MmrError {
-    InvalidPosition(usize),
-    InvalidPeaks,
-    InvalidPeak,
-    PeakOutOfBounds(usize, usize),
+    #[error("mmr does not contain position {0}")]
+    PositionNotFound(usize),
+    #[error("mmr peaks are invalid: {0}")]
+    InvalidPeaks(String),
+    #[error(
+        "mmr peak does not match the computed merkle root of the provided authentication path"
+    )]
+    PeakPathMismatch,
+    #[error("requested peak index is {peak_idx} but the number of peaks is {peaks_len}")]
+    PeakOutOfBounds { peak_idx: usize, peaks_len: usize },
+    #[error("invalid mmr update")]
     InvalidUpdate,
-    UnknownPeak,
-    MerkleError(MerkleError),
+    #[error("mmr does not contain a peak with depth {0}")]
+    UnknownPeak(u8),
+    #[error("invalid merkle path")]
+    InvalidMerklePath(#[source] MerkleError),
+    #[error("merkle root computation failed")]
+    MerkleRootComputationFailed(#[source] MerkleError),
 }
-
-impl Display for MmrError {
-    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), core::fmt::Error> {
-        match self {
-            MmrError::InvalidPosition(pos) => write!(fmt, "Mmr does not contain position {pos}"),
-            MmrError::InvalidPeaks => write!(fmt, "Invalid peaks count"),
-            MmrError::InvalidPeak => {
-                write!(fmt, "Peak values does not match merkle path computed root")
-            },
-            MmrError::PeakOutOfBounds(peak_idx, peaks_len) => write!(
-                fmt,
-                "Requested peak index is {} but the number of peaks is {}",
-                peak_idx, peaks_len
-            ),
-            MmrError::InvalidUpdate => write!(fmt, "Invalid Mmr update"),
-            MmrError::UnknownPeak => {
-                write!(fmt, "Peak not in Mmr")
-            },
-            MmrError::MerkleError(err) => write!(fmt, "{}", err),
-        }
-    }
-}
-
-#[cfg(feature = "std")]
-impl Error for MmrError {}

--- a/src/merkle/mmr/error.rs
+++ b/src/merkle/mmr/error.rs
@@ -4,7 +4,7 @@ use std::error::Error;
 
 use crate::merkle::MerkleError;
 
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug)]
 pub enum MmrError {
     InvalidPosition(usize),
     InvalidPeaks,

--- a/src/merkle/mmr/peaks.rs
+++ b/src/merkle/mmr/peaks.rs
@@ -45,7 +45,11 @@ impl MmrPeaks {
     /// Returns an error if the number of leaves and the number of peaks are inconsistent.
     pub fn new(num_leaves: usize, peaks: Vec<RpoDigest>) -> Result<Self, MmrError> {
         if num_leaves.count_ones() as usize != peaks.len() {
-            return Err(MmrError::InvalidPeaks);
+            return Err(MmrError::InvalidPeaks(format!(
+                "number of one bits in leaves is {} which does not equal peak length {}",
+                num_leaves.count_ones(),
+                peaks.len()
+            )));
         }
 
         Ok(Self { num_leaves, peaks })
@@ -77,7 +81,7 @@ impl MmrPeaks {
     pub fn get_peak(&self, peak_idx: usize) -> Result<&RpoDigest, MmrError> {
         self.peaks
             .get(peak_idx)
-            .ok_or(MmrError::PeakOutOfBounds(peak_idx, self.peaks.len()))
+            .ok_or(MmrError::PeakOutOfBounds { peak_idx, peaks_len: self.peaks.len() })
     }
 
     /// Converts this [MmrPeaks] into its components: number of leaves and a vector of peaks of
@@ -106,7 +110,7 @@ impl MmrPeaks {
         opening
             .merkle_path
             .verify(opening.relative_pos() as u64, value, root)
-            .map_err(MmrError::MerkleError)
+            .map_err(MmrError::InvalidMerklePath)
     }
 
     /// Flattens and pads the peaks to make hashing inside of the Miden VM easier.

--- a/src/merkle/path.rs
+++ b/src/merkle/path.rs
@@ -61,7 +61,10 @@ impl MerklePath {
     pub fn verify(&self, index: u64, node: RpoDigest, root: &RpoDigest) -> Result<(), MerkleError> {
         let computed_root = self.compute_root(index, node)?;
         if &computed_root != root {
-            return Err(MerkleError::ConflictingRoots(vec![computed_root, *root]));
+            return Err(MerkleError::ConflictingRoots {
+                expected_root: *root,
+                actual_root: computed_root,
+            });
         }
 
         Ok(())

--- a/src/merkle/smt/full/proof.rs
+++ b/src/merkle/smt/full/proof.rs
@@ -25,7 +25,7 @@ impl SmtProof {
     pub fn new(path: MerklePath, leaf: SmtLeaf) -> Result<Self, SmtProofError> {
         let depth: usize = SMT_DEPTH.into();
         if path.len() != depth {
-            return Err(SmtProofError::InvalidPathLength(path.len()));
+            return Err(SmtProofError::InvalidMerklePathLength(path.len()));
         }
 
         Ok(Self { path, leaf })

--- a/src/merkle/smt/mod.rs
+++ b/src/merkle/smt/mod.rs
@@ -267,7 +267,10 @@ pub(crate) trait SparseMerkleTree<const DEPTH: u8> {
         // Guard against accidentally trying to apply mutations that were computed against a
         // different tree, including a stale version of this tree.
         if old_root != self.root() {
-            return Err(MerkleError::ConflictingRoots(vec![old_root, self.root()]));
+            return Err(MerkleError::ConflictingRoots {
+                expected_root: self.root(),
+                actual_root: old_root,
+            });
         }
 
         for (index, mutation) in node_mutations {
@@ -403,7 +406,7 @@ impl<const DEPTH: u8> TryFrom<NodeIndex> for LeafIndex<DEPTH> {
 
     fn try_from(node_index: NodeIndex) -> Result<Self, Self::Error> {
         if node_index.depth() != DEPTH {
-            return Err(MerkleError::InvalidDepth {
+            return Err(MerkleError::InvalidNodeIndexDepth {
                 expected: DEPTH,
                 provided: node_index.depth(),
             });

--- a/src/merkle/smt/simple/mod.rs
+++ b/src/merkle/smt/simple/mod.rs
@@ -81,7 +81,7 @@ impl<const DEPTH: u8> SimpleSmt<DEPTH> {
 
         for (idx, (key, value)) in entries.into_iter().enumerate() {
             if idx >= max_num_entries {
-                return Err(MerkleError::InvalidNumEntries(max_num_entries));
+                return Err(MerkleError::TooManyEntries(max_num_entries));
             }
 
             let old_value = tree.insert(LeafIndex::<DEPTH>::new(key)?, value);
@@ -246,7 +246,7 @@ impl<const DEPTH: u8> SimpleSmt<DEPTH> {
         subtree: SimpleSmt<SUBTREE_DEPTH>,
     ) -> Result<RpoDigest, MerkleError> {
         if SUBTREE_DEPTH > DEPTH {
-            return Err(MerkleError::InvalidSubtreeDepth {
+            return Err(MerkleError::SubtreeDepthExceedsDepth {
                 subtree_depth: SUBTREE_DEPTH,
                 tree_depth: DEPTH,
             });

--- a/src/merkle/smt/simple/tests.rs
+++ b/src/merkle/smt/simple/tests.rs
@@ -1,5 +1,7 @@
 use alloc::vec::Vec;
 
+use assert_matches::assert_matches;
+
 use super::{
     super::{MerkleError, RpoDigest, SimpleSmt},
     NodeIndex,
@@ -257,12 +259,12 @@ fn test_simplesmt_fail_on_duplicates() {
         // consecutive
         let entries = [(1, *first), (1, *second)];
         let smt = SimpleSmt::<64>::with_leaves(entries);
-        assert_eq!(smt.unwrap_err(), MerkleError::DuplicateValuesForIndex(1));
+        assert_matches!(smt.unwrap_err(), MerkleError::DuplicateValuesForIndex(1));
 
         // not consecutive
         let entries = [(1, *first), (5, int_to_leaf(5)), (1, *second)];
         let smt = SimpleSmt::<64>::with_leaves(entries);
-        assert_eq!(smt.unwrap_err(), MerkleError::DuplicateValuesForIndex(1));
+        assert_matches!(smt.unwrap_err(), MerkleError::DuplicateValuesForIndex(1));
     }
 }
 

--- a/src/merkle/store/mod.rs
+++ b/src/merkle/store/mod.rs
@@ -136,7 +136,10 @@ impl<T: KvMap<RpoDigest, StoreNode>> MerkleStore<T> {
         self.nodes.get(&hash).ok_or(MerkleError::RootNotInStore(hash))?;
 
         for i in (0..index.depth()).rev() {
-            let node = self.nodes.get(&hash).ok_or(MerkleError::NodeNotInStore(hash, index))?;
+            let node = self
+                .nodes
+                .get(&hash)
+                .ok_or(MerkleError::NodeIndexNotFoundInStore(hash, index))?;
 
             let bit = (index.value() >> i) & 1;
             hash = if bit == 0 { node.left } else { node.right }
@@ -162,7 +165,10 @@ impl<T: KvMap<RpoDigest, StoreNode>> MerkleStore<T> {
         self.nodes.get(&hash).ok_or(MerkleError::RootNotInStore(hash))?;
 
         for i in (0..index.depth()).rev() {
-            let node = self.nodes.get(&hash).ok_or(MerkleError::NodeNotInStore(hash, index))?;
+            let node = self
+                .nodes
+                .get(&hash)
+                .ok_or(MerkleError::NodeIndexNotFoundInStore(hash, index))?;
 
             let bit = (index.value() >> i) & 1;
             hash = if bit == 0 {

--- a/src/merkle/store/tests.rs
+++ b/src/merkle/store/tests.rs
@@ -1,3 +1,4 @@
+use assert_matches::assert_matches;
 use seq_macro::seq;
 #[cfg(feature = "std")]
 use {
@@ -42,14 +43,14 @@ const VALUES8: [RpoDigest; 8] = [
 fn test_root_not_in_store() -> Result<(), MerkleError> {
     let mtree = MerkleTree::new(digests_to_words(&VALUES4))?;
     let store = MerkleStore::from(&mtree);
-    assert_eq!(
+    assert_matches!(
         store.get_node(VALUES4[0], NodeIndex::make(mtree.depth(), 0)),
-        Err(MerkleError::RootNotInStore(VALUES4[0])),
+        Err(MerkleError::RootNotInStore(root)) if root == VALUES4[0],
         "Leaf 0 is not a root"
     );
-    assert_eq!(
+    assert_matches!(
         store.get_path(VALUES4[0], NodeIndex::make(mtree.depth(), 0)),
-        Err(MerkleError::RootNotInStore(VALUES4[0])),
+        Err(MerkleError::RootNotInStore(root)) if root == VALUES4[0],
         "Leaf 0 is not a root"
     );
 
@@ -64,46 +65,46 @@ fn test_merkle_tree() -> Result<(), MerkleError> {
     // STORE LEAVES ARE CORRECT -------------------------------------------------------------------
     // checks the leaves in the store corresponds to the expected values
     assert_eq!(
-        store.get_node(mtree.root(), NodeIndex::make(mtree.depth(), 0)),
-        Ok(VALUES4[0]),
+        store.get_node(mtree.root(), NodeIndex::make(mtree.depth(), 0)).unwrap(),
+        VALUES4[0],
         "node 0 must be in the tree"
     );
     assert_eq!(
-        store.get_node(mtree.root(), NodeIndex::make(mtree.depth(), 1)),
-        Ok(VALUES4[1]),
+        store.get_node(mtree.root(), NodeIndex::make(mtree.depth(), 1)).unwrap(),
+        VALUES4[1],
         "node 1 must be in the tree"
     );
     assert_eq!(
-        store.get_node(mtree.root(), NodeIndex::make(mtree.depth(), 2)),
-        Ok(VALUES4[2]),
+        store.get_node(mtree.root(), NodeIndex::make(mtree.depth(), 2)).unwrap(),
+        VALUES4[2],
         "node 2 must be in the tree"
     );
     assert_eq!(
-        store.get_node(mtree.root(), NodeIndex::make(mtree.depth(), 3)),
-        Ok(VALUES4[3]),
+        store.get_node(mtree.root(), NodeIndex::make(mtree.depth(), 3)).unwrap(),
+        VALUES4[3],
         "node 3 must be in the tree"
     );
 
     // STORE LEAVES MATCH TREE --------------------------------------------------------------------
     // sanity check the values returned by the store and the tree
     assert_eq!(
-        mtree.get_node(NodeIndex::make(mtree.depth(), 0)),
-        store.get_node(mtree.root(), NodeIndex::make(mtree.depth(), 0)),
+        mtree.get_node(NodeIndex::make(mtree.depth(), 0)).unwrap(),
+        store.get_node(mtree.root(), NodeIndex::make(mtree.depth(), 0)).unwrap(),
         "node 0 must be the same for both MerkleTree and MerkleStore"
     );
     assert_eq!(
-        mtree.get_node(NodeIndex::make(mtree.depth(), 1)),
-        store.get_node(mtree.root(), NodeIndex::make(mtree.depth(), 1)),
+        mtree.get_node(NodeIndex::make(mtree.depth(), 1)).unwrap(),
+        store.get_node(mtree.root(), NodeIndex::make(mtree.depth(), 1)).unwrap(),
         "node 1 must be the same for both MerkleTree and MerkleStore"
     );
     assert_eq!(
-        mtree.get_node(NodeIndex::make(mtree.depth(), 2)),
-        store.get_node(mtree.root(), NodeIndex::make(mtree.depth(), 2)),
+        mtree.get_node(NodeIndex::make(mtree.depth(), 2)).unwrap(),
+        store.get_node(mtree.root(), NodeIndex::make(mtree.depth(), 2)).unwrap(),
         "node 2 must be the same for both MerkleTree and MerkleStore"
     );
     assert_eq!(
-        mtree.get_node(NodeIndex::make(mtree.depth(), 3)),
-        store.get_node(mtree.root(), NodeIndex::make(mtree.depth(), 3)),
+        mtree.get_node(NodeIndex::make(mtree.depth(), 3)).unwrap(),
+        store.get_node(mtree.root(), NodeIndex::make(mtree.depth(), 3)).unwrap(),
         "node 3 must be the same for both MerkleTree and MerkleStore"
     );
 
@@ -115,8 +116,8 @@ fn test_merkle_tree() -> Result<(), MerkleError> {
         "Value for merkle path at index 0 must match leaf value"
     );
     assert_eq!(
-        mtree.get_path(NodeIndex::make(mtree.depth(), 0)),
-        Ok(result.path),
+        mtree.get_path(NodeIndex::make(mtree.depth(), 0)).unwrap(),
+        result.path,
         "merkle path for index 0 must be the same for the MerkleTree and MerkleStore"
     );
 
@@ -126,8 +127,8 @@ fn test_merkle_tree() -> Result<(), MerkleError> {
         "Value for merkle path at index 0 must match leaf value"
     );
     assert_eq!(
-        mtree.get_path(NodeIndex::make(mtree.depth(), 1)),
-        Ok(result.path),
+        mtree.get_path(NodeIndex::make(mtree.depth(), 1)).unwrap(),
+        result.path,
         "merkle path for index 1 must be the same for the MerkleTree and MerkleStore"
     );
 
@@ -137,8 +138,8 @@ fn test_merkle_tree() -> Result<(), MerkleError> {
         "Value for merkle path at index 0 must match leaf value"
     );
     assert_eq!(
-        mtree.get_path(NodeIndex::make(mtree.depth(), 2)),
-        Ok(result.path),
+        mtree.get_path(NodeIndex::make(mtree.depth(), 2)).unwrap(),
+        result.path,
         "merkle path for index 0 must be the same for the MerkleTree and MerkleStore"
     );
 
@@ -148,8 +149,8 @@ fn test_merkle_tree() -> Result<(), MerkleError> {
         "Value for merkle path at index 0 must match leaf value"
     );
     assert_eq!(
-        mtree.get_path(NodeIndex::make(mtree.depth(), 3)),
-        Ok(result.path),
+        mtree.get_path(NodeIndex::make(mtree.depth(), 3)).unwrap(),
+        result.path,
         "merkle path for index 0 must be the same for the MerkleTree and MerkleStore"
     );
 
@@ -240,56 +241,56 @@ fn test_sparse_merkle_tree() -> Result<(), MerkleError> {
     // STORE LEAVES ARE CORRECT ==============================================================
     // checks the leaves in the store corresponds to the expected values
     assert_eq!(
-        store.get_node(smt.root(), NodeIndex::make(SMT_MAX_DEPTH, 0)),
-        Ok(VALUES4[0]),
+        store.get_node(smt.root(), NodeIndex::make(SMT_MAX_DEPTH, 0)).unwrap(),
+        VALUES4[0],
         "node 0 must be in the tree"
     );
     assert_eq!(
-        store.get_node(smt.root(), NodeIndex::make(SMT_MAX_DEPTH, 1)),
-        Ok(VALUES4[1]),
+        store.get_node(smt.root(), NodeIndex::make(SMT_MAX_DEPTH, 1)).unwrap(),
+        VALUES4[1],
         "node 1 must be in the tree"
     );
     assert_eq!(
-        store.get_node(smt.root(), NodeIndex::make(SMT_MAX_DEPTH, 2)),
-        Ok(VALUES4[2]),
+        store.get_node(smt.root(), NodeIndex::make(SMT_MAX_DEPTH, 2)).unwrap(),
+        VALUES4[2],
         "node 2 must be in the tree"
     );
     assert_eq!(
-        store.get_node(smt.root(), NodeIndex::make(SMT_MAX_DEPTH, 3)),
-        Ok(VALUES4[3]),
+        store.get_node(smt.root(), NodeIndex::make(SMT_MAX_DEPTH, 3)).unwrap(),
+        VALUES4[3],
         "node 3 must be in the tree"
     );
     assert_eq!(
-        store.get_node(smt.root(), NodeIndex::make(SMT_MAX_DEPTH, 4)),
-        Ok(RpoDigest::default()),
+        store.get_node(smt.root(), NodeIndex::make(SMT_MAX_DEPTH, 4)).unwrap(),
+        RpoDigest::default(),
         "unmodified node 4 must be ZERO"
     );
 
     // STORE LEAVES MATCH TREE ===============================================================
     // sanity check the values returned by the store and the tree
     assert_eq!(
-        smt.get_node(NodeIndex::make(SMT_MAX_DEPTH, 0)),
-        store.get_node(smt.root(), NodeIndex::make(SMT_MAX_DEPTH, 0)),
+        smt.get_node(NodeIndex::make(SMT_MAX_DEPTH, 0)).unwrap(),
+        store.get_node(smt.root(), NodeIndex::make(SMT_MAX_DEPTH, 0)).unwrap(),
         "node 0 must be the same for both SparseMerkleTree and MerkleStore"
     );
     assert_eq!(
-        smt.get_node(NodeIndex::make(SMT_MAX_DEPTH, 1)),
-        store.get_node(smt.root(), NodeIndex::make(SMT_MAX_DEPTH, 1)),
+        smt.get_node(NodeIndex::make(SMT_MAX_DEPTH, 1)).unwrap(),
+        store.get_node(smt.root(), NodeIndex::make(SMT_MAX_DEPTH, 1)).unwrap(),
         "node 1 must be the same for both SparseMerkleTree and MerkleStore"
     );
     assert_eq!(
-        smt.get_node(NodeIndex::make(SMT_MAX_DEPTH, 2)),
-        store.get_node(smt.root(), NodeIndex::make(SMT_MAX_DEPTH, 2)),
+        smt.get_node(NodeIndex::make(SMT_MAX_DEPTH, 2)).unwrap(),
+        store.get_node(smt.root(), NodeIndex::make(SMT_MAX_DEPTH, 2)).unwrap(),
         "node 2 must be the same for both SparseMerkleTree and MerkleStore"
     );
     assert_eq!(
-        smt.get_node(NodeIndex::make(SMT_MAX_DEPTH, 3)),
-        store.get_node(smt.root(), NodeIndex::make(SMT_MAX_DEPTH, 3)),
+        smt.get_node(NodeIndex::make(SMT_MAX_DEPTH, 3)).unwrap(),
+        store.get_node(smt.root(), NodeIndex::make(SMT_MAX_DEPTH, 3)).unwrap(),
         "node 3 must be the same for both SparseMerkleTree and MerkleStore"
     );
     assert_eq!(
-        smt.get_node(NodeIndex::make(SMT_MAX_DEPTH, 4)),
-        store.get_node(smt.root(), NodeIndex::make(SMT_MAX_DEPTH, 4)),
+        smt.get_node(NodeIndex::make(SMT_MAX_DEPTH, 4)).unwrap(),
+        store.get_node(smt.root(), NodeIndex::make(SMT_MAX_DEPTH, 4)).unwrap(),
         "node 4 must be the same for both SparseMerkleTree and MerkleStore"
     );
 
@@ -385,46 +386,46 @@ fn test_add_merkle_paths() -> Result<(), MerkleError> {
     // STORE LEAVES ARE CORRECT ==============================================================
     // checks the leaves in the store corresponds to the expected values
     assert_eq!(
-        store.get_node(pmt.root(), NodeIndex::make(pmt.max_depth(), 0)),
-        Ok(VALUES4[0]),
+        store.get_node(pmt.root(), NodeIndex::make(pmt.max_depth(), 0)).unwrap(),
+        VALUES4[0],
         "node 0 must be in the pmt"
     );
     assert_eq!(
-        store.get_node(pmt.root(), NodeIndex::make(pmt.max_depth(), 1)),
-        Ok(VALUES4[1]),
+        store.get_node(pmt.root(), NodeIndex::make(pmt.max_depth(), 1)).unwrap(),
+        VALUES4[1],
         "node 1 must be in the pmt"
     );
     assert_eq!(
-        store.get_node(pmt.root(), NodeIndex::make(pmt.max_depth(), 2)),
-        Ok(VALUES4[2]),
+        store.get_node(pmt.root(), NodeIndex::make(pmt.max_depth(), 2)).unwrap(),
+        VALUES4[2],
         "node 2 must be in the pmt"
     );
     assert_eq!(
-        store.get_node(pmt.root(), NodeIndex::make(pmt.max_depth(), 3)),
-        Ok(VALUES4[3]),
+        store.get_node(pmt.root(), NodeIndex::make(pmt.max_depth(), 3)).unwrap(),
+        VALUES4[3],
         "node 3 must be in the pmt"
     );
 
     // STORE LEAVES MATCH PMT ================================================================
     // sanity check the values returned by the store and the pmt
     assert_eq!(
-        pmt.get_node(NodeIndex::make(pmt.max_depth(), 0)),
-        store.get_node(pmt.root(), NodeIndex::make(pmt.max_depth(), 0)),
+        pmt.get_node(NodeIndex::make(pmt.max_depth(), 0)).unwrap(),
+        store.get_node(pmt.root(), NodeIndex::make(pmt.max_depth(), 0)).unwrap(),
         "node 0 must be the same for both PartialMerkleTree and MerkleStore"
     );
     assert_eq!(
-        pmt.get_node(NodeIndex::make(pmt.max_depth(), 1)),
-        store.get_node(pmt.root(), NodeIndex::make(pmt.max_depth(), 1)),
+        pmt.get_node(NodeIndex::make(pmt.max_depth(), 1)).unwrap(),
+        store.get_node(pmt.root(), NodeIndex::make(pmt.max_depth(), 1)).unwrap(),
         "node 1 must be the same for both PartialMerkleTree and MerkleStore"
     );
     assert_eq!(
-        pmt.get_node(NodeIndex::make(pmt.max_depth(), 2)),
-        store.get_node(pmt.root(), NodeIndex::make(pmt.max_depth(), 2)),
+        pmt.get_node(NodeIndex::make(pmt.max_depth(), 2)).unwrap(),
+        store.get_node(pmt.root(), NodeIndex::make(pmt.max_depth(), 2)).unwrap(),
         "node 2 must be the same for both PartialMerkleTree and MerkleStore"
     );
     assert_eq!(
-        pmt.get_node(NodeIndex::make(pmt.max_depth(), 3)),
-        store.get_node(pmt.root(), NodeIndex::make(pmt.max_depth(), 3)),
+        pmt.get_node(NodeIndex::make(pmt.max_depth(), 3)).unwrap(),
+        store.get_node(pmt.root(), NodeIndex::make(pmt.max_depth(), 3)).unwrap(),
         "node 3 must be the same for both PartialMerkleTree and MerkleStore"
     );
 
@@ -436,8 +437,8 @@ fn test_add_merkle_paths() -> Result<(), MerkleError> {
         "Value for merkle path at index 0 must match leaf value"
     );
     assert_eq!(
-        pmt.get_path(NodeIndex::make(pmt.max_depth(), 0)),
-        Ok(result.path),
+        pmt.get_path(NodeIndex::make(pmt.max_depth(), 0)).unwrap(),
+        result.path,
         "merkle path for index 0 must be the same for the MerkleTree and MerkleStore"
     );
 
@@ -447,8 +448,8 @@ fn test_add_merkle_paths() -> Result<(), MerkleError> {
         "Value for merkle path at index 0 must match leaf value"
     );
     assert_eq!(
-        pmt.get_path(NodeIndex::make(pmt.max_depth(), 1)),
-        Ok(result.path),
+        pmt.get_path(NodeIndex::make(pmt.max_depth(), 1)).unwrap(),
+        result.path,
         "merkle path for index 1 must be the same for the MerkleTree and MerkleStore"
     );
 
@@ -458,8 +459,8 @@ fn test_add_merkle_paths() -> Result<(), MerkleError> {
         "Value for merkle path at index 0 must match leaf value"
     );
     assert_eq!(
-        pmt.get_path(NodeIndex::make(pmt.max_depth(), 2)),
-        Ok(result.path),
+        pmt.get_path(NodeIndex::make(pmt.max_depth(), 2)).unwrap(),
+        result.path,
         "merkle path for index 0 must be the same for the MerkleTree and MerkleStore"
     );
 
@@ -469,8 +470,8 @@ fn test_add_merkle_paths() -> Result<(), MerkleError> {
         "Value for merkle path at index 0 must match leaf value"
     );
     assert_eq!(
-        pmt.get_path(NodeIndex::make(pmt.max_depth(), 3)),
-        Ok(result.path),
+        pmt.get_path(NodeIndex::make(pmt.max_depth(), 3)).unwrap(),
+        result.path,
         "merkle path for index 0 must be the same for the MerkleTree and MerkleStore"
     );
 
@@ -498,7 +499,7 @@ fn wont_open_to_different_depth_root() {
     let store = MerkleStore::from(&mtree);
     let index = NodeIndex::root();
     let err = store.get_node(root, index).err().unwrap();
-    assert_eq!(err, MerkleError::RootNotInStore(root));
+    assert_matches!(err, MerkleError::RootNotInStore(err_root) if err_root == root);
 }
 
 #[test]
@@ -537,7 +538,7 @@ fn test_set_node() -> Result<(), MerkleError> {
     let value = int_to_node(42);
     let index = NodeIndex::make(mtree.depth(), 0);
     let new_root = store.set_node(mtree.root(), index, value)?.root;
-    assert_eq!(store.get_node(new_root, index), Ok(value), "Value must have changed");
+    assert_eq!(store.get_node(new_root, index).unwrap(), value, "value must have changed");
 
     Ok(())
 }
@@ -745,7 +746,7 @@ fn get_leaf_depth_works_with_depth_8() {
     // duplicate the tree on `a` and assert the depth is short-circuited by such sub-tree
     let index = NodeIndex::new(8, a).unwrap();
     root = store.set_node(root, index, root).unwrap().root;
-    assert_eq!(Err(MerkleError::DepthTooBig(9)), store.get_leaf_depth(root, 8, a));
+    assert_matches!(store.get_leaf_depth(root, 8, a).unwrap_err(), MerkleError::DepthTooBig(9));
 }
 
 #[test]


### PR DESCRIPTION
## Describe your changes

Refactor error messages, use `thiserror` to derive errors and implement `core::error::Error`.

Various errors were renamed or restructured to provide better error messages which means this is a breaking change, so this targets `next`.

Fixes the changelog for `0.12` and moves the #343 PR to the next version, `0.13`.

Related to https://github.com/0xPolygonMiden/miden-base/issues/972.

## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
