### PR TITLE
remove duplicated check in falcon verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.14.0 (TBD)
 
 - [BREAKING] Increment minimum supported Rust version to 1.84.
+- Removed duplicated check in RpoFalcon512 verification (#368).
 
 ## 0.13.2 (2025-01-24)
 

--- a/src/dsa/rpo_falcon512/signature.rs
+++ b/src/dsa/rpo_falcon512/signature.rs
@@ -97,7 +97,7 @@ impl Signature {
         }
 
         let c = hash_to_point_rpo256(message, &self.nonce);
-        h_digest == pubkey_com && verify_helper(&c, &self.s2, self.pk_poly())
+        verify_helper(&c, &self.s2, self.pk_poly())
     }
 }
 


### PR DESCRIPTION
Minor change removing a duplicated check of `h_digest==pubkey_com`at [`src/dsa/rpo_falcon512/signature.rs#L100`]( https://github.com/0xPolygonMiden/crypto/blob/2a5b8ffb2116281636a41037b8580a7d93ebb3cf/src/dsa/rpo_falcon512/signature.rs#L100), which is already done at [`src/dsa/rpo_falcon512/signature.rs#L95`]( https://github.com/0xPolygonMiden/crypto/blob/2a5b8ffb2116281636a41037b8580a7d93ebb3cf/src/dsa/rpo_falcon512/signature.rs#L95).