### PR TITLE
typo-Update mod.rs

### DIFF
--- a/src/merkle/smt/mod.rs
+++ b/src/merkle/smt/mod.rs
@@ -441,7 +441,7 @@ pub struct MutationSet<const DEPTH: u8, K, V> {
     old_root: RpoDigest,
     /// The set of nodes that need to be removed or added. The "effective" node at an index is the
     /// Merkle tree's existing node at that index, with the [`NodeMutation`] in this map at that
-    /// index overlayed, if any. Each [`NodeMutation::Addition`] corresponds to a
+    /// index overlaid, if any. Each [`NodeMutation::Addition`] corresponds to a
     /// [`SparseMerkleTree::insert_inner_node()`] call, and each [`NodeMutation::Removal`]
     /// corresponds to a [`SparseMerkleTree::remove_inner_node()`] call.
     node_mutations: BTreeMap<NodeIndex, NodeMutation>,


### PR DESCRIPTION
# Fix: Corrected typo in source file

## Changes
- `src/merkle/smt/mod.rs:444`: "overlayed" corrected to "overlaid".

## Purpose
- Improved code accuracy and professionalism by fixing the typo.

