### PR TITLE
feat(SMT): added getters for `MutationSet` fields access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# TBD
+## Unreleased
 
 - Generate reverse mutations set on applying of mutations set, implemented serialization of `MutationsSet` (#355).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Fixed a bug in the implementation of `draw_integers` for `RpoRandomCoin` (#343).
 - [BREAKING] Refactor error messages and use `thiserror` to derive errors (#344).
+- [BREAKING] Updated Winterfell dependency to v0.11 (#346).
 
 ## 0.12.0 (2024-10-30)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# TBD
+
+- Generate reverse mutations set on applying of mutations set, implemented serialization of `MutationsSet` (#355).
+
 ## 0.13.0 (2024-11-24)
 
 - Fixed a bug in the implementation of `draw_integers` for `RpoRandomCoin` (#343).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## 0.12.0 (2024-10-30)
 
 - [BREAKING] Updated Winterfell dependency to v0.10 (#338).
+- Added parallel implementation of `Smt::with_entries()` with significantly better performance when the `concurrent` feature is enabled (#341).
 
 ## 0.11.0 (2024-10-17)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.13.0 (TBD)
+## 0.13.0 (2024-11-24)
 
 - Fixed a bug in the implementation of `draw_integers` for `RpoRandomCoin` (#343).
 - [BREAKING] Refactor error messages and use `thiserror` to derive errors (#344).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Generate reverse mutations set on applying of mutations set, implemented serialization of `MutationsSet` (#355).
+- Added getters for `MutationSet` fields access (#356).
 
 ## 0.13.0 (2024-11-24)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -541,6 +541,7 @@ dependencies = [
  "rand",
  "rand_chacha",
  "rand_core",
+ "rayon",
  "seq-macro",
  "serde",
  "sha3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -249,9 +249,9 @@ checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ca741a962e1b0bff6d724a1a0958b686406e853bb14061f218562e1896f95e6"
+checksum = "16b80225097f2e5ae4e7179dd2266824648f3e2f49d9134d584b76389d31c4c3"
 dependencies = [
  "libc",
 ]
@@ -1173,9 +1173,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winter-crypto"
-version = "0.10.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fcae1ada055aa10554910ecffc106cb116a19dba11ac91390ef982f94adb9c5"
+checksum = "67c57748fd2da77742be601f03eda639ff6046879738fd1faae86e80018263cb"
 dependencies = [
  "blake3",
  "sha3",
@@ -1185,9 +1185,9 @@ dependencies = [
 
 [[package]]
 name = "winter-math"
-version = "0.10.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82479f94efc0b5374a93e2074ba46ef404384fb1ea6e35a847febec53096509b"
+checksum = "6020c17839fa107ce4a7cc178e407ebbc24adfac1980f4fa2111198e052700ab"
 dependencies = [
  "serde",
  "winter-utils",
@@ -1195,9 +1195,9 @@ dependencies = [
 
 [[package]]
 name = "winter-rand-utils"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a7616d11fcc26552dada45c803a884ac97c253218835b83a2c63e1c2a988639"
+checksum = "226e4c455f6eb72f64ac6eeb7642df25e21ff2280a4f6b09db75392ad6b390ef"
 dependencies = [
  "rand",
  "winter-utils",
@@ -1205,9 +1205,9 @@ dependencies = [
 
 [[package]]
 name = "winter-utils"
-version = "0.10.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f948e71ffd482aa13d0ec3349047f81ecdb89f3b3287577973dcbf092a25fb4"
+checksum = "1507ef312ea5569d54c2c7446a18b82143eb2a2e21f5c3ec7cfbe8200c03bd7c"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -388,17 +388,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi",
- "wasm-bindgen",
 ]
-
-[[package]]
-name = "glob"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "half"
@@ -532,8 +524,6 @@ dependencies = [
  "cc",
  "clap",
  "criterion",
- "getrandom",
- "glob",
  "hex",
  "num",
  "num-complex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,9 +19,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
-version = "0.6.17"
+version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23a1e53f0f5d86382dafe1cf314783b2044280f406e7e1506368220ad11b1338"
+checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -34,9 +34,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8365de52b16c035ff4fcafe0092ba9390540e3e352870ac09933bebcaa2c8c56"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
 
 [[package]]
 name = "anstyle-parse"
@@ -153,9 +153,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.1.31"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2e7962b54006dcfcc61cb72735f4d89bb97061dd6a7ed882ec6b8ee53714c6f"
+checksum = "fd9de9f2205d5ef3fd67e685b0df337994ddd4495e2a28d185500d0e1edfea47"
 dependencies = [
  "jobserver",
  "libc",
@@ -197,9 +197,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.20"
+version = "4.5.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97f376d85a664d5837dbae44bf546e6477a679ff6610010f17276f686d867e8"
+checksum = "fb3b4b9e5a7c7514dfa52869339ee98b3156b0bfb4e8a77c4ff4babb64b1604f"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -207,9 +207,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.20"
+version = "4.5.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19bc80abd44e4bed93ca373a0704ccbd1b710dc5749406201bb018272808dc54"
+checksum = "b17a95aa67cc7b5ebd32aa5370189aa0d79069ef1c64ce893bd30fb24bff20ec"
 dependencies = [
  "anstream",
  "anstyle",
@@ -231,9 +231,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
+checksum = "afb84c814227b90d6895e01398aee0d8033c00e7466aca416fb6a8e0eb19d8a7"
 
 [[package]]
 name = "colorchoice"
@@ -249,9 +249,9 @@ checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "608697df725056feaccfa42cffdaeeec3fccc4ffc38358ecd19b243e716a78e0"
+checksum = "0ca741a962e1b0bff6d724a1a0958b686406e853bb14061f218562e1896f95e6"
 dependencies = [
  "libc",
 ]
@@ -361,9 +361,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
+checksum = "486f806e73c5707928240ddc295403b1b93c96a02038563881c4a2fd84b81ac4"
 
 [[package]]
 name = "fnv"
@@ -456,9 +456,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.11"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+checksum = "540654e97a3f4470a492cd30ff187bc95d89557a903a2bbf112e2fae98104ef2"
 
 [[package]]
 name = "jobserver"
@@ -495,9 +495,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.161"
+version = "0.2.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
+checksum = "433bfe06b8c75da9b2e3fbea6e5329ff87748f0b144ef75306e674c3f6f7c13f"
 
 [[package]]
 name = "libm"
@@ -525,7 +525,7 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "miden-crypto"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "assert_matches",
  "blake3",
@@ -676,9 +676,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.91"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "307e3004becf10f5a6e0d59d20f3cd28231b0e0827a96cd3e0ce6d14bc1e4bb3"
+checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
 dependencies = [
  "unicode-ident",
 ]
@@ -791,9 +791,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -808,9 +808,9 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rustix"
-version = "0.38.38"
+version = "0.38.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa260229e6538e52293eeb577aabd09945a09d6d9cc0fc550ed7529056c2e32a"
+checksum = "d7f649912bc1495e167a6edee79151c84b1bad49748cb4f1f1167f459f6224f6"
 dependencies = [
  "bitflags",
  "errno",
@@ -854,18 +854,18 @@ checksum = "a3f0bf26fd526d2a95683cd0f87bf103b8539e2ca1ef48ce002d67aad59aa0b4"
 
 [[package]]
 name = "serde"
-version = "1.0.214"
+version = "1.0.215"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f55c3193aca71c12ad7890f1785d2b73e1b9f63a0bbc353c08ef26fe03fc56b5"
+checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.214"
+version = "1.0.215"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de523f781f095e28fa605cdce0f8307e451cc0fd14e2eb4cd2e98a355b147766"
+checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -874,9 +874,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.132"
+version = "1.0.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d726bfaff4b320266d395898905d0eba0345aae23b54aee3a737e260fd46db03"
+checksum = "c7fceb2473b9166b2294ef05efcb65a3db80803f0b03ef86a5fc88a2b85ee377"
 dependencies = [
  "itoa",
  "memchr",
@@ -919,9 +919,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.13.0"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f2c9fc62d0beef6951ccffd757e241266a2c833136efbe35af6cd2567dca5b"
+checksum = "28cce251fcbc87fac86a866eeb0d6c2d536fc16d06f184bb61aeae11aa4cee0c"
 dependencies = [
  "cfg-if",
  "fastrand",
@@ -974,9 +974,9 @@ checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
+checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
 
 [[package]]
 name = "utf8parse"
@@ -1173,9 +1173,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winter-crypto"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "163da45f1d4d65cac361b8df4835a6daa95b3399154e16eb0305c178c6f6c1f4"
+checksum = "3fcae1ada055aa10554910ecffc106cb116a19dba11ac91390ef982f94adb9c5"
 dependencies = [
  "blake3",
  "sha3",
@@ -1185,9 +1185,9 @@ dependencies = [
 
 [[package]]
 name = "winter-math"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a8ba832121679e79b004b0003018c85873956d742a39c348c247f680fe15e00"
+checksum = "82479f94efc0b5374a93e2074ba46ef404384fb1ea6e35a847febec53096509b"
 dependencies = [
  "serde",
  "winter-utils",
@@ -1205,9 +1205,9 @@ dependencies = [
 
 [[package]]
 name = "winter-utils"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76b116c8ade0172506f8bda32dc674cf6b230adc8516e5138a0173ae69158a4f"
+checksum = "1f948e71ffd482aa13d0ec3349047f81ecdb89f3b3287577973dcbf092a25fb4"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,13 +52,13 @@ num = { version = "0.4", default-features = false, features = ["alloc", "libm"] 
 num-complex = { version = "0.4", default-features = false }
 rand = { version = "0.8", default-features = false }
 rand_core = { version = "0.6", default-features = false }
-rand-utils = { version = "0.10", package = "winter-rand-utils", optional = true }
+rand-utils = { version = "0.11", package = "winter-rand-utils", optional = true }
 serde = { version = "1.0", default-features = false, optional = true, features = ["derive"] }
 sha3 = { version = "0.10", default-features = false }
 thiserror = { version = "2.0", default-features = false }
-winter-crypto = { version = "0.10", default-features = false }
-winter-math = { version = "0.10", default-features = false }
-winter-utils = { version = "0.10", default-features = false }
+winter-crypto = { version = "0.11", default-features = false }
+winter-math = { version = "0.11", default-features = false }
+winter-utils = { version = "0.11", default-features = false }
 
 [dev-dependencies]
 assert_matches = { version = "1.5", default-features = false }
@@ -67,7 +67,7 @@ getrandom = { version = "0.2", features = ["js"] }
 hex = { version = "0.4", default-features = false, features = ["alloc"] }
 proptest = "1.5"
 rand_chacha = { version = "0.3", default-features = false }
-rand-utils = { version = "0.10", package = "winter-rand-utils" }
+rand-utils = { version = "0.11", package = "winter-rand-utils" }
 seq-macro = { version = "0.3" }
 
 [build-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,12 +28,27 @@ name = "smt"
 harness = false
 
 [[bench]]
+name = "smt-subtree"
+harness = false
+required-features = ["internal"]
+
+[[bench]]
+name = "merkle"
+harness = false
+
+[[bench]]
+name = "smt-with-entries"
+harness = false
+
+[[bench]]
 name = "store"
 harness = false
 
 [features]
-default = ["std"]
+concurrent = ["dep:rayon"]
+default = ["std", "concurrent"]
 executable = ["dep:clap", "dep:rand-utils", "std"]
+internal = []
 serde = ["dep:serde", "serde?/alloc", "winter-math/serde"]
 std = [
     "blake3/std",
@@ -53,6 +68,7 @@ num-complex = { version = "0.4", default-features = false }
 rand = { version = "0.8", default-features = false }
 rand_core = { version = "0.6", default-features = false }
 rand-utils = { version = "0.11", package = "winter-rand-utils", optional = true }
+rayon = { version = "1.10", optional = true }
 serde = { version = "1.0", default-features = false, optional = true, features = ["derive"] }
 sha3 = { version = "0.10", default-features = false }
 thiserror = { version = "2.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,10 @@ name = "smt"
 harness = false
 
 [[bench]]
+name = "smt-mutations"
+harness = false
+
+[[bench]]
 name = "smt-subtree"
 harness = false
 required-features = ["internal"]
@@ -79,7 +83,6 @@ winter-utils = { version = "0.11", default-features = false }
 [dev-dependencies]
 assert_matches = { version = "1.5", default-features = false }
 criterion = { version = "0.5", features = ["html_reports"] }
-getrandom = { version = "0.2", features = ["js"] }
 hex = { version = "0.4", default-features = false, features = ["alloc"] }
 proptest = "1.5"
 rand_chacha = { version = "0.3", default-features = false }
@@ -88,4 +91,3 @@ seq-macro = { version = "0.3" }
 
 [build-dependencies]
 cc = { version = "1.2", optional = true, features = ["parallel"] }
-glob = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "miden-crypto"
-version = "0.12.0"
+version = "0.13.0"
 description = "Miden Cryptographic primitives"
 authors = ["miden contributors"]
 readme = "README.md"
 license = "MIT"
 repository = "https://github.com/0xPolygonMiden/crypto"
-documentation = "https://docs.rs/miden-crypto/0.12.0"
+documentation = "https://docs.rs/miden-crypto/0.13.0"
 categories = ["cryptography", "no-std"]
 keywords = ["miden", "crypto", "hash", "merkle"]
 edition = "2021"
@@ -61,7 +61,7 @@ winter-math = { version = "0.10", default-features = false }
 winter-utils = { version = "0.10", default-features = false }
 
 [dev-dependencies]
-assert_matches = { version = "1.5.0", default-features = false }
+assert_matches = { version = "1.5", default-features = false }
 criterion = { version = "0.5", features = ["html_reports"] }
 getrandom = { version = "0.2", features = ["js"] }
 hex = { version = "0.4", default-features = false, features = ["alloc"] }
@@ -71,5 +71,5 @@ rand-utils = { version = "0.10", package = "winter-rand-utils" }
 seq-macro = { version = "0.3" }
 
 [build-dependencies]
-cc = { version = "1.1", optional = true, features = ["parallel"] }
+cc = { version = "1.2", optional = true, features = ["parallel"] }
 glob = "0.3"

--- a/Makefile
+++ b/Makefile
@@ -83,4 +83,4 @@ build-sve: ## Build with sve support
 
 .PHONY: bench-tx
 bench-tx: ## Run crypto benchmarks
-	cargo bench
+	cargo bench --features="concurrent"

--- a/README.md
+++ b/README.md
@@ -60,10 +60,11 @@ make
 
 This crate can be compiled with the following features:
 
+- `concurrent`- enabled by default; enables multi-threaded implementation of `Smt::with_entries()` which significantly improves performance on multi-core CPUs.
 - `std` - enabled by default and relies on the Rust standard library.
 - `no_std` does not rely on the Rust standard library and enables compilation to WebAssembly.
 
-Both of these features imply the use of [alloc](https://doc.rust-lang.org/alloc/) to support heap-allocated collections.
+All of these features imply the use of [alloc](https://doc.rust-lang.org/alloc/) to support heap-allocated collections.
 
 To compile with `no_std`, disable default features via `--no-default-features` flag or using the following command:
 

--- a/benches/merkle.rs
+++ b/benches/merkle.rs
@@ -1,0 +1,66 @@
+//! Benchmark for building a [`miden_crypto::merkle::MerkleTree`]. This is intended to be compared
+//! with the results from `benches/smt-subtree.rs`, as building a fully balanced Merkle tree with
+//! 256 leaves should indicate the *absolute best* performance we could *possibly* get for building
+//! a depth-8 sparse Merkle subtree, though practically speaking building a fully balanced Merkle
+//! tree will perform better than the sparse version. At the time of this writing (2024/11/24), this
+//! benchmark is about four times more efficient than the equivalent benchmark in
+//! `benches/smt-subtree.rs`.
+use std::{hint, mem, time::Duration};
+
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
+use miden_crypto::{merkle::MerkleTree, Felt, Word, ONE};
+use rand_utils::prng_array;
+
+fn balanced_merkle_even(c: &mut Criterion) {
+    c.bench_function("balanced-merkle-even", |b| {
+        b.iter_batched(
+            || {
+                let entries: Vec<Word> =
+                    (0..256).map(|i| [Felt::new(i), ONE, ONE, Felt::new(i)]).collect();
+                assert_eq!(entries.len(), 256);
+                entries
+            },
+            |leaves| {
+                let tree = MerkleTree::new(hint::black_box(leaves)).unwrap();
+                assert_eq!(tree.depth(), 8);
+            },
+            BatchSize::SmallInput,
+        );
+    });
+}
+
+fn balanced_merkle_rand(c: &mut Criterion) {
+    let mut seed = [0u8; 32];
+    c.bench_function("balanced-merkle-rand", |b| {
+        b.iter_batched(
+            || {
+                let entries: Vec<Word> = (0..256).map(|_| generate_word(&mut seed)).collect();
+                assert_eq!(entries.len(), 256);
+                entries
+            },
+            |leaves| {
+                let tree = MerkleTree::new(hint::black_box(leaves)).unwrap();
+                assert_eq!(tree.depth(), 8);
+            },
+            BatchSize::SmallInput,
+        );
+    });
+}
+
+criterion_group! {
+    name = smt_subtree_group;
+    config = Criterion::default()
+        .measurement_time(Duration::from_secs(20))
+        .configure_from_args();
+    targets = balanced_merkle_even, balanced_merkle_rand
+}
+criterion_main!(smt_subtree_group);
+
+// HELPER FUNCTIONS
+// --------------------------------------------------------------------------------------------
+
+fn generate_word(seed: &mut [u8; 32]) -> Word {
+    mem::swap(seed, &mut prng_array(*seed));
+    let nums: [u64; 4] = prng_array(*seed);
+    [Felt::new(nums[0]), Felt::new(nums[1]), Felt::new(nums[2]), Felt::new(nums[3])]
+}

--- a/benches/smt-mutations.rs
+++ b/benches/smt-mutations.rs
@@ -1,0 +1,108 @@
+use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion};
+use miden_crypto::{
+    merkle::{LeafIndex, SimpleSmt},
+    Felt, Word, EMPTY_WORD,
+};
+use rand::{prelude::SliceRandom, rngs::StdRng, Rng, SeedableRng};
+
+const DEPTH: u8 = 64;
+
+fn benchmark_apply_mutations(c: &mut Criterion) {
+    let mut group = c.benchmark_group("apply_mutations");
+    group.sample_size(10);
+    group.measurement_time(std::time::Duration::from_secs(300));
+
+    // Fixed seed for reproducibility
+    let rng_seed = 42;
+    let mut rng = StdRng::seed_from_u64(rng_seed);
+
+    // Benchmark for various mutation set sizes
+    for &mutation_count in &[1_000, 100_000] {
+        group.bench_with_input(
+            BenchmarkId::new("SimpleSmt: apply_mutations", mutation_count),
+            &mutation_count,
+            |b, &mutation_count| {
+                // Batch-based benchmarking
+                b.iter_batched(
+                    || {
+                        const REMOVAL_PROBABILITY: f64 = 0.2;
+
+                        // Fill tree with 10x more initial elements
+                        let initial_fill_count = mutation_count * 10;
+
+                        // Initialize the tree with initial random values
+                        let initial_kv_pairs = generate_kv_pairs(&mut rng, initial_fill_count);
+                        let smt = SimpleSmt::<DEPTH>::with_leaves(initial_kv_pairs.iter().cloned())
+                            .unwrap();
+
+                        // Select and change a half of pairs from the filled tree (values to be
+                        // updated or removed with given probability)
+                        let mut mutation_kv_pairs: Vec<_> = initial_kv_pairs
+                            .choose_multiple(&mut rng, mutation_count / 2)
+                            .cloned()
+                            .map(|(key, _value)| {
+                                let value = if rng.gen_bool(REMOVAL_PROBABILITY) {
+                                    EMPTY_WORD
+                                } else {
+                                    generate_word(&mut rng)
+                                };
+
+                                (key, value)
+                            })
+                            .collect();
+
+                        // Append another half of new values (values to be added)
+                        for _ in 0..mutation_count / 2 {
+                            mutation_kv_pairs.push((rng.gen(), generate_word(&mut rng)));
+                        }
+
+                        // Compute mutations
+                        let mutations = smt.compute_mutations(
+                            mutation_kv_pairs
+                                .into_iter()
+                                .map(|(key, value)| (LeafIndex::new(key).unwrap(), value)),
+                        );
+
+                        (smt, mutations)
+                    },
+                    |(mut smt, mutations)| {
+                        // Apply mutations in the benchmark to measure execution time
+                        smt.apply_mutations(mutations).unwrap();
+                    },
+                    BatchSize::SmallInput,
+                );
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, benchmark_apply_mutations);
+criterion_main!(benches);
+
+// HELPER FUNCTIONS
+// =================================================================================================
+
+/// Helper function to generate random `(u64, Word)` key-value pairs
+fn generate_kv_pairs(rng: &mut StdRng, count: usize) -> Vec<(u64, Word)> {
+    (0..count)
+        .map(|_| {
+            let key = rng.gen();
+            let value = generate_word(rng);
+
+            (key, value)
+        })
+        .collect()
+}
+
+/// Helper function to generate random `Word`
+fn generate_word(rng: &mut StdRng) -> Word {
+    // Random Word value
+    [
+        Felt::new(rng.gen()),
+        Felt::new(rng.gen()),
+        Felt::new(rng.gen()),
+        Felt::new(rng.gen()),
+    ]
+}

--- a/benches/smt-subtree.rs
+++ b/benches/smt-subtree.rs
@@ -1,0 +1,142 @@
+use std::{fmt::Debug, hint, mem, time::Duration};
+
+use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion};
+use miden_crypto::{
+    hash::rpo::RpoDigest,
+    merkle::{build_subtree_for_bench, NodeIndex, SmtLeaf, SubtreeLeaf, SMT_DEPTH},
+    Felt, Word, ONE,
+};
+use rand_utils::prng_array;
+use winter_utils::Randomizable;
+
+const PAIR_COUNTS: [u64; 5] = [1, 64, 128, 192, 256];
+
+fn smt_subtree_even(c: &mut Criterion) {
+    let mut seed = [0u8; 32];
+
+    let mut group = c.benchmark_group("subtree8-even");
+
+    for pair_count in PAIR_COUNTS {
+        let bench_id = BenchmarkId::from_parameter(pair_count);
+        group.bench_with_input(bench_id, &pair_count, |b, &pair_count| {
+            b.iter_batched(
+                || {
+                    // Setup.
+                    let entries: Vec<(RpoDigest, Word)> = (0..pair_count)
+                        .map(|n| {
+                            // A single depth-8 subtree can have a maximum of 255 leaves.
+                            let leaf_index = ((n as f64 / pair_count as f64) * 255.0) as u64;
+                            let key = RpoDigest::new([
+                                generate_value(&mut seed),
+                                ONE,
+                                Felt::new(n),
+                                Felt::new(leaf_index),
+                            ]);
+                            let value = generate_word(&mut seed);
+                            (key, value)
+                        })
+                        .collect();
+
+                    let mut leaves: Vec<_> = entries
+                        .iter()
+                        .map(|(key, value)| {
+                            let leaf = SmtLeaf::new_single(*key, *value);
+                            let col = NodeIndex::from(leaf.index()).value();
+                            let hash = leaf.hash();
+                            SubtreeLeaf { col, hash }
+                        })
+                        .collect();
+                    leaves.sort();
+                    leaves.dedup_by_key(|leaf| leaf.col);
+                    leaves
+                },
+                |leaves| {
+                    // Benchmarked function.
+                    let (subtree, _) = build_subtree_for_bench(
+                        hint::black_box(leaves),
+                        hint::black_box(SMT_DEPTH),
+                        hint::black_box(SMT_DEPTH),
+                    );
+                    assert!(!subtree.is_empty());
+                },
+                BatchSize::SmallInput,
+            );
+        });
+    }
+}
+
+fn smt_subtree_random(c: &mut Criterion) {
+    let mut seed = [0u8; 32];
+
+    let mut group = c.benchmark_group("subtree8-rand");
+
+    for pair_count in PAIR_COUNTS {
+        let bench_id = BenchmarkId::from_parameter(pair_count);
+        group.bench_with_input(bench_id, &pair_count, |b, &pair_count| {
+            b.iter_batched(
+                || {
+                    // Setup.
+                    let entries: Vec<(RpoDigest, Word)> = (0..pair_count)
+                        .map(|i| {
+                            let leaf_index: u8 = generate_value(&mut seed);
+                            let key = RpoDigest::new([
+                                ONE,
+                                ONE,
+                                Felt::new(i),
+                                Felt::new(leaf_index as u64),
+                            ]);
+                            let value = generate_word(&mut seed);
+                            (key, value)
+                        })
+                        .collect();
+
+                    let mut leaves: Vec<_> = entries
+                        .iter()
+                        .map(|(key, value)| {
+                            let leaf = SmtLeaf::new_single(*key, *value);
+                            let col = NodeIndex::from(leaf.index()).value();
+                            let hash = leaf.hash();
+                            SubtreeLeaf { col, hash }
+                        })
+                        .collect();
+                    leaves.sort();
+                    leaves
+                },
+                |leaves| {
+                    let (subtree, _) = build_subtree_for_bench(
+                        hint::black_box(leaves),
+                        hint::black_box(SMT_DEPTH),
+                        hint::black_box(SMT_DEPTH),
+                    );
+                    assert!(!subtree.is_empty());
+                },
+                BatchSize::SmallInput,
+            );
+        });
+    }
+}
+
+criterion_group! {
+    name = smt_subtree_group;
+    config = Criterion::default()
+        .measurement_time(Duration::from_secs(40))
+        .sample_size(60)
+        .configure_from_args();
+    targets = smt_subtree_even, smt_subtree_random
+}
+criterion_main!(smt_subtree_group);
+
+// HELPER FUNCTIONS
+// --------------------------------------------------------------------------------------------
+
+fn generate_value<T: Copy + Debug + Randomizable>(seed: &mut [u8; 32]) -> T {
+    mem::swap(seed, &mut prng_array(*seed));
+    let value: [T; 1] = rand_utils::prng_array(*seed);
+    value[0]
+}
+
+fn generate_word(seed: &mut [u8; 32]) -> Word {
+    mem::swap(seed, &mut prng_array(*seed));
+    let nums: [u64; 4] = prng_array(*seed);
+    [Felt::new(nums[0]), Felt::new(nums[1]), Felt::new(nums[2]), Felt::new(nums[3])]
+}

--- a/benches/smt-with-entries.rs
+++ b/benches/smt-with-entries.rs
@@ -1,0 +1,71 @@
+use std::{fmt::Debug, hint, mem, time::Duration};
+
+use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion};
+use miden_crypto::{hash::rpo::RpoDigest, merkle::Smt, Felt, Word, ONE};
+use rand_utils::prng_array;
+use winter_utils::Randomizable;
+
+// 2^0, 2^4, 2^8, 2^12, 2^16
+const PAIR_COUNTS: [u64; 6] = [1, 16, 256, 4096, 65536, 1_048_576];
+
+fn smt_with_entries(c: &mut Criterion) {
+    let mut seed = [0u8; 32];
+
+    let mut group = c.benchmark_group("smt-with-entries");
+
+    for pair_count in PAIR_COUNTS {
+        let bench_id = BenchmarkId::from_parameter(pair_count);
+        group.bench_with_input(bench_id, &pair_count, |b, &pair_count| {
+            b.iter_batched(
+                || {
+                    // Setup.
+                    prepare_entries(pair_count, &mut seed)
+                },
+                |entries| {
+                    // Benchmarked function.
+                    Smt::with_entries(hint::black_box(entries)).unwrap();
+                },
+                BatchSize::SmallInput,
+            );
+        });
+    }
+}
+
+criterion_group! {
+    name = smt_with_entries_group;
+    config = Criterion::default()
+        //.measurement_time(Duration::from_secs(960))
+        .measurement_time(Duration::from_secs(60))
+        .sample_size(10)
+        .configure_from_args();
+    targets = smt_with_entries
+}
+criterion_main!(smt_with_entries_group);
+
+// HELPER FUNCTIONS
+// --------------------------------------------------------------------------------------------
+
+fn prepare_entries(pair_count: u64, seed: &mut [u8; 32]) -> Vec<(RpoDigest, [Felt; 4])> {
+    let entries: Vec<(RpoDigest, Word)> = (0..pair_count)
+        .map(|i| {
+            let count = pair_count as f64;
+            let idx = ((i as f64 / count) * (count)) as u64;
+            let key = RpoDigest::new([generate_value(seed), ONE, Felt::new(i), Felt::new(idx)]);
+            let value = generate_word(seed);
+            (key, value)
+        })
+        .collect();
+    entries
+}
+
+fn generate_value<T: Copy + Debug + Randomizable>(seed: &mut [u8; 32]) -> T {
+    mem::swap(seed, &mut prng_array(*seed));
+    let value: [T; 1] = rand_utils::prng_array(*seed);
+    value[0]
+}
+
+fn generate_word(seed: &mut [u8; 32]) -> Word {
+    mem::swap(seed, &mut prng_array(*seed));
+    let nums: [u64; 4] = prng_array(*seed);
+    [Felt::new(nums[0]), Felt::new(nums[1]), Felt::new(nums[2]), Felt::new(nums[3])]
+}

--- a/src/merkle/index.rs
+++ b/src/merkle/index.rs
@@ -97,6 +97,14 @@ impl NodeIndex {
         self
     }
 
+    /// Returns the parent of the current node. This is the same as [`Self::move_up()`], but returns
+    /// a new value instead of mutating `self`.
+    pub const fn parent(mut self) -> Self {
+        self.depth = self.depth.saturating_sub(1);
+        self.value >>= 1;
+        self
+    }
+
     // PROVIDERS
     // --------------------------------------------------------------------------------------------
 

--- a/src/merkle/index.rs
+++ b/src/merkle/index.rs
@@ -136,7 +136,7 @@ impl NodeIndex {
         self.value
     }
 
-    /// Returns true if the current instance points to a right sibling node.
+    /// Returns `true` if the current instance points to a right sibling node.
     pub const fn is_value_odd(&self) -> bool {
         (self.value & 1) == 1
     }

--- a/src/merkle/mod.rs
+++ b/src/merkle/mod.rs
@@ -21,9 +21,11 @@ mod path;
 pub use path::{MerklePath, RootPath, ValuePath};
 
 mod smt;
+#[cfg(feature = "internal")]
+pub use smt::build_subtree_for_bench;
 pub use smt::{
     LeafIndex, MutationSet, SimpleSmt, Smt, SmtLeaf, SmtLeafError, SmtProof, SmtProofError,
-    SMT_DEPTH, SMT_MAX_DEPTH, SMT_MIN_DEPTH,
+    SubtreeLeaf, SMT_DEPTH, SMT_MAX_DEPTH, SMT_MIN_DEPTH,
 };
 
 mod mmr;

--- a/src/merkle/smt/full/leaf.rs
+++ b/src/merkle/smt/full/leaf.rs
@@ -70,7 +70,7 @@ impl SmtLeaf {
         Self::Single((key, value))
     }
 
-    /// Returns a new single leaf with the specified entry. The leaf index is derived from the
+    /// Returns a new multiple leaf with the specified entries. The leaf index is derived from the
     /// entries' keys.
     ///
     /// # Errors

--- a/src/merkle/smt/full/mod.rs
+++ b/src/merkle/smt/full/mod.rs
@@ -266,7 +266,7 @@ impl Smt {
     pub fn apply_mutations(
         &mut self,
         mutations: MutationSet<SMT_DEPTH, RpoDigest, Word>,
-    ) -> Result<(), MerkleError> {
+    ) -> Result<MutationSet<SMT_DEPTH, RpoDigest, Word>, MerkleError> {
         <Self as SparseMerkleTree<SMT_DEPTH>>::apply_mutations(self, mutations)
     }
 
@@ -344,12 +344,12 @@ impl SparseMerkleTree<SMT_DEPTH> for Smt {
             .unwrap_or_else(|| EmptySubtreeRoots::get_inner_node(SMT_DEPTH, index.depth()))
     }
 
-    fn insert_inner_node(&mut self, index: NodeIndex, inner_node: InnerNode) {
-        self.inner_nodes.insert(index, inner_node);
+    fn insert_inner_node(&mut self, index: NodeIndex, inner_node: InnerNode) -> Option<InnerNode> {
+        self.inner_nodes.insert(index, inner_node)
     }
 
-    fn remove_inner_node(&mut self, index: NodeIndex) {
-        let _ = self.inner_nodes.remove(&index);
+    fn remove_inner_node(&mut self, index: NodeIndex) -> Option<InnerNode> {
+        self.inner_nodes.remove(&index)
     }
 
     fn insert_value(&mut self, key: Self::Key, value: Self::Value) -> Option<Self::Value> {

--- a/src/merkle/smt/full/mod.rs
+++ b/src/merkle/smt/full/mod.rs
@@ -256,7 +256,9 @@ impl Smt {
         <Self as SparseMerkleTree<SMT_DEPTH>>::compute_mutations(self, kv_pairs)
     }
 
-    /// Apply the prospective mutations computed with [`Smt::compute_mutations()`] to this tree.
+    /// Applies the prospective mutations computed with [`Smt::compute_mutations()`] to
+    /// this tree and returns the reverse mutation set. Applying the reverse mutation sets to the
+    /// updated tree will revert the changes.
     ///
     /// # Errors
     /// If `mutations` was computed on a tree with a different root than this one, returns

--- a/src/merkle/smt/full/tests.rs
+++ b/src/merkle/smt/full/tests.rs
@@ -1,12 +1,15 @@
 use alloc::vec::Vec;
+use std::collections::BTreeMap;
 
 use super::{Felt, LeafIndex, NodeIndex, Rpo256, RpoDigest, Smt, SmtLeaf, EMPTY_WORD, SMT_DEPTH};
 use crate::{
-    merkle::{smt::SparseMerkleTree, EmptySubtreeRoots, MerkleStore},
+    merkle::{
+        smt::{NodeMutation, SparseMerkleTree},
+        EmptySubtreeRoots, MerkleStore, MutationSet,
+    },
     utils::{Deserializable, Serializable},
     Word, ONE, WORD_SIZE,
 };
-
 // SMT
 // --------------------------------------------------------------------------------------------
 
@@ -412,21 +415,49 @@ fn test_prospective_insertion() {
 
     let mutations = smt.compute_mutations(vec![(key_1, value_1)]);
     assert_eq!(mutations.root(), root_1, "prospective root 1 did not match actual root 1");
-    smt.apply_mutations(mutations).unwrap();
+    let revert = smt.apply_mutations(mutations).unwrap();
     assert_eq!(smt.root(), root_1, "mutations before and after apply did not match");
+    assert_eq!(revert.old_root, smt.root(), "reverse mutations old root did not match");
+    assert_eq!(revert.root(), root_empty, "reverse mutations new root did not match");
+    assert_eq!(
+        revert.new_pairs,
+        BTreeMap::from_iter([(key_1, EMPTY_WORD)]),
+        "reverse mutations pairs did not match"
+    );
+    assert_eq!(
+        revert.node_mutations,
+        smt.inner_nodes.iter().map(|(key, _)| (*key, NodeMutation::Removal)).collect(),
+        "reverse mutations inner nodes did not match"
+    );
 
     let mutations = smt.compute_mutations(vec![(key_2, value_2)]);
     assert_eq!(mutations.root(), root_2, "prospective root 2 did not match actual root 2");
     let mutations =
         smt.compute_mutations(vec![(key_3, EMPTY_WORD), (key_2, value_2), (key_3, value_3)]);
     assert_eq!(mutations.root(), root_3, "mutations before and after apply did not match");
-    smt.apply_mutations(mutations).unwrap();
+    let old_root = smt.root();
+    let revert = smt.apply_mutations(mutations).unwrap();
+    assert_eq!(revert.old_root, smt.root(), "reverse mutations old root did not match");
+    assert_eq!(revert.root(), old_root, "reverse mutations new root did not match");
+    assert_eq!(
+        revert.new_pairs,
+        BTreeMap::from_iter([(key_2, EMPTY_WORD), (key_3, EMPTY_WORD)]),
+        "reverse mutations pairs did not match"
+    );
 
     // Edge case: multiple values at the same key, where a later pair restores the original value.
     let mutations = smt.compute_mutations(vec![(key_3, EMPTY_WORD), (key_3, value_3)]);
     assert_eq!(mutations.root(), root_3);
-    smt.apply_mutations(mutations).unwrap();
+    let old_root = smt.root();
+    let revert = smt.apply_mutations(mutations).unwrap();
     assert_eq!(smt.root(), root_3);
+    assert_eq!(revert.old_root, smt.root(), "reverse mutations old root did not match");
+    assert_eq!(revert.root(), old_root, "reverse mutations new root did not match");
+    assert_eq!(
+        revert.new_pairs,
+        BTreeMap::from_iter([(key_3, value_3)]),
+        "reverse mutations pairs did not match"
+    );
 
     // Test batch updates, and that the order doesn't matter.
     let pairs =
@@ -437,14 +468,88 @@ fn test_prospective_insertion() {
         root_empty,
         "prospective root for batch removal did not match actual root",
     );
-    smt.apply_mutations(mutations).unwrap();
+    let old_root = smt.root();
+    let revert = smt.apply_mutations(mutations).unwrap();
     assert_eq!(smt.root(), root_empty, "mutations before and after apply did not match");
+    assert_eq!(revert.old_root, smt.root(), "reverse mutations old root did not match");
+    assert_eq!(revert.root(), old_root, "reverse mutations new root did not match");
+    assert_eq!(
+        revert.new_pairs,
+        BTreeMap::from_iter([(key_1, value_1), (key_2, value_2), (key_3, value_3)]),
+        "reverse mutations pairs did not match"
+    );
 
     let pairs = vec![(key_3, value_3), (key_1, value_1), (key_2, value_2)];
     let mutations = smt.compute_mutations(pairs);
     assert_eq!(mutations.root(), root_3);
     smt.apply_mutations(mutations).unwrap();
     assert_eq!(smt.root(), root_3);
+}
+
+#[test]
+fn test_mutations_revert() {
+    let mut smt = Smt::default();
+
+    let key_1: RpoDigest = RpoDigest::from([ONE, ONE, ONE, Felt::new(1)]);
+    let key_2: RpoDigest =
+        RpoDigest::from([2_u32.into(), 2_u32.into(), 2_u32.into(), Felt::new(2)]);
+    let key_3: RpoDigest =
+        RpoDigest::from([0_u32.into(), 0_u32.into(), 0_u32.into(), Felt::new(3)]);
+
+    let value_1 = [ONE; WORD_SIZE];
+    let value_2 = [2_u32.into(); WORD_SIZE];
+    let value_3 = [3_u32.into(); WORD_SIZE];
+
+    smt.insert(key_1, value_1);
+    smt.insert(key_2, value_2);
+
+    let mutations =
+        smt.compute_mutations(vec![(key_1, EMPTY_WORD), (key_2, value_1), (key_3, value_3)]);
+
+    let original = smt.clone();
+
+    let revert = smt.apply_mutations(mutations).unwrap();
+    assert_eq!(revert.old_root, smt.root(), "reverse mutations old root did not match");
+    assert_eq!(revert.root(), original.root(), "reverse mutations new root did not match");
+
+    let _ = smt.apply_mutations(revert).unwrap();
+
+    assert_eq!(smt, original, "SMT with applied revert mutations did not match original SMT");
+}
+
+#[test]
+fn test_mutation_set_serialization() {
+    let mut smt = Smt::default();
+
+    let key_1: RpoDigest = RpoDigest::from([ONE, ONE, ONE, Felt::new(1)]);
+    let key_2: RpoDigest =
+        RpoDigest::from([2_u32.into(), 2_u32.into(), 2_u32.into(), Felt::new(2)]);
+    let key_3: RpoDigest =
+        RpoDigest::from([0_u32.into(), 0_u32.into(), 0_u32.into(), Felt::new(3)]);
+
+    let value_1 = [ONE; WORD_SIZE];
+    let value_2 = [2_u32.into(); WORD_SIZE];
+    let value_3 = [3_u32.into(); WORD_SIZE];
+
+    smt.insert(key_1, value_1);
+    smt.insert(key_2, value_2);
+
+    let mutations =
+        smt.compute_mutations(vec![(key_1, EMPTY_WORD), (key_2, value_1), (key_3, value_3)]);
+
+    let serialized = mutations.to_bytes();
+    let deserialized =
+        MutationSet::<SMT_DEPTH, RpoDigest, Word>::read_from_bytes(&serialized).unwrap();
+
+    assert_eq!(deserialized, mutations, "deserialized mutations did not match original");
+
+    let revert = smt.apply_mutations(mutations).unwrap();
+
+    let serialized = revert.to_bytes();
+    let deserialized =
+        MutationSet::<SMT_DEPTH, RpoDigest, Word>::read_from_bytes(&serialized).unwrap();
+
+    assert_eq!(deserialized, revert, "deserialized mutations did not match original");
 }
 
 /// Tests that 2 key-value pairs stored in the same leaf have the same path

--- a/src/merkle/smt/full/tests.rs
+++ b/src/merkle/smt/full/tests.rs
@@ -1,5 +1,4 @@
-use alloc::vec::Vec;
-use std::collections::BTreeMap;
+use alloc::{collections::BTreeMap, vec::Vec};
 
 use super::{Felt, LeafIndex, NodeIndex, Rpo256, RpoDigest, Smt, SmtLeaf, EMPTY_WORD, SMT_DEPTH};
 use crate::{

--- a/src/merkle/smt/mod.rs
+++ b/src/merkle/smt/mod.rs
@@ -588,7 +588,7 @@ impl<const DEPTH: u8> TryFrom<NodeIndex> for LeafIndex<DEPTH> {
 /// [`MutationSet`] stores this type in relation to a [`NodeIndex`] to keep track of what changes
 /// need to occur at which node indices.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) enum NodeMutation {
+pub enum NodeMutation {
     /// Corresponds to [`SparseMerkleTree::remove_inner_node()`].
     Removal,
     /// Corresponds to [`SparseMerkleTree::insert_inner_node()`].
@@ -621,10 +621,26 @@ pub struct MutationSet<const DEPTH: u8, K, V> {
 }
 
 impl<const DEPTH: u8, K, V> MutationSet<DEPTH, K, V> {
-    /// Queries the root that was calculated during `SparseMerkleTree::compute_mutations()`. See
+    /// Returns the SMT root that was calculated during `SparseMerkleTree::compute_mutations()`. See
     /// that method for more information.
     pub fn root(&self) -> RpoDigest {
         self.new_root
+    }
+
+    /// Returns the SMT root before the mutations were applied.
+    pub fn old_root(&self) -> RpoDigest {
+        self.old_root
+    }
+
+    /// Returns the set of inner nodes that need to be removed or added.
+    pub fn node_mutations(&self) -> &BTreeMap<NodeIndex, NodeMutation> {
+        &self.node_mutations
+    }
+
+    /// Returns the set of top-level key-value pairs that need to be added, updated or deleted
+    /// (i.e. set to `EMPTY_WORD`).
+    pub fn new_pairs(&self) -> &BTreeMap<K, V> {
+        &self.new_pairs
     }
 }
 

--- a/src/merkle/smt/mod.rs
+++ b/src/merkle/smt/mod.rs
@@ -256,8 +256,9 @@ pub(crate) trait SparseMerkleTree<const DEPTH: u8> {
         }
     }
 
-    /// Apply the prospective mutations computed with [`SparseMerkleTree::compute_mutations()`] to
-    /// this tree. Return reverse mutation set.
+    /// Applies the prospective mutations computed with [`SparseMerkleTree::compute_mutations()`] to
+    /// this tree and returns the reverse mutation set. Applying the reverse mutation sets to the
+    /// updated tree will revert the changes.
     ///
     /// # Errors
     /// If `mutations` was computed on a tree with a different root than this one, returns

--- a/src/merkle/smt/mod.rs
+++ b/src/merkle/smt/mod.rs
@@ -1,4 +1,7 @@
 use alloc::{collections::BTreeMap, vec::Vec};
+use core::mem;
+
+use num::Integer;
 
 use super::{EmptySubtreeRoots, InnerNodeInfo, MerkleError, MerklePath, NodeIndex};
 use crate::{
@@ -61,6 +64,17 @@ pub(crate) trait SparseMerkleTree<const DEPTH: u8> {
 
     // PROVIDED METHODS
     // ---------------------------------------------------------------------------------------------
+
+    /// Creates a new sparse Merkle tree from an existing set of key-value pairs, in parallel.
+    #[cfg(feature = "concurrent")]
+    fn with_entries_par(entries: Vec<(Self::Key, Self::Value)>) -> Result<Self, MerkleError>
+    where
+        Self: Sized,
+    {
+        let (inner_nodes, leaves) = Self::build_subtrees(entries);
+        let root = inner_nodes.get(&NodeIndex::root()).unwrap().hash();
+        Self::from_raw_parts(inner_nodes, leaves, root)
+    }
 
     /// Returns an opening of the leaf associated with `key`. Conceptually, an opening is a Merkle
     /// path to the leaf, as well as the leaf itself.
@@ -292,6 +306,16 @@ pub(crate) trait SparseMerkleTree<const DEPTH: u8> {
     // REQUIRED METHODS
     // ---------------------------------------------------------------------------------------------
 
+    /// Construct this type from already computed leaves and nodes. The caller ensures passed
+    /// arguments are correct and consistent with each other.
+    fn from_raw_parts(
+        inner_nodes: BTreeMap<NodeIndex, InnerNode>,
+        leaves: BTreeMap<u64, Self::Leaf>,
+        root: RpoDigest,
+    ) -> Result<Self, MerkleError>
+    where
+        Self: Sized;
+
     /// The root of the tree
     fn root(&self) -> RpoDigest;
 
@@ -341,18 +365,137 @@ pub(crate) trait SparseMerkleTree<const DEPTH: u8> {
     /// Maps a key to a leaf index
     fn key_to_leaf_index(key: &Self::Key) -> LeafIndex<DEPTH>;
 
+    /// Constructs a single leaf from an arbitrary amount of key-value pairs.
+    /// Those pairs must all have the same leaf index.
+    fn pairs_to_leaf(pairs: Vec<(Self::Key, Self::Value)>) -> Self::Leaf;
+
     /// Maps a (MerklePath, Self::Leaf) to an opening.
     ///
     /// The length `path` is guaranteed to be equal to `DEPTH`
     fn path_and_leaf_to_opening(path: MerklePath, leaf: Self::Leaf) -> Self::Opening;
+
+    /// Performs the initial transforms for constructing a [`SparseMerkleTree`] by composing
+    /// subtrees. In other words, this function takes the key-value inputs to the tree, and produces
+    /// the inputs to feed into [`build_subtree()`].
+    ///
+    /// `pairs` *must* already be sorted **by leaf index column**, not simply sorted by key. If
+    /// `pairs` is not correctly sorted, the returned computations will be incorrect.
+    ///
+    /// # Panics
+    /// With debug assertions on, this function panics if it detects that `pairs` is not correctly
+    /// sorted. Without debug assertions, the returned computations will be incorrect.
+    fn sorted_pairs_to_leaves(
+        pairs: Vec<(Self::Key, Self::Value)>,
+    ) -> PairComputations<u64, Self::Leaf> {
+        debug_assert!(pairs.is_sorted_by_key(|(key, _)| Self::key_to_leaf_index(key).value()));
+
+        let mut accumulator: PairComputations<u64, Self::Leaf> = Default::default();
+        let mut accumulated_leaves: Vec<SubtreeLeaf> = Vec::with_capacity(pairs.len() / 2);
+
+        // As we iterate, we'll keep track of the kv-pairs we've seen so far that correspond to a
+        // single leaf. When we see a pair that's in a different leaf, we'll swap these pairs
+        // out and store them in our accumulated leaves.
+        let mut current_leaf_buffer: Vec<(Self::Key, Self::Value)> = Default::default();
+
+        let mut iter = pairs.into_iter().peekable();
+        while let Some((key, value)) = iter.next() {
+            let col = Self::key_to_leaf_index(&key).index.value();
+            let peeked_col = iter.peek().map(|(key, _v)| {
+                let index = Self::key_to_leaf_index(key);
+                let next_col = index.index.value();
+                // We panic if `pairs` is not sorted by column.
+                debug_assert!(next_col >= col);
+                next_col
+            });
+            current_leaf_buffer.push((key, value));
+
+            // If the next pair is the same column as this one, then we're done after adding this
+            // pair to the buffer.
+            if peeked_col == Some(col) {
+                continue;
+            }
+
+            // Otherwise, the next pair is a different column, or there is no next pair. Either way
+            // it's time to swap out our buffer.
+            let leaf_pairs = mem::take(&mut current_leaf_buffer);
+            let leaf = Self::pairs_to_leaf(leaf_pairs);
+            let hash = Self::hash_leaf(&leaf);
+
+            accumulator.nodes.insert(col, leaf);
+            accumulated_leaves.push(SubtreeLeaf { col, hash });
+
+            debug_assert!(current_leaf_buffer.is_empty());
+        }
+
+        // TODO: determine is there is any notable performance difference between computing
+        // subtree boundaries after the fact as an iterator adapter (like this), versus computing
+        // subtree boundaries as we go. Either way this function is only used at the beginning of a
+        // parallel construction, so it should not be a critical path.
+        accumulator.leaves = SubtreeLeavesIter::from_leaves(&mut accumulated_leaves).collect();
+        accumulator
+    }
+
+    /// Computes the raw parts for a new sparse Merkle tree from a set of key-value pairs.
+    ///
+    /// `entries` need not be sorted. This function will sort them.
+    #[cfg(feature = "concurrent")]
+    fn build_subtrees(
+        mut entries: Vec<(Self::Key, Self::Value)>,
+    ) -> (BTreeMap<NodeIndex, InnerNode>, BTreeMap<u64, Self::Leaf>) {
+        entries.sort_by_key(|item| {
+            let index = Self::key_to_leaf_index(&item.0);
+            index.value()
+        });
+        Self::build_subtrees_from_sorted_entries(entries)
+    }
+
+    /// Computes the raw parts for a new sparse Merkle tree from a set of key-value pairs.
+    ///
+    /// This function is mostly an implementation detail of
+    /// [`SparseMerkleTree::with_entries_par()`].
+    #[cfg(feature = "concurrent")]
+    fn build_subtrees_from_sorted_entries(
+        entries: Vec<(Self::Key, Self::Value)>,
+    ) -> (BTreeMap<NodeIndex, InnerNode>, BTreeMap<u64, Self::Leaf>) {
+        use rayon::prelude::*;
+
+        let mut accumulated_nodes: BTreeMap<NodeIndex, InnerNode> = Default::default();
+
+        let PairComputations {
+            leaves: mut leaf_subtrees,
+            nodes: initial_leaves,
+        } = Self::sorted_pairs_to_leaves(entries);
+
+        for current_depth in (SUBTREE_DEPTH..=DEPTH).step_by(SUBTREE_DEPTH as usize).rev() {
+            let (nodes, mut subtree_roots): (Vec<BTreeMap<_, _>>, Vec<SubtreeLeaf>) = leaf_subtrees
+                .into_par_iter()
+                .map(|subtree| {
+                    debug_assert!(subtree.is_sorted());
+                    debug_assert!(!subtree.is_empty());
+
+                    let (nodes, subtree_root) = build_subtree(subtree, DEPTH, current_depth);
+                    (nodes, subtree_root)
+                })
+                .unzip();
+
+            leaf_subtrees = SubtreeLeavesIter::from_leaves(&mut subtree_roots).collect();
+            accumulated_nodes.extend(nodes.into_iter().flatten());
+
+            debug_assert!(!leaf_subtrees.is_empty());
+        }
+        (accumulated_nodes, initial_leaves)
+    }
 }
 
 // INNER NODE
 // ================================================================================================
 
+/// This struct is public so functions returning it can be used in `benches/`, but is otherwise not
+/// part of the public API.
+#[doc(hidden)]
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
-pub(crate) struct InnerNode {
+pub struct InnerNode {
     pub left: RpoDigest,
     pub right: RpoDigest,
 }
@@ -462,3 +605,197 @@ impl<const DEPTH: u8, K, V> MutationSet<DEPTH, K, V> {
         self.new_root
     }
 }
+
+// SUBTREES
+// ================================================================================================
+/// A subtree is of depth 8.
+const SUBTREE_DEPTH: u8 = 8;
+
+/// A depth-8 subtree contains 256 "columns" that can possibly be occupied.
+const COLS_PER_SUBTREE: u64 = u64::pow(2, SUBTREE_DEPTH as u32);
+
+/// Helper struct for organizing the data we care about when computing Merkle subtrees.
+///
+/// Note that these represet "conceptual" leaves of some subtree, not necessarily
+/// the leaf type for the sparse Merkle tree.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Default)]
+pub struct SubtreeLeaf {
+    /// The 'value' field of [`NodeIndex`]. When computing a subtree, the depth is already known.
+    pub col: u64,
+    /// The hash of the node this `SubtreeLeaf` represents.
+    pub hash: RpoDigest,
+}
+
+/// Helper struct to organize the return value of [`SparseMerkleTree::sorted_pairs_to_leaves()`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PairComputations<K, L> {
+    /// Literal leaves to be added to the sparse Merkle tree's internal mapping.
+    pub nodes: BTreeMap<K, L>,
+    /// "Conceptual" leaves that will be used for computations.
+    pub leaves: Vec<Vec<SubtreeLeaf>>,
+}
+
+// Derive requires `L` to impl Default, even though we don't actually need that.
+impl<K, L> Default for PairComputations<K, L> {
+    fn default() -> Self {
+        Self {
+            nodes: Default::default(),
+            leaves: Default::default(),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct SubtreeLeavesIter<'s> {
+    leaves: core::iter::Peekable<alloc::vec::Drain<'s, SubtreeLeaf>>,
+}
+impl<'s> SubtreeLeavesIter<'s> {
+    fn from_leaves(leaves: &'s mut Vec<SubtreeLeaf>) -> Self {
+        // TODO: determine if there is any notable performance difference between taking a Vec,
+        // which many need flattening first, vs storing a `Box<dyn Iterator<Item = SubtreeLeaf>>`.
+        // The latter may have self-referential properties that are impossible to express in purely
+        // safe Rust Rust.
+        Self { leaves: leaves.drain(..).peekable() }
+    }
+}
+impl core::iter::Iterator for SubtreeLeavesIter<'_> {
+    type Item = Vec<SubtreeLeaf>;
+
+    /// Each `next()` collects an entire subtree.
+    fn next(&mut self) -> Option<Vec<SubtreeLeaf>> {
+        let mut subtree: Vec<SubtreeLeaf> = Default::default();
+
+        let mut last_subtree_col = 0;
+
+        while let Some(leaf) = self.leaves.peek() {
+            last_subtree_col = u64::max(1, last_subtree_col);
+            let is_exact_multiple = Integer::is_multiple_of(&last_subtree_col, &COLS_PER_SUBTREE);
+            let next_subtree_col = if is_exact_multiple {
+                u64::next_multiple_of(last_subtree_col + 1, COLS_PER_SUBTREE)
+            } else {
+                last_subtree_col.next_multiple_of(COLS_PER_SUBTREE)
+            };
+
+            last_subtree_col = leaf.col;
+            if leaf.col < next_subtree_col {
+                subtree.push(self.leaves.next().unwrap());
+            } else if subtree.is_empty() {
+                continue;
+            } else {
+                break;
+            }
+        }
+
+        if subtree.is_empty() {
+            debug_assert!(self.leaves.peek().is_none());
+            return None;
+        }
+
+        Some(subtree)
+    }
+}
+
+// HELPER FUNCTIONS
+// ================================================================================================
+
+/// Builds Merkle nodes from a bottom layer of "leaves" -- represented by a horizontal index and
+/// the hash of the leaf at that index. `leaves` *must* be sorted by horizontal index, and
+/// `leaves` must not contain more than one depth-8 subtree's worth of leaves.
+///
+/// This function will then calculate the inner nodes above each leaf for 8 layers, as well as
+/// the "leaves" for the next 8-deep subtree, so this function can effectively be chained into
+/// itself.
+///
+/// # Panics
+/// With debug assertions on, this function panics under invalid inputs: if `leaves` contains
+/// more entries than can fit in a depth-8 subtree, if `leaves` contains leaves belonging to
+/// different depth-8 subtrees, if `bottom_depth` is lower in the tree than the specified
+/// maximum depth (`DEPTH`), or if `leaves` is not sorted.
+fn build_subtree(
+    mut leaves: Vec<SubtreeLeaf>,
+    tree_depth: u8,
+    bottom_depth: u8,
+) -> (BTreeMap<NodeIndex, InnerNode>, SubtreeLeaf) {
+    debug_assert!(bottom_depth <= tree_depth);
+    debug_assert!(Integer::is_multiple_of(&bottom_depth, &SUBTREE_DEPTH));
+    debug_assert!(leaves.len() <= usize::pow(2, SUBTREE_DEPTH as u32));
+    let subtree_root = bottom_depth - SUBTREE_DEPTH;
+    let mut inner_nodes: BTreeMap<NodeIndex, InnerNode> = Default::default();
+    let mut next_leaves: Vec<SubtreeLeaf> = Vec::with_capacity(leaves.len() / 2);
+    for next_depth in (subtree_root..bottom_depth).rev() {
+        debug_assert!(next_depth <= bottom_depth);
+        // `next_depth` is the stuff we're making.
+        // `current_depth` is the stuff we have.
+        let current_depth = next_depth + 1;
+        let mut iter = leaves.drain(..).peekable();
+        while let Some(first) = iter.next() {
+            // On non-continuous iterations, including the first iteration, `first_column` may
+            // be a left or right node. On subsequent continuous iterations, we will always call
+            // `iter.next()` twice.
+            // On non-continuous iterations (including the very first iteration), this column
+            // could be either on the left or the right. If the next iteration is not
+            // discontinuous with our right node, then the next iteration's
+            let is_right = first.col.is_odd();
+            let (left, right) = if is_right {
+                // Discontinuous iteration: we have no left node, so it must be empty.
+                let left = SubtreeLeaf {
+                    col: first.col - 1,
+                    hash: *EmptySubtreeRoots::entry(tree_depth, current_depth),
+                };
+                let right = first;
+                (left, right)
+            } else {
+                let left = first;
+                let right_col = first.col + 1;
+                let right = match iter.peek().copied() {
+                    Some(SubtreeLeaf { col, .. }) if col == right_col => {
+                        // Our inputs must be sorted.
+                        debug_assert!(left.col <= col);
+                        // The next leaf in the iterator is our sibling. Use it and consume it!
+                        iter.next().unwrap()
+                    },
+                    // Otherwise, the leaves don't contain our sibling, so our sibling must be
+                    // empty.
+                    _ => SubtreeLeaf {
+                        col: right_col,
+                        hash: *EmptySubtreeRoots::entry(tree_depth, current_depth),
+                    },
+                };
+                (left, right)
+            };
+            let index = NodeIndex::new_unchecked(current_depth, left.col).parent();
+            let node = InnerNode { left: left.hash, right: right.hash };
+            let hash = node.hash();
+            let &equivalent_empty_hash = EmptySubtreeRoots::entry(tree_depth, next_depth);
+            // If this hash is empty, then it doesn't become a new inner node, nor does it count
+            // as a leaf for the next depth.
+            if hash != equivalent_empty_hash {
+                inner_nodes.insert(index, node);
+                next_leaves.push(SubtreeLeaf { col: index.value(), hash });
+            }
+        }
+        // Stop borrowing `leaves`, so we can swap it.
+        // The iterator is empty at this point anyway.
+        drop(iter);
+        // After each depth, consider the stuff we just made the new "leaves", and empty the
+        // other collection.
+        mem::swap(&mut leaves, &mut next_leaves);
+    }
+    debug_assert_eq!(leaves.len(), 1);
+    let root = leaves.pop().unwrap();
+    (inner_nodes, root)
+}
+
+#[cfg(feature = "internal")]
+pub fn build_subtree_for_bench(
+    leaves: Vec<SubtreeLeaf>,
+    tree_depth: u8,
+    bottom_depth: u8,
+) -> (BTreeMap<NodeIndex, InnerNode>, SubtreeLeaf) {
+    build_subtree(leaves, tree_depth, bottom_depth)
+}
+
+// TESTS
+// ================================================================================================
+#[cfg(test)]
+mod tests;

--- a/src/merkle/smt/simple/mod.rs
+++ b/src/merkle/smt/simple/mod.rs
@@ -252,7 +252,7 @@ impl<const DEPTH: u8> SimpleSmt<DEPTH> {
     pub fn apply_mutations(
         &mut self,
         mutations: MutationSet<DEPTH, LeafIndex<DEPTH>, Word>,
-    ) -> Result<(), MerkleError> {
+    ) -> Result<MutationSet<DEPTH, LeafIndex<DEPTH>, Word>, MerkleError> {
         <Self as SparseMerkleTree<DEPTH>>::apply_mutations(self, mutations)
     }
 
@@ -354,12 +354,12 @@ impl<const DEPTH: u8> SparseMerkleTree<DEPTH> for SimpleSmt<DEPTH> {
             .unwrap_or_else(|| EmptySubtreeRoots::get_inner_node(DEPTH, index.depth()))
     }
 
-    fn insert_inner_node(&mut self, index: NodeIndex, inner_node: InnerNode) {
-        self.inner_nodes.insert(index, inner_node);
+    fn insert_inner_node(&mut self, index: NodeIndex, inner_node: InnerNode) -> Option<InnerNode> {
+        self.inner_nodes.insert(index, inner_node)
     }
 
-    fn remove_inner_node(&mut self, index: NodeIndex) {
-        let _ = self.inner_nodes.remove(&index);
+    fn remove_inner_node(&mut self, index: NodeIndex) -> Option<InnerNode> {
+        self.inner_nodes.remove(&index)
     }
 
     fn insert_value(&mut self, key: LeafIndex<DEPTH>, value: Word) -> Option<Word> {

--- a/src/merkle/smt/simple/mod.rs
+++ b/src/merkle/smt/simple/mod.rs
@@ -241,8 +241,9 @@ impl<const DEPTH: u8> SimpleSmt<DEPTH> {
         <Self as SparseMerkleTree<DEPTH>>::compute_mutations(self, kv_pairs)
     }
 
-    /// Apply the prospective mutations computed with [`SimpleSmt::compute_mutations()`] to this
-    /// tree.
+    /// Applies the prospective mutations computed with [`SimpleSmt::compute_mutations()`] to
+    /// this tree and returns the reverse mutation set. Applying the reverse mutation sets to the
+    /// updated tree will revert the changes.
     ///
     /// # Errors
     /// If `mutations` was computed on a tree with a different root than this one, returns

--- a/src/merkle/smt/tests.rs
+++ b/src/merkle/smt/tests.rs
@@ -1,0 +1,417 @@
+use alloc::{collections::BTreeMap, vec::Vec};
+
+use super::{
+    build_subtree, InnerNode, LeafIndex, NodeIndex, PairComputations, SmtLeaf, SparseMerkleTree,
+    SubtreeLeaf, SubtreeLeavesIter, COLS_PER_SUBTREE, SUBTREE_DEPTH,
+};
+use crate::{
+    hash::rpo::RpoDigest,
+    merkle::{Smt, SMT_DEPTH},
+    Felt, Word, ONE,
+};
+
+fn smtleaf_to_subtree_leaf(leaf: &SmtLeaf) -> SubtreeLeaf {
+    SubtreeLeaf {
+        col: leaf.index().index.value(),
+        hash: leaf.hash(),
+    }
+}
+
+#[test]
+fn test_sorted_pairs_to_leaves() {
+    let entries: Vec<(RpoDigest, Word)> = vec![
+        // Subtree 0.
+        (RpoDigest::new([ONE, ONE, ONE, Felt::new(16)]), [ONE; 4]),
+        (RpoDigest::new([ONE, ONE, ONE, Felt::new(17)]), [ONE; 4]),
+        // Leaf index collision.
+        (RpoDigest::new([ONE, ONE, Felt::new(10), Felt::new(20)]), [ONE; 4]),
+        (RpoDigest::new([ONE, ONE, Felt::new(20), Felt::new(20)]), [ONE; 4]),
+        // Subtree 1. Normal single leaf again.
+        (RpoDigest::new([ONE, ONE, ONE, Felt::new(400)]), [ONE; 4]), // Subtree boundary.
+        (RpoDigest::new([ONE, ONE, ONE, Felt::new(401)]), [ONE; 4]),
+        // Subtree 2. Another normal leaf.
+        (RpoDigest::new([ONE, ONE, ONE, Felt::new(1024)]), [ONE; 4]),
+    ];
+
+    let control = Smt::with_entries_sequential(entries.clone()).unwrap();
+
+    let control_leaves: Vec<SmtLeaf> = {
+        let mut entries_iter = entries.iter().cloned();
+        let mut next_entry = || entries_iter.next().unwrap();
+        let control_leaves = vec![
+            // Subtree 0.
+            SmtLeaf::Single(next_entry()),
+            SmtLeaf::Single(next_entry()),
+            SmtLeaf::new_multiple(vec![next_entry(), next_entry()]).unwrap(),
+            // Subtree 1.
+            SmtLeaf::Single(next_entry()),
+            SmtLeaf::Single(next_entry()),
+            // Subtree 2.
+            SmtLeaf::Single(next_entry()),
+        ];
+        assert_eq!(entries_iter.next(), None);
+        control_leaves
+    };
+
+    let control_subtree_leaves: Vec<Vec<SubtreeLeaf>> = {
+        let mut control_leaves_iter = control_leaves.iter();
+        let mut next_leaf = || control_leaves_iter.next().unwrap();
+
+        let control_subtree_leaves: Vec<Vec<SubtreeLeaf>> = [
+            // Subtree 0.
+            vec![next_leaf(), next_leaf(), next_leaf()],
+            // Subtree 1.
+            vec![next_leaf(), next_leaf()],
+            // Subtree 2.
+            vec![next_leaf()],
+        ]
+        .map(|subtree| subtree.into_iter().map(smtleaf_to_subtree_leaf).collect())
+        .to_vec();
+        assert_eq!(control_leaves_iter.next(), None);
+        control_subtree_leaves
+    };
+
+    let subtrees: PairComputations<u64, SmtLeaf> = Smt::sorted_pairs_to_leaves(entries);
+    // This will check that the hashes, columns, and subtree assignments all match.
+    assert_eq!(subtrees.leaves, control_subtree_leaves);
+
+    // Flattening and re-separating out the leaves into subtrees should have the same result.
+    let mut all_leaves: Vec<SubtreeLeaf> = subtrees.leaves.clone().into_iter().flatten().collect();
+    let re_grouped: Vec<Vec<_>> = SubtreeLeavesIter::from_leaves(&mut all_leaves).collect();
+    assert_eq!(subtrees.leaves, re_grouped);
+
+    // Then finally we might as well check the computed leaf nodes too.
+    let control_leaves: BTreeMap<u64, SmtLeaf> = control
+        .leaves()
+        .map(|(index, value)| (index.index.value(), value.clone()))
+        .collect();
+
+    for (column, test_leaf) in subtrees.nodes {
+        if test_leaf.is_empty() {
+            continue;
+        }
+        let control_leaf = control_leaves
+            .get(&column)
+            .unwrap_or_else(|| panic!("no leaf node found for column {column}"));
+        assert_eq!(control_leaf, &test_leaf);
+    }
+}
+
+// Helper for the below tests.
+fn generate_entries(pair_count: u64) -> Vec<(RpoDigest, Word)> {
+    (0..pair_count)
+        .map(|i| {
+            let leaf_index = ((i as f64 / pair_count as f64) * (pair_count as f64)) as u64;
+            let key = RpoDigest::new([ONE, ONE, Felt::new(i), Felt::new(leaf_index)]);
+            let value = [ONE, ONE, ONE, Felt::new(i)];
+            (key, value)
+        })
+        .collect()
+}
+
+#[test]
+fn test_single_subtree() {
+    // A single subtree's worth of leaves.
+    const PAIR_COUNT: u64 = COLS_PER_SUBTREE;
+
+    let entries = generate_entries(PAIR_COUNT);
+
+    let control = Smt::with_entries_sequential(entries.clone()).unwrap();
+
+    // `entries` should already be sorted by nature of how we constructed it.
+    let leaves = Smt::sorted_pairs_to_leaves(entries).leaves;
+    let leaves = leaves.into_iter().next().unwrap();
+
+    let (first_subtree, subtree_root) = build_subtree(leaves, SMT_DEPTH, SMT_DEPTH);
+    assert!(!first_subtree.is_empty());
+
+    // The inner nodes computed from that subtree should match the nodes in our control tree.
+    for (index, node) in first_subtree.into_iter() {
+        let control = control.get_inner_node(index);
+        assert_eq!(
+            control, node,
+            "subtree-computed node at index {index:?} does not match control",
+        );
+    }
+
+    // The root returned should also match the equivalent node in the control tree.
+    let control_root_index =
+        NodeIndex::new(SMT_DEPTH - SUBTREE_DEPTH, subtree_root.col).expect("Valid root index");
+    let control_root_node = control.get_inner_node(control_root_index);
+    let control_hash = control_root_node.hash();
+    assert_eq!(
+        control_hash, subtree_root.hash,
+        "Subtree-computed root at index {control_root_index:?} does not match control"
+    );
+}
+
+// Test that not just can we compute a subtree correctly, but we can feed the results of one
+// subtree into computing another. In other words, test that `build_subtree()` is correctly
+// composable.
+#[test]
+fn test_two_subtrees() {
+    // Two subtrees' worth of leaves.
+    const PAIR_COUNT: u64 = COLS_PER_SUBTREE * 2;
+
+    let entries = generate_entries(PAIR_COUNT);
+
+    let control = Smt::with_entries_sequential(entries.clone()).unwrap();
+
+    let PairComputations { leaves, .. } = Smt::sorted_pairs_to_leaves(entries);
+    // With two subtrees' worth of leaves, we should have exactly two subtrees.
+    let [first, second]: [Vec<_>; 2] = leaves.try_into().unwrap();
+    assert_eq!(first.len() as u64, PAIR_COUNT / 2);
+    assert_eq!(first.len(), second.len());
+
+    let mut current_depth = SMT_DEPTH;
+    let mut next_leaves: Vec<SubtreeLeaf> = Default::default();
+
+    let (first_nodes, first_root) = build_subtree(first, SMT_DEPTH, current_depth);
+    next_leaves.push(first_root);
+
+    let (second_nodes, second_root) = build_subtree(second, SMT_DEPTH, current_depth);
+    next_leaves.push(second_root);
+
+    // All new inner nodes + the new subtree-leaves should be 512, for one depth-cycle.
+    let total_computed = first_nodes.len() + second_nodes.len() + next_leaves.len();
+    assert_eq!(total_computed as u64, PAIR_COUNT);
+
+    // Verify the computed nodes of both subtrees.
+    let computed_nodes = first_nodes.clone().into_iter().chain(second_nodes);
+    for (index, test_node) in computed_nodes {
+        let control_node = control.get_inner_node(index);
+        assert_eq!(
+            control_node, test_node,
+            "subtree-computed node at index {index:?} does not match control",
+        );
+    }
+
+    current_depth -= SUBTREE_DEPTH;
+
+    let (nodes, root_leaf) = build_subtree(next_leaves, SMT_DEPTH, current_depth);
+    assert_eq!(nodes.len(), SUBTREE_DEPTH as usize);
+    assert_eq!(root_leaf.col, 0);
+
+    for (index, test_node) in nodes {
+        let control_node = control.get_inner_node(index);
+        assert_eq!(
+            control_node, test_node,
+            "subtree-computed node at index {index:?} does not match control",
+        );
+    }
+
+    let index = NodeIndex::new(current_depth - SUBTREE_DEPTH, root_leaf.col).unwrap();
+    let control_root = control.get_inner_node(index).hash();
+    assert_eq!(control_root, root_leaf.hash, "Root mismatch");
+}
+
+#[test]
+fn test_singlethreaded_subtrees() {
+    const PAIR_COUNT: u64 = COLS_PER_SUBTREE * 64;
+
+    let entries = generate_entries(PAIR_COUNT);
+
+    let control = Smt::with_entries_sequential(entries.clone()).unwrap();
+
+    let mut accumulated_nodes: BTreeMap<NodeIndex, InnerNode> = Default::default();
+
+    let PairComputations {
+        leaves: mut leaf_subtrees,
+        nodes: test_leaves,
+    } = Smt::sorted_pairs_to_leaves(entries);
+
+    for current_depth in (SUBTREE_DEPTH..=SMT_DEPTH).step_by(SUBTREE_DEPTH as usize).rev() {
+        // There's no flat_map_unzip(), so this is the best we can do.
+        let (nodes, mut subtree_roots): (Vec<BTreeMap<_, _>>, Vec<SubtreeLeaf>) = leaf_subtrees
+            .into_iter()
+            .enumerate()
+            .map(|(i, subtree)| {
+                // Pre-assertions.
+                assert!(
+                    subtree.is_sorted(),
+                    "subtree {i} at bottom-depth {current_depth} is not sorted",
+                );
+                assert!(
+                    !subtree.is_empty(),
+                    "subtree {i} at bottom-depth {current_depth} is empty!",
+                );
+
+                // Do actual things.
+                let (nodes, subtree_root) = build_subtree(subtree, SMT_DEPTH, current_depth);
+
+                // Post-assertions.
+                for (&index, test_node) in nodes.iter() {
+                    let control_node = control.get_inner_node(index);
+                    assert_eq!(
+                        test_node, &control_node,
+                        "depth {} subtree {}: test node does not match control at index {:?}",
+                        current_depth, i, index,
+                    );
+                }
+
+                (nodes, subtree_root)
+            })
+            .unzip();
+
+        // Update state between each depth iteration.
+
+        leaf_subtrees = SubtreeLeavesIter::from_leaves(&mut subtree_roots).collect();
+        accumulated_nodes.extend(nodes.into_iter().flatten());
+
+        assert!(!leaf_subtrees.is_empty(), "on depth {current_depth}");
+    }
+
+    // Make sure the true leaves match, first checking length and then checking each individual
+    // leaf.
+    let control_leaves: BTreeMap<_, _> = control.leaves().collect();
+    let control_leaves_len = control_leaves.len();
+    let test_leaves_len = test_leaves.len();
+    assert_eq!(test_leaves_len, control_leaves_len);
+    for (col, ref test_leaf) in test_leaves {
+        let index = LeafIndex::new_max_depth(col);
+        let &control_leaf = control_leaves.get(&index).unwrap();
+        assert_eq!(test_leaf, control_leaf, "test leaf at column {col} does not match control");
+    }
+
+    // Make sure the inner nodes match, checking length first and then each individual leaf.
+    let control_nodes_len = control.inner_nodes().count();
+    let test_nodes_len = accumulated_nodes.len();
+    assert_eq!(test_nodes_len, control_nodes_len);
+    for (index, test_node) in accumulated_nodes.clone() {
+        let control_node = control.get_inner_node(index);
+        assert_eq!(test_node, control_node, "test node does not match control at {index:?}");
+    }
+
+    // After the last iteration of the above for loop, we should have the new root node actually
+    // in two places: one in `accumulated_nodes`, and the other as the "next leaves" return from
+    // `build_subtree()`. So let's check both!
+
+    let control_root = control.get_inner_node(NodeIndex::root());
+
+    // That for loop should have left us with only one leaf subtree...
+    let [leaf_subtree]: [Vec<_>; 1] = leaf_subtrees.try_into().unwrap();
+    // which itself contains only one 'leaf'...
+    let [root_leaf]: [SubtreeLeaf; 1] = leaf_subtree.try_into().unwrap();
+    // which matches the expected root.
+    assert_eq!(control.root(), root_leaf.hash);
+
+    // Likewise `accumulated_nodes` should contain a node at the root index...
+    assert!(accumulated_nodes.contains_key(&NodeIndex::root()));
+    // and it should match our actual root.
+    let test_root = accumulated_nodes.get(&NodeIndex::root()).unwrap();
+    assert_eq!(control_root, *test_root);
+    // And of course the root we got from each place should match.
+    assert_eq!(control.root(), root_leaf.hash);
+}
+
+/// The parallel version of `test_singlethreaded_subtree()`.
+#[test]
+#[cfg(feature = "concurrent")]
+fn test_multithreaded_subtrees() {
+    use rayon::prelude::*;
+
+    const PAIR_COUNT: u64 = COLS_PER_SUBTREE * 64;
+
+    let entries = generate_entries(PAIR_COUNT);
+
+    let control = Smt::with_entries_sequential(entries.clone()).unwrap();
+
+    let mut accumulated_nodes: BTreeMap<NodeIndex, InnerNode> = Default::default();
+
+    let PairComputations {
+        leaves: mut leaf_subtrees,
+        nodes: test_leaves,
+    } = Smt::sorted_pairs_to_leaves(entries);
+
+    for current_depth in (SUBTREE_DEPTH..=SMT_DEPTH).step_by(SUBTREE_DEPTH as usize).rev() {
+        let (nodes, mut subtree_roots): (Vec<BTreeMap<_, _>>, Vec<SubtreeLeaf>) = leaf_subtrees
+            .into_par_iter()
+            .enumerate()
+            .map(|(i, subtree)| {
+                // Pre-assertions.
+                assert!(
+                    subtree.is_sorted(),
+                    "subtree {i} at bottom-depth {current_depth} is not sorted",
+                );
+                assert!(
+                    !subtree.is_empty(),
+                    "subtree {i} at bottom-depth {current_depth} is empty!",
+                );
+
+                let (nodes, subtree_root) = build_subtree(subtree, SMT_DEPTH, current_depth);
+
+                // Post-assertions.
+                for (&index, test_node) in nodes.iter() {
+                    let control_node = control.get_inner_node(index);
+                    assert_eq!(
+                        test_node, &control_node,
+                        "depth {} subtree {}: test node does not match control at index {:?}",
+                        current_depth, i, index,
+                    );
+                }
+
+                (nodes, subtree_root)
+            })
+            .unzip();
+
+        leaf_subtrees = SubtreeLeavesIter::from_leaves(&mut subtree_roots).collect();
+        accumulated_nodes.extend(nodes.into_iter().flatten());
+
+        assert!(!leaf_subtrees.is_empty(), "on depth {current_depth}");
+    }
+
+    // Make sure the true leaves match, checking length first and then each individual leaf.
+    let control_leaves: BTreeMap<_, _> = control.leaves().collect();
+    let control_leaves_len = control_leaves.len();
+    let test_leaves_len = test_leaves.len();
+    assert_eq!(test_leaves_len, control_leaves_len);
+    for (col, ref test_leaf) in test_leaves {
+        let index = LeafIndex::new_max_depth(col);
+        let &control_leaf = control_leaves.get(&index).unwrap();
+        assert_eq!(test_leaf, control_leaf);
+    }
+
+    // Make sure the inner nodes match, checking length first and then each individual leaf.
+    let control_nodes_len = control.inner_nodes().count();
+    let test_nodes_len = accumulated_nodes.len();
+    assert_eq!(test_nodes_len, control_nodes_len);
+    for (index, test_node) in accumulated_nodes.clone() {
+        let control_node = control.get_inner_node(index);
+        assert_eq!(test_node, control_node, "test node does not match control at {index:?}");
+    }
+
+    // After the last iteration of the above for loop, we should have the new root node actually
+    // in two places: one in `accumulated_nodes`, and the other as the "next leaves" return from
+    // `build_subtree()`. So let's check both!
+
+    let control_root = control.get_inner_node(NodeIndex::root());
+
+    // That for loop should have left us with only one leaf subtree...
+    let [leaf_subtree]: [_; 1] = leaf_subtrees.try_into().unwrap();
+    // which itself contains only one 'leaf'...
+    let [root_leaf]: [_; 1] = leaf_subtree.try_into().unwrap();
+    // which matches the expected root.
+    assert_eq!(control.root(), root_leaf.hash);
+
+    // Likewise `accumulated_nodes` should contain a node at the root index...
+    assert!(accumulated_nodes.contains_key(&NodeIndex::root()));
+    // and it should match our actual root.
+    let test_root = accumulated_nodes.get(&NodeIndex::root()).unwrap();
+    assert_eq!(control_root, *test_root);
+    // And of course the root we got from each place should match.
+    assert_eq!(control.root(), root_leaf.hash);
+}
+
+#[test]
+#[cfg(feature = "concurrent")]
+fn test_with_entries_parallel() {
+    const PAIR_COUNT: u64 = COLS_PER_SUBTREE * 64;
+
+    let entries = generate_entries(PAIR_COUNT);
+
+    let control = Smt::with_entries_sequential(entries.clone()).unwrap();
+
+    let smt = Smt::with_entries(entries.clone()).unwrap();
+    assert_eq!(smt.root(), control.root());
+    assert_eq!(smt, control);
+}

--- a/src/merkle/store/tests.rs
+++ b/src/merkle/store/tests.rs
@@ -725,7 +725,7 @@ fn get_leaf_depth_works_with_depth_8() {
         assert_eq!(8, store.get_leaf_depth(root, 8, k).unwrap());
     }
 
-    // flip last bit of a and expect it to return the the same depth, but for an empty node
+    // flip last bit of a and expect it to return the same depth, but for an empty node
     assert_eq!(8, store.get_leaf_depth(root, 8, 0b01101000_u64).unwrap());
 
     // flip fourth bit of a and expect an empty node on depth 4


### PR DESCRIPTION
Related to https://github.com/0xPolygonMiden/miden-node/issues/527

These getters are necessary for traversing through inner nodes and values of mutation sets.