### PR TITLE
fix: dead_code warning on pairs_to_leaf when not(feature = "concurrent")

### DIFF
--- a/src/merkle/smt/full/concurrent/mod.rs
+++ b/src/merkle/smt/full/concurrent/mod.rs
@@ -245,6 +245,25 @@ impl Smt {
         Self::process_sorted_pairs_to_leaves(pairs, Self::pairs_to_leaf)
     }
 
+    /// Constructs a single leaf from an arbitrary amount of key-value pairs.
+    /// Those pairs must all have the same leaf index.
+    fn pairs_to_leaf(mut pairs: Vec<(RpoDigest, Word)>) -> SmtLeaf {
+        assert!(!pairs.is_empty());
+
+        if pairs.len() > 1 {
+            SmtLeaf::new_multiple(pairs).unwrap()
+        } else {
+            let (key, value) = pairs.pop().unwrap();
+            // TODO: should we ever be constructing empty leaves from pairs?
+            if value == Self::EMPTY_VALUE {
+                let index = Self::key_to_leaf_index(&key);
+                SmtLeaf::new_empty(index)
+            } else {
+                SmtLeaf::new_single(key, value)
+            }
+        }
+    }
+
     /// Computes leaves from a set of key-value pairs and current leaf values.
     /// Derived from `sorted_pairs_to_leaves`
     fn sorted_pairs_to_mutated_subtree_leaves(

--- a/src/merkle/smt/full/mod.rs
+++ b/src/merkle/smt/full/mod.rs
@@ -430,23 +430,6 @@ impl SparseMerkleTree<SMT_DEPTH> for Smt {
     fn path_and_leaf_to_opening(path: MerklePath, leaf: SmtLeaf) -> SmtProof {
         SmtProof::new_unchecked(path, leaf)
     }
-
-    fn pairs_to_leaf(mut pairs: Vec<(RpoDigest, Word)>) -> SmtLeaf {
-        assert!(!pairs.is_empty());
-
-        if pairs.len() > 1 {
-            SmtLeaf::new_multiple(pairs).unwrap()
-        } else {
-            let (key, value) = pairs.pop().unwrap();
-            // TODO: should we ever be constructing empty leaves from pairs?
-            if value == Self::EMPTY_VALUE {
-                let index = Self::key_to_leaf_index(&key);
-                SmtLeaf::new_empty(index)
-            } else {
-                SmtLeaf::new_single(key, value)
-            }
-        }
-    }
 }
 
 impl Default for Smt {

--- a/src/merkle/smt/mod.rs
+++ b/src/merkle/smt/mod.rs
@@ -451,10 +451,6 @@ pub(crate) trait SparseMerkleTree<const DEPTH: u8> {
     /// Maps a key to a leaf index
     fn key_to_leaf_index(key: &Self::Key) -> LeafIndex<DEPTH>;
 
-    /// Constructs a single leaf from an arbitrary amount of key-value pairs.
-    /// Those pairs must all have the same leaf index.
-    fn pairs_to_leaf(pairs: Vec<(Self::Key, Self::Value)>) -> Self::Leaf;
-
     /// Maps a (MerklePath, Self::Leaf) to an opening.
     ///
     /// The length `path` is guaranteed to be equal to `DEPTH`

--- a/src/merkle/smt/simple/mod.rs
+++ b/src/merkle/smt/simple/mod.rs
@@ -1,4 +1,4 @@
-use alloc::{collections::BTreeSet, vec::Vec};
+use alloc::collections::BTreeSet;
 
 use super::{
     super::ValuePath, EmptySubtreeRoots, InnerNode, InnerNodeInfo, InnerNodes, LeafIndex,
@@ -414,12 +414,5 @@ impl<const DEPTH: u8> SparseMerkleTree<DEPTH> for SimpleSmt<DEPTH> {
 
     fn path_and_leaf_to_opening(path: MerklePath, leaf: Word) -> ValuePath {
         (path, leaf).into()
-    }
-
-    fn pairs_to_leaf(mut pairs: Vec<(LeafIndex<DEPTH>, Word)>) -> Word {
-        // SimpleSmt can't have more than one value per key.
-        assert_eq!(pairs.len(), 1);
-        let (_key, value) = pairs.pop().unwrap();
-        value
     }
 }


### PR DESCRIPTION
Trivial change to fix a warning with `--no-default-features`.
