### PR TITLE
Filter empty values in `Smt::with_entries`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Implemented parallel leaf hashing in `Smt::process_sorted_pairs_to_leaves` (#365).
 - [BREAKING] Updated Winterfell dependency to v0.12 (#374).
 - Added debug-only duplicate column check in `build_subtree` (#378).
+- Filter out empty values in concurrent version of `Smt::with_entries` to fix a panic (#383).
 
 ## 0.13.3 (2025-02-18)
 

--- a/src/merkle/smt/full/concurrent/mod.rs
+++ b/src/merkle/smt/full/concurrent/mod.rs
@@ -7,10 +7,7 @@ use super::{
     EmptySubtreeRoots, InnerNode, InnerNodes, LeafIndex, Leaves, MerkleError, MutationSet,
     NodeIndex, RpoDigest, Smt, SmtLeaf, SparseMerkleTree, Word, SMT_DEPTH,
 };
-use crate::{
-    merkle::smt::{NodeMutation, NodeMutations, UnorderedMap},
-    EMPTY_WORD,
-};
+use crate::merkle::smt::{NodeMutation, NodeMutations, UnorderedMap};
 
 #[cfg(test)]
 mod tests;
@@ -43,7 +40,7 @@ impl Smt {
         let entries: Vec<_> = entries
             .into_iter()
             // Filter out key-value pairs whose value is empty.
-            .filter(|(_key, value)| *value != EMPTY_WORD)
+            .filter(|(_key, value)| *value != Self::EMPTY_VALUE)
             .map(|(key, value)| {
                 if seen_keys.insert(key) {
                     Ok((key, value))

--- a/src/merkle/smt/full/concurrent/mod.rs
+++ b/src/merkle/smt/full/concurrent/mod.rs
@@ -7,7 +7,10 @@ use super::{
     EmptySubtreeRoots, InnerNode, InnerNodes, LeafIndex, Leaves, MerkleError, MutationSet,
     NodeIndex, RpoDigest, Smt, SmtLeaf, SparseMerkleTree, Word, SMT_DEPTH,
 };
-use crate::merkle::smt::{NodeMutation, NodeMutations, UnorderedMap};
+use crate::{
+    merkle::smt::{NodeMutation, NodeMutations, UnorderedMap},
+    EMPTY_WORD,
+};
 
 #[cfg(test)]
 mod tests;
@@ -39,6 +42,8 @@ impl Smt {
         let mut seen_keys = BTreeSet::new();
         let entries: Vec<_> = entries
             .into_iter()
+            // Filter out key-value pairs whose value is empty.
+            .filter(|(_key, value)| *value != EMPTY_WORD)
             .map(|(key, value)| {
                 if seen_keys.insert(key) {
                     Ok((key, value))

--- a/src/merkle/smt/full/concurrent/tests.rs
+++ b/src/merkle/smt/full/concurrent/tests.rs
@@ -375,7 +375,15 @@ fn test_multithreaded_subtrees() {
 #[test]
 fn test_with_entries_concurrent() {
     const PAIR_COUNT: u64 = COLS_PER_SUBTREE * 64;
-    let entries = generate_entries(PAIR_COUNT);
+    let mut entries = generate_entries(PAIR_COUNT);
+    let mut rng = rand::thread_rng();
+
+    // Set 10% of the entries to have empty words as their values.
+    for _ in 0..PAIR_COUNT / 10 {
+        let random_index = rng.gen_range(0..PAIR_COUNT);
+        entries[random_index as usize].1 = EMPTY_WORD;
+    }
+
     let control = Smt::with_entries_sequential(entries.clone()).unwrap();
     let smt = Smt::with_entries(entries.clone()).unwrap();
     assert_eq!(smt.root(), control.root());


### PR DESCRIPTION
## Describe your changes

The `partial_smt_root_mismatch_on_empty_values` test passes key-value pairs to `Smt::with_entries` where some of the values are `EMPTY_WORD`. This causes a panic in the concurrent subtree computation of the `Smt` on current `next`, e.g.: https://github.com/0xPolygonMiden/crypto/actions/runs/13387187735/job/37386455081#step:4:500.

One fix is to make the test not pass empty values, which is actually unnecessary, since it's the default value. However, I think `with_entries` shouldn't panic when empty values are passed, so I fixed that instead by filtering them out early in the process.

## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
