### PR TITLE
Fix `PartialSmt` stale proofs not resulting in error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.13.3 (tbd)
 
-- Implement `PartialSmt` (#372).
+- Implement `PartialSmt` (#372, #381).
 
 ## 0.13.2 (2025-01-24)
 


### PR DESCRIPTION
## Describe your changes

Fixes an edge case in `PartialSmt::add_path` that should result in an error but did not.

The scenario is the following: When we add an empty leaf's path to a PartialSmt as the first leaf, then the root of the partial SMT afterwards is still the empty root. This means when we add a second leaf to the SMT whose root is different, it will not result in a root conflict error.
This is because of the `self.root() != EMPTY_ROOT` exception which we use to determine whether we're adding the first leaf or not. This PR changes the way we determine whether we've added the first leaf to check for `self.0.num_leaves() != 1`, which will trigger the error also in the above case.

See `partial_smt_root_mismatch_on_empty_values` for a test that did not suceed prior to this PR.

Adds two tests checking for the root conflict case.

This came up in a test involving stale nullifier merkle paths in the partial nullifier tree in https://github.com/0xPolygonMiden/miden-base/pull/1152.

Also adds a new `PartialSmt::add_proof` which is a convenience wrapper around `add_path`.

## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
