### PR TITLE
Added support for hashmaps in `Smt` and `SimpleSmt`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         toolchain: [stable, nightly]
         os: [ubuntu]
-        args: [default, no-std]
+        args: [default, smt-hashmaps, no-std]
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Fixed a bug in the implementation of `draw_integers` for `RpoRandomCoin` (#343).
 - [BREAKING] Refactor error messages and use `thiserror` to derive errors (#344).
 - [BREAKING] Updated Winterfell dependency to v0.11 (#346).
+- Added support for hashmaps in `Smt` and `SimpleSmt` which gives up to 10x boost in some operations (#363).
 
 ## 0.12.0 (2024-10-30)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -350,6 +356,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
 name = "errno"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -370,6 +382,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f81ec6369c545a7d40e4589b5597581fa1c441fe1cce96dd1de43159910a36a2"
 
 [[package]]
 name = "generic-array"
@@ -408,6 +426,18 @@ checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
 dependencies = [
  "cfg-if",
  "crunchy",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+ "serde",
 ]
 
 [[package]]
@@ -534,6 +564,7 @@ dependencies = [
  "criterion",
  "getrandom",
  "glob",
+ "hashbrown",
  "hex",
  "num",
  "num-complex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ harness = false
 concurrent = ["dep:rayon"]
 default = ["std", "concurrent"]
 executable = ["dep:clap", "dep:rand-utils", "std"]
+hashmaps = ["dep:hashbrown"]
 internal = []
 serde = ["dep:serde", "serde?/alloc", "winter-math/serde"]
 std = [
@@ -63,7 +64,7 @@ std = [
 [dependencies]
 blake3 = { version = "1.5", default-features = false }
 clap = { version = "4.5", optional = true, features = ["derive"] }
-hashbrown = { version = "0.15", features = ["serde"] }
+hashbrown = { version = "0.15", optional = true, features = ["serde"] }
 num = { version = "0.4", default-features = false, features = ["alloc", "libm"] }
 num-complex = { version = "0.4", default-features = false }
 rand = { version = "0.8", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ std = [
 [dependencies]
 blake3 = { version = "1.5", default-features = false }
 clap = { version = "4.5", optional = true, features = ["derive"] }
+hashbrown = { version = "0.15", features = ["serde"] }
 num = { version = "0.4", default-features = false, features = ["alloc", "libm"] }
 num-complex = { version = "0.4", default-features = false }
 rand = { version = "0.8", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ harness = false
 concurrent = ["dep:rayon"]
 default = ["std", "concurrent"]
 executable = ["dep:clap", "dep:rand-utils", "std"]
-smt_hashmaps = []
+smt_hashmaps = ["dep:hashbrown"]
 internal = []
 serde = ["dep:serde", "serde?/alloc", "winter-math/serde"]
 std = [
@@ -64,7 +64,7 @@ std = [
 [dependencies]
 blake3 = { version = "1.5", default-features = false }
 clap = { version = "4.5", optional = true, features = ["derive"] }
-hashbrown = { version = "0.15", features = ["serde"] }
+hashbrown = { version = "0.15", optional = true, features = ["serde"] }
 num = { version = "0.4", default-features = false, features = ["alloc", "libm"] }
 num-complex = { version = "0.4", default-features = false }
 rand = { version = "0.8", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ harness = false
 concurrent = ["dep:rayon"]
 default = ["std", "concurrent"]
 executable = ["dep:clap", "dep:rand-utils", "std"]
-hashmaps = ["dep:hashbrown"]
+smt_hashmaps = []
 internal = []
 serde = ["dep:serde", "serde?/alloc", "winter-math/serde"]
 std = [
@@ -64,7 +64,7 @@ std = [
 [dependencies]
 blake3 = { version = "1.5", default-features = false }
 clap = { version = "4.5", optional = true, features = ["derive"] }
-hashbrown = { version = "0.15", optional = true, features = ["serde"] }
+hashbrown = { version = "0.15", features = ["serde"] }
 num = { version = "0.4", default-features = false, features = ["alloc", "libm"] }
 num-complex = { version = "0.4", default-features = false }
 rand = { version = "0.8", default-features = false }

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,9 @@ doc: ## Generate and check documentation
 test-default: ## Run tests with default features
 	$(DEBUG_OVERFLOW_INFO) cargo nextest run --profile default --release --all-features
 
+.PHONY: test-smt-hashmaps
+test-smt-hashmaps: ## Run tests with `smt_hashmaps` feature enabled
+	$(DEBUG_OVERFLOW_INFO) cargo nextest run --profile default --release --features smt_hashmaps
 
 .PHONY: test-no-std
 test-no-std: ## Run tests with `no-default-features` (std)
@@ -53,7 +56,7 @@ test-no-std: ## Run tests with `no-default-features` (std)
 
 
 .PHONY: test
-test: test-default test-no-std ## Run all tests
+test: test-default test-smt-hashmaps test-no-std ## Run all tests
 
 # --- checking ------------------------------------------------------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ This crate can be compiled with the following features:
 - `concurrent`- enabled by default; enables multi-threaded implementation of `Smt::with_entries()` which significantly improves performance on multi-core CPUs.
 - `std` - enabled by default and relies on the Rust standard library.
 - `no_std` does not rely on the Rust standard library and enables compilation to WebAssembly.
+- `smt_hashmaps` - uses hashbrown hashmaps in SMT implementation which significantly improves performance of SMT updating. Keys ordering in SMT iterators is not guarantied when this feature is enabled.
 
 All of these features imply the use of [alloc](https://doc.rust-lang.org/alloc/) to support heap-allocated collections.
 

--- a/src/hash/rescue/rpo/digest.rs
+++ b/src/hash/rescue/rpo/digest.rs
@@ -1,6 +1,11 @@
 use alloc::string::String;
-use core::{cmp::Ordering, fmt::Display, ops::Deref, slice};
-use std::hash::{Hash, Hasher};
+use core::{
+    cmp::Ordering,
+    fmt::Display,
+    hash::{Hash, Hasher},
+    ops::Deref,
+    slice,
+};
 
 use thiserror::Error;
 

--- a/src/hash/rescue/rpo/digest.rs
+++ b/src/hash/rescue/rpo/digest.rs
@@ -1,5 +1,6 @@
 use alloc::string::String;
 use core::{cmp::Ordering, fmt::Display, ops::Deref, slice};
+use std::hash::{Hash, Hasher};
 
 use thiserror::Error;
 
@@ -52,6 +53,12 @@ impl RpoDigest {
     /// Returns hexadecimal representation of this digest prefixed with `0x`.
     pub fn to_hex(&self) -> String {
         bytes_to_hex_string(self.as_bytes())
+    }
+}
+
+impl Hash for RpoDigest {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        state.write(&self.as_bytes());
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,14 +26,6 @@ pub use winter_math::{
 /// A group of four field elements in the Miden base field.
 pub type Word = [Felt; WORD_SIZE];
 
-/// A map whose keys are not guarantied to be ordered.
-#[cfg(feature = "hashmaps")]
-type UnorderedMap<K, V> = hashbrown::HashMap<K, V>;
-
-/// A map whose keys are not guarantied to be ordered.
-#[cfg(not(feature = "hashmaps"))]
-type UnorderedMap<K, V> = alloc::collections::BTreeMap<K, V>;
-
 // CONSTANTS
 // ================================================================================================
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,14 @@ pub use winter_math::{
 /// A group of four field elements in the Miden base field.
 pub type Word = [Felt; WORD_SIZE];
 
+/// A map whose keys are not guarantied to be ordered.
+#[cfg(feature = "hashmaps")]
+type UnorderedMap<K, V> = hashbrown::HashMap<K, V>;
+
+/// A map whose keys are not guarantied to be ordered.
+#[cfg(not(feature = "hashmaps"))]
+type UnorderedMap<K, V> = alloc::collections::BTreeMap<K, V>;
+
 // CONSTANTS
 // ================================================================================================
 

--- a/src/merkle/node.rs
+++ b/src/merkle/node.rs
@@ -1,8 +1,9 @@
 use super::RpoDigest;
 
 /// Representation of a node with two children used for iterating over containers.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(test, derive(PartialOrd, Ord))]
 pub struct InnerNodeInfo {
     pub value: RpoDigest,
     pub left: RpoDigest,

--- a/src/merkle/node.rs
+++ b/src/merkle/node.rs
@@ -1,7 +1,7 @@
 use super::RpoDigest;
 
 /// Representation of a node with two children used for iterating over containers.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct InnerNodeInfo {
     pub value: RpoDigest,

--- a/src/merkle/smt/full/mod.rs
+++ b/src/merkle/smt/full/mod.rs
@@ -1,8 +1,6 @@
-use alloc::{
-    collections::{BTreeMap, BTreeSet},
-    string::ToString,
-    vec::Vec,
-};
+use alloc::{collections::BTreeSet, string::ToString, vec::Vec};
+
+use hashbrown::HashMap;
 
 use super::{
     EmptySubtreeRoots, Felt, InnerNode, InnerNodeInfo, LeafIndex, MerkleError, MerklePath,
@@ -43,8 +41,8 @@ pub const SMT_DEPTH: u8 = 64;
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct Smt {
     root: RpoDigest,
-    leaves: BTreeMap<u64, SmtLeaf>,
-    inner_nodes: BTreeMap<NodeIndex, InnerNode>,
+    inner_nodes: HashMap<NodeIndex, InnerNode>,
+    leaves: HashMap<u64, SmtLeaf>,
 }
 
 impl Smt {
@@ -64,8 +62,8 @@ impl Smt {
 
         Self {
             root,
-            leaves: BTreeMap::new(),
-            inner_nodes: BTreeMap::new(),
+            inner_nodes: Default::default(),
+            leaves: Default::default(),
         }
     }
 
@@ -149,8 +147,8 @@ impl Smt {
     /// With debug assertions on, this function panics if `root` does not match the root node in
     /// `inner_nodes`.
     pub fn from_raw_parts(
-        inner_nodes: BTreeMap<NodeIndex, InnerNode>,
-        leaves: BTreeMap<u64, SmtLeaf>,
+        inner_nodes: HashMap<NodeIndex, InnerNode>,
+        leaves: HashMap<u64, SmtLeaf>,
         root: RpoDigest,
     ) -> Self {
         // Our particular implementation of `from_raw_parts()` never returns `Err`.
@@ -317,8 +315,8 @@ impl SparseMerkleTree<SMT_DEPTH> for Smt {
     const EMPTY_ROOT: RpoDigest = *EmptySubtreeRoots::entry(SMT_DEPTH, 0);
 
     fn from_raw_parts(
-        inner_nodes: BTreeMap<NodeIndex, InnerNode>,
-        leaves: BTreeMap<u64, SmtLeaf>,
+        inner_nodes: HashMap<NodeIndex, InnerNode>,
+        leaves: HashMap<u64, SmtLeaf>,
         root: RpoDigest,
     ) -> Result<Self, MerkleError> {
         if cfg!(debug_assertions) {

--- a/src/merkle/smt/full/tests.rs
+++ b/src/merkle/smt/full/tests.rs
@@ -499,21 +499,21 @@ fn test_smt_get_value() {
 /// Tests that `entries()` works as expected
 #[test]
 fn test_smt_entries() {
-    let key_1: RpoDigest = RpoDigest::from([ONE, ONE, ONE, ONE]);
-    let key_2: RpoDigest = RpoDigest::from([2_u32, 2_u32, 2_u32, 2_u32]);
+    let key_1 = RpoDigest::from([ONE, ONE, ONE, ONE]);
+    let key_2 = RpoDigest::from([2_u32, 2_u32, 2_u32, 2_u32]);
 
     let value_1 = [ONE; WORD_SIZE];
     let value_2 = [2_u32.into(); WORD_SIZE];
+    let entries = [(key_1, value_1), (key_2, value_2)];
 
-    let smt = Smt::with_entries([(key_1, value_1), (key_2, value_2)]).unwrap();
+    let smt = Smt::with_entries(entries).unwrap();
 
-    let mut entries = smt.entries();
+    let mut expected = Vec::from_iter(entries);
+    expected.sort_by_key(|(k, _)| *k);
+    let mut actual: Vec<_> = smt.entries().cloned().collect();
+    actual.sort_by_key(|(k, _)| *k);
 
-    // Note: for simplicity, we assume the order `(k1,v1), (k2,v2)`. If a new implementation
-    // switches the order, it is OK to modify the order here as well.
-    assert_eq!(&(key_1, value_1), entries.next().unwrap());
-    assert_eq!(&(key_2, value_2), entries.next().unwrap());
-    assert!(entries.next().is_none());
+    assert_eq!(actual, expected);
 }
 
 /// Tests that `EMPTY_ROOT` constant generated in the `Smt` equals to the root of the empty tree of

--- a/src/merkle/smt/full/tests.rs
+++ b/src/merkle/smt/full/tests.rs
@@ -1,9 +1,9 @@
-use alloc::{collections::BTreeMap, vec::Vec};
+use alloc::vec::Vec;
 
 use super::{Felt, LeafIndex, NodeIndex, Rpo256, RpoDigest, Smt, SmtLeaf, EMPTY_WORD, SMT_DEPTH};
 use crate::{
     merkle::{
-        smt::{NodeMutation, SparseMerkleTree},
+        smt::{types::UnorderedMap, NodeMutation, SparseMerkleTree},
         EmptySubtreeRoots, MerkleStore, MutationSet,
     },
     utils::{Deserializable, Serializable},
@@ -420,7 +420,7 @@ fn test_prospective_insertion() {
     assert_eq!(revert.root(), root_empty, "reverse mutations new root did not match");
     assert_eq!(
         revert.new_pairs,
-        BTreeMap::from_iter([(key_1, EMPTY_WORD)]),
+        UnorderedMap::from_iter([(key_1, EMPTY_WORD)]),
         "reverse mutations pairs did not match"
     );
     assert_eq!(
@@ -440,7 +440,7 @@ fn test_prospective_insertion() {
     assert_eq!(revert.root(), old_root, "reverse mutations new root did not match");
     assert_eq!(
         revert.new_pairs,
-        BTreeMap::from_iter([(key_2, EMPTY_WORD), (key_3, EMPTY_WORD)]),
+        UnorderedMap::from_iter([(key_2, EMPTY_WORD), (key_3, EMPTY_WORD)]),
         "reverse mutations pairs did not match"
     );
 
@@ -454,7 +454,7 @@ fn test_prospective_insertion() {
     assert_eq!(revert.root(), old_root, "reverse mutations new root did not match");
     assert_eq!(
         revert.new_pairs,
-        BTreeMap::from_iter([(key_3, value_3)]),
+        UnorderedMap::from_iter([(key_3, value_3)]),
         "reverse mutations pairs did not match"
     );
 
@@ -474,7 +474,7 @@ fn test_prospective_insertion() {
     assert_eq!(revert.root(), old_root, "reverse mutations new root did not match");
     assert_eq!(
         revert.new_pairs,
-        BTreeMap::from_iter([(key_1, value_1), (key_2, value_2), (key_3, value_3)]),
+        UnorderedMap::from_iter([(key_1, value_1), (key_2, value_2), (key_3, value_3)]),
         "reverse mutations pairs did not match"
     );
 

--- a/src/merkle/smt/full/tests.rs
+++ b/src/merkle/smt/full/tests.rs
@@ -3,7 +3,7 @@ use alloc::vec::Vec;
 use super::{Felt, LeafIndex, NodeIndex, Rpo256, RpoDigest, Smt, SmtLeaf, EMPTY_WORD, SMT_DEPTH};
 use crate::{
     merkle::{
-        smt::{types::UnorderedMap, NodeMutation, SparseMerkleTree},
+        smt::{NodeMutation, SparseMerkleTree, UnorderedMap},
         EmptySubtreeRoots, MerkleStore, MutationSet,
     },
     utils::{Deserializable, Serializable},

--- a/src/merkle/smt/mod.rs
+++ b/src/merkle/smt/mod.rs
@@ -1,6 +1,5 @@
 use alloc::{collections::BTreeMap, vec::Vec};
-use core::mem;
-use std::hash::Hash;
+use core::{hash::Hash, mem};
 
 use num::Integer;
 use types::{KeyConstrains, UnorderedMap};

--- a/src/merkle/smt/mod.rs
+++ b/src/merkle/smt/mod.rs
@@ -795,25 +795,13 @@ impl<const DEPTH: u8, K: Serializable, V: Serializable> Serializable for Mutatio
             })
             .collect();
 
-        target.write_u32(
-            inner_removals
-                .len()
-                .try_into()
-                .expect("Number of items to remove must fit in `u32`"),
-        );
+        target.write_usize(inner_removals.len());
         target.write_many(inner_removals);
 
-        target.write_u32(
-            inner_additions
-                .len()
-                .try_into()
-                .expect("Number of items to add must fit in `u32`"),
-        );
+        target.write_usize(inner_additions.len());
         target.write_many(inner_additions);
 
-        target.write_u32(
-            self.new_pairs.len().try_into().expect("Number of new pairs must fit in `u32`"),
-        );
+        target.write_usize(self.new_pairs.len());
         target.write_many(&self.new_pairs);
     }
 }
@@ -825,10 +813,10 @@ impl<const DEPTH: u8, K: Deserializable + KeyConstraints, V: Deserializable> Des
         let old_root = source.read()?;
         let new_root = source.read()?;
 
-        let num_removals = source.read_u32()? as usize;
+        let num_removals = source.read_usize()?;
         let inner_removals: Vec<NodeIndex> = source.read_many(num_removals)?;
 
-        let num_additions = source.read_u32()? as usize;
+        let num_additions = source.read_usize()?;
         let inner_additions: Vec<(NodeIndex, InnerNode)> = source.read_many(num_additions)?;
 
         let node_mutations = NodeMutations::from_iter(
@@ -839,7 +827,7 @@ impl<const DEPTH: u8, K: Deserializable + KeyConstraints, V: Deserializable> Des
             ),
         );
 
-        let num_new_pairs = source.read_u32()? as usize;
+        let num_new_pairs = source.read_usize()?;
         let new_pairs = source.read_many(num_new_pairs)?;
         let new_pairs = UnorderedMap::from_iter(new_pairs);
 

--- a/src/merkle/smt/mod.rs
+++ b/src/merkle/smt/mod.rs
@@ -2,7 +2,7 @@ use alloc::{collections::BTreeMap, vec::Vec};
 use core::{hash::Hash, mem};
 
 use num::Integer;
-use types::{KeyConstrains, UnorderedMap};
+use types::{KeyConstraints, UnorderedMap};
 use winter_utils::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable};
 
 use super::{EmptySubtreeRoots, InnerNodeInfo, MerkleError, MerklePath, NodeIndex};
@@ -36,8 +36,8 @@ mod types {
     /// A map whose keys are not guarantied to be ordered.
     pub type UnorderedMap<K, V> = hashbrown::HashMap<K, V>;
 
-    pub trait KeyConstrains: Hash + Eq {}
-    impl<T: Hash + Eq> KeyConstrains for T {}
+    pub trait KeyConstraints: Hash + Eq {}
+    impl<T: Hash + Eq> KeyConstraints for T {}
 }
 
 #[cfg(not(feature = "smt_hashmaps"))]
@@ -45,8 +45,8 @@ mod types {
     /// A map whose keys are not guarantied to be ordered.
     pub type UnorderedMap<K, V> = alloc::collections::BTreeMap<K, V>;
 
-    pub trait KeyConstrains: Ord {}
-    impl<T: Ord> KeyConstrains for T {}
+    pub trait KeyConstraints: Ord {}
+    impl<T: Ord> KeyConstraints for T {}
 }
 
 type InnerNodes = UnorderedMap<NodeIndex, InnerNode>;
@@ -74,7 +74,7 @@ type NodeMutations = UnorderedMap<NodeIndex, NodeMutation>;
 /// [SparseMerkleTree] currently doesn't support optimizations that compress Merkle proofs.
 pub(crate) trait SparseMerkleTree<const DEPTH: u8> {
     /// The type for a key
-    type Key: Clone + KeyConstrains;
+    type Key: Clone + KeyConstraints;
     /// The type for a value
     type Value: Clone + PartialEq;
     /// The type for a leaf
@@ -722,7 +722,7 @@ impl<const DEPTH: u8, K, V> MutationSet<DEPTH, K, V> {
     }
 }
 
-impl<const DEPTH: u8, K: KeyConstrains, V: PartialEq> PartialEq for MutationSet<DEPTH, K, V> {
+impl<const DEPTH: u8, K: KeyConstraints, V: PartialEq> PartialEq for MutationSet<DEPTH, K, V> {
     fn eq(&self, other: &Self) -> bool {
         self.old_root == other.old_root
             && self.node_mutations == other.node_mutations
@@ -731,7 +731,7 @@ impl<const DEPTH: u8, K: KeyConstrains, V: PartialEq> PartialEq for MutationSet<
     }
 }
 
-impl<const DEPTH: u8, K: KeyConstrains, V: PartialEq> Eq for MutationSet<DEPTH, K, V> {}
+impl<const DEPTH: u8, K: KeyConstraints, V: PartialEq> Eq for MutationSet<DEPTH, K, V> {}
 
 // SERIALIZATION
 // ================================================================================================
@@ -809,7 +809,7 @@ impl<const DEPTH: u8, K: Serializable, V: Serializable> Serializable for Mutatio
     }
 }
 
-impl<const DEPTH: u8, K: Deserializable + KeyConstrains, V: Deserializable> Deserializable
+impl<const DEPTH: u8, K: Deserializable + KeyConstraints, V: Deserializable> Deserializable
     for MutationSet<DEPTH, K, V>
 {
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {

--- a/src/merkle/smt/mod.rs
+++ b/src/merkle/smt/mod.rs
@@ -770,11 +770,8 @@ impl<const DEPTH: u8, K: Serializable + Eq + Hash, V: Serializable> Serializable
             })
             .collect();
 
-        target.write_usize(inner_removals.len());
-        target.write_many(inner_removals);
-
-        target.write_usize(inner_additions.len());
-        target.write_many(inner_additions);
+        target.write(inner_removals);
+        target.write(inner_additions);
 
         target.write_usize(self.new_pairs.len());
         target.write_many(&self.new_pairs);
@@ -788,11 +785,8 @@ impl<const DEPTH: u8, K: Deserializable + Ord + Eq + Hash, V: Deserializable> De
         let old_root = source.read()?;
         let new_root = source.read()?;
 
-        let num_removals = source.read_usize()?;
-        let inner_removals: Vec<NodeIndex> = source.read_many(num_removals)?;
-
-        let num_additions = source.read_usize()?;
-        let inner_additions: Vec<(NodeIndex, InnerNode)> = source.read_many(num_additions)?;
+        let inner_removals: Vec<NodeIndex> = source.read()?;
+        let inner_additions: Vec<(NodeIndex, InnerNode)> = source.read()?;
 
         let node_mutations = NodeMutations::from_iter(
             inner_removals.into_iter().map(|index| (index, NodeMutation::Removal)).chain(

--- a/src/merkle/smt/simple/mod.rs
+++ b/src/merkle/smt/simple/mod.rs
@@ -1,7 +1,6 @@
-use alloc::{
-    collections::{BTreeMap, BTreeSet},
-    vec::Vec,
-};
+use alloc::{collections::BTreeSet, vec::Vec};
+
+use hashbrown::HashMap;
 
 use super::{
     super::ValuePath, EmptySubtreeRoots, InnerNode, InnerNodeInfo, LeafIndex, MerkleError,
@@ -22,8 +21,8 @@ mod tests;
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct SimpleSmt<const DEPTH: u8> {
     root: RpoDigest,
-    leaves: BTreeMap<u64, Word>,
-    inner_nodes: BTreeMap<NodeIndex, InnerNode>,
+    inner_nodes: HashMap<NodeIndex, InnerNode>,
+    leaves: HashMap<u64, Word>,
 }
 
 impl<const DEPTH: u8> SimpleSmt<DEPTH> {
@@ -54,8 +53,8 @@ impl<const DEPTH: u8> SimpleSmt<DEPTH> {
 
         Ok(Self {
             root,
-            leaves: BTreeMap::new(),
-            inner_nodes: BTreeMap::new(),
+            inner_nodes: Default::default(),
+            leaves: Default::default(),
         })
     }
 
@@ -109,8 +108,8 @@ impl<const DEPTH: u8> SimpleSmt<DEPTH> {
     /// With debug assertions on, this function panics if `root` does not match the root node in
     /// `inner_nodes`.
     pub fn from_raw_parts(
-        inner_nodes: BTreeMap<NodeIndex, InnerNode>,
-        leaves: BTreeMap<u64, Word>,
+        inner_nodes: HashMap<NodeIndex, InnerNode>,
+        leaves: HashMap<u64, Word>,
         root: RpoDigest,
     ) -> Self {
         // Our particular implementation of `from_raw_parts()` never returns `Err`.
@@ -327,8 +326,8 @@ impl<const DEPTH: u8> SparseMerkleTree<DEPTH> for SimpleSmt<DEPTH> {
     const EMPTY_ROOT: RpoDigest = *EmptySubtreeRoots::entry(DEPTH, 0);
 
     fn from_raw_parts(
-        inner_nodes: BTreeMap<NodeIndex, InnerNode>,
-        leaves: BTreeMap<u64, Word>,
+        inner_nodes: HashMap<NodeIndex, InnerNode>,
+        leaves: HashMap<u64, Word>,
         root: RpoDigest,
     ) -> Result<Self, MerkleError> {
         if cfg!(debug_assertions) {

--- a/src/merkle/smt/simple/tests.rs
+++ b/src/merkle/smt/simple/tests.rs
@@ -1,4 +1,4 @@
-use alloc::vec::Vec;
+use alloc::{collections::BTreeSet, vec::Vec};
 
 use assert_matches::assert_matches;
 
@@ -141,12 +141,12 @@ fn test_inner_node_iterator() -> Result<(), MerkleError> {
     let l2n2 = tree.get_node(NodeIndex::make(2, 2))?;
     let l2n3 = tree.get_node(NodeIndex::make(2, 3))?;
 
-    let nodes: Vec<InnerNodeInfo> = tree.inner_nodes().collect();
-    let expected = vec![
+    let nodes: BTreeSet<InnerNodeInfo> = tree.inner_nodes().collect();
+    let expected = BTreeSet::from_iter([
         InnerNodeInfo { value: root, left: l1n0, right: l1n1 },
         InnerNodeInfo { value: l1n0, left: l2n0, right: l2n1 },
         InnerNodeInfo { value: l1n1, left: l2n2, right: l2n3 },
-    ];
+    ]);
     assert_eq!(nodes, expected);
 
     Ok(())

--- a/src/merkle/smt/simple/tests.rs
+++ b/src/merkle/smt/simple/tests.rs
@@ -1,4 +1,4 @@
-use alloc::{collections::BTreeSet, vec::Vec};
+use alloc::vec::Vec;
 
 use assert_matches::assert_matches;
 
@@ -141,12 +141,15 @@ fn test_inner_node_iterator() -> Result<(), MerkleError> {
     let l2n2 = tree.get_node(NodeIndex::make(2, 2))?;
     let l2n3 = tree.get_node(NodeIndex::make(2, 3))?;
 
-    let nodes: BTreeSet<InnerNodeInfo> = tree.inner_nodes().collect();
-    let expected = BTreeSet::from_iter([
+    let mut nodes: Vec<InnerNodeInfo> = tree.inner_nodes().collect();
+    let mut expected = [
         InnerNodeInfo { value: root, left: l1n0, right: l1n1 },
         InnerNodeInfo { value: l1n0, left: l2n0, right: l2n1 },
         InnerNodeInfo { value: l1n1, left: l2n2, right: l2n3 },
-    ]);
+    ];
+    nodes.sort();
+    expected.sort();
+
     assert_eq!(nodes, expected);
 
     Ok(())


### PR DESCRIPTION
After benchmarking of `compute_mutations` and `apply_mutations` we noticed poor performance of multiple key-value insertions into `BTreeMap` which is used in our SMT implementations. Rewriting to hashbrown's `HashMap` (which supports no-std) gave us more than 10x boost in `apply_mutations` operation for large trees.

---

apply_mutations/SimpleSmt: apply_mutations/10000
                        time:   [154.52 ms 163.09 ms 174.46 ms]
                        change: [-93.242% -92.753% -92.142%] (p = 0.00 < 0.05)
                        Performance has improved.

---

(More context in the PR: https://github.com/0xPolygonMiden/crypto/pull/355)

In this implementation we also introduced `smt_hashmaps` feature. If it's switched off, the SMT uses binary-tree implementation, as before. This might be useful for backward-compatibility with code, which relies on entry ordering in SMTs.