### PR TITLE
Fix `subtree8-rand` benchmark panics with debug assertions enabled (#377)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added parallel implementation of `Smt::compute_mutations` with better performance (#365).
 - Implemented parallel leaf hashing in `Smt::process_sorted_pairs_to_leaves` (#365).
 - [BREAKING] Updated Winterfell dependency to v0.12 (#374).
+- Added debug-only duplicate column check in `build_subtree` (#378).
 
 ## 0.13.3 (2025-02-12)
 

--- a/benches/smt-subtree.rs
+++ b/benches/smt-subtree.rs
@@ -100,6 +100,7 @@ fn smt_subtree_random(c: &mut Criterion) {
                         })
                         .collect();
                     leaves.sort();
+                    leaves.dedup_by_key(|leaf| leaf.col);
                     leaves
                 },
                 |leaves| {

--- a/src/merkle/smt/full/concurrent/mod.rs
+++ b/src/merkle/smt/full/concurrent/mod.rs
@@ -480,11 +480,14 @@ fn build_subtree(
 ) -> (UnorderedMap<NodeIndex, InnerNode>, SubtreeLeaf) {
     #[cfg(debug_assertions)]
     {
+        // Ensure that all leaves have unique column indices within this subtree.
+        // In normal usage via public APIs, this should never happen because leaf
+        // construction enforces uniqueness. However, when testing or benchmarking
+        // `build_subtree()` in isolation, duplicate columns can appear if input
+        // constraints are not enforced.
         let mut seen_cols = BTreeSet::new();
         for leaf in &leaves {
-            if !seen_cols.insert(leaf.col) {
-                panic!("Duplicate column found in subtree: {}", leaf.col);
-            }
+            assert!(seen_cols.insert(leaf.col), "Duplicate column found in subtree: {}", leaf.col);
         }
     }
     debug_assert!(bottom_depth <= tree_depth);

--- a/src/merkle/smt/full/concurrent/mod.rs
+++ b/src/merkle/smt/full/concurrent/mod.rs
@@ -478,6 +478,15 @@ fn build_subtree(
     tree_depth: u8,
     bottom_depth: u8,
 ) -> (UnorderedMap<NodeIndex, InnerNode>, SubtreeLeaf) {
+    #[cfg(debug_assertions)]
+    {
+        let mut seen_cols = BTreeSet::new();
+        for leaf in &leaves {
+            if !seen_cols.insert(leaf.col) {
+                panic!("Duplicate column found in subtree: {}", leaf.col);
+            }
+        }
+    }
     debug_assert!(bottom_depth <= tree_depth);
     debug_assert!(Integer::is_multiple_of(&bottom_depth, &SUBTREE_DEPTH));
     debug_assert!(leaves.len() <= usize::pow(2, SUBTREE_DEPTH as u32));


### PR DESCRIPTION
This PR fixes #377 by ensuring that all leaves in `subtree8-rand` benchmark are unique before constructing the subtree.

Changes:
- Added a debug-only check in `build_subtree()` to detect duplicate leaf columns.
- Ensured leaves are deduplicated in `subtree8-rand` benchmark to prevent assertion failures in debug mode.