### PR TITLE
Changes needed for implementing of openings computing for recent blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.13.2 (2025-01-24)
+
+- Made `InnerNode` and `NodeMutation` public. Implemented (de)serialization of `LeafIndex` (#367).
+
 ## 0.13.1 (2024-12-26)
 
 - Generate reverse mutations set on applying of mutations set, implemented serialization of `MutationsSet` (#355).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -526,7 +526,7 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "miden-crypto"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "assert_matches",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-crypto"
-version = "0.13.1"
+version = "0.13.2"
 description = "Miden Cryptographic primitives"
 authors = ["miden contributors"]
 readme = "README.md"

--- a/src/merkle/mod.rs
+++ b/src/merkle/mod.rs
@@ -22,8 +22,8 @@ pub use path::{MerklePath, RootPath, ValuePath};
 
 mod smt;
 pub use smt::{
-    LeafIndex, MutationSet, SimpleSmt, Smt, SmtLeaf, SmtLeafError, SmtProof, SmtProofError,
-    SMT_DEPTH, SMT_MAX_DEPTH, SMT_MIN_DEPTH,
+    InnerNode, LeafIndex, MutationSet, NodeMutation, SimpleSmt, Smt, SmtLeaf, SmtLeafError,
+    SmtProof, SmtProofError, SMT_DEPTH, SMT_MAX_DEPTH, SMT_MIN_DEPTH,
 };
 
 mod mmr;

--- a/src/merkle/smt/mod.rs
+++ b/src/merkle/smt/mod.rs
@@ -492,6 +492,18 @@ impl<const DEPTH: u8> TryFrom<NodeIndex> for LeafIndex<DEPTH> {
     }
 }
 
+impl<const DEPTH: u8> Serializable for LeafIndex<DEPTH> {
+    fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        self.index.write_into(target);
+    }
+}
+
+impl<const DEPTH: u8> Deserializable for LeafIndex<DEPTH> {
+    fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
+        Ok(Self { index: source.read()? })
+    }
+}
+
 // MUTATIONS
 // ================================================================================================
 

--- a/src/merkle/smt/mod.rs
+++ b/src/merkle/smt/mod.rs
@@ -507,14 +507,14 @@ impl<const DEPTH: u8> Deserializable for LeafIndex<DEPTH> {
 // MUTATIONS
 // ================================================================================================
 
-/// A change to an inner node of a [`SparseMerkleTree`] that hasn't yet been applied.
+/// A change to an inner node of a sparse Merkle tree that hasn't yet been applied.
 /// [`MutationSet`] stores this type in relation to a [`NodeIndex`] to keep track of what changes
 /// need to occur at which node indices.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum NodeMutation {
-    /// Corresponds to [`SparseMerkleTree::remove_inner_node()`].
+    /// Node needs to be removed.
     Removal,
-    /// Corresponds to [`SparseMerkleTree::insert_inner_node()`].
+    /// Node needs to be inserted.
     Addition(InnerNode),
 }
 


### PR DESCRIPTION
* Made `InnerNode` and `NodeMutation` public.
* Implemented (de)serialization of `LeafIndex`.