### PR TITLE
smt: optimized duplicate key detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Sort keys in a leaf in the concurrent implementation of `Smt::with_entries`, ensuring consistency with the sequential version (#385).
 - Skip unchanged leaves in the concurrent implementation of `Smt::compute_mutations` (#385).
 - Add range checks to `ntru_gen` for Falcon DSA (#391).
+- Optimized duplicate key detection in `Smt::with_entries_concurrent`
 
 ## 0.13.3 (2025-02-18)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - Sort keys in a leaf in the concurrent implementation of `Smt::with_entries`, ensuring consistency with the sequential version (#385).
 - Skip unchanged leaves in the concurrent implementation of `Smt::compute_mutations` (#385).
 - Add range checks to `ntru_gen` for Falcon DSA (#391).
-- Optimized duplicate key detection in `Smt::with_entries_concurrent`
+- Optimized duplicate key detection in `Smt::with_entries_concurrent` (#395).
 
 ## 0.13.3 (2025-02-18)
 

--- a/src/merkle/smt/full/concurrent/mod.rs
+++ b/src/merkle/smt/full/concurrent/mod.rs
@@ -1,11 +1,12 @@
-use alloc::{collections::BTreeSet, vec::Vec};
+use alloc::vec::Vec;
 use core::mem;
 
 use num::Integer;
+use rayon::prelude::*;
 
 use super::{
-    leaf, EmptySubtreeRoots, InnerNode, InnerNodes, LeafIndex, Leaves, MerkleError, MutationSet,
-    NodeIndex, RpoDigest, Smt, SmtLeaf, SparseMerkleTree, Word, SMT_DEPTH,
+    leaf, EmptySubtreeRoots, InnerNode, InnerNodes, Leaves, MerkleError, MutationSet, NodeIndex,
+    RpoDigest, Smt, SmtLeaf, SparseMerkleTree, Word, SMT_DEPTH,
 };
 use crate::merkle::smt::{NodeMutation, NodeMutations, UnorderedMap};
 
@@ -36,25 +37,21 @@ impl Smt {
     pub(crate) fn with_entries_concurrent(
         entries: impl IntoIterator<Item = (RpoDigest, Word)>,
     ) -> Result<Self, MerkleError> {
-        let mut seen_keys = BTreeSet::new();
-        let entries: Vec<_> = entries
-            .into_iter()
-            // Filter out key-value pairs whose value is empty.
-            .filter(|(_key, value)| *value != Self::EMPTY_VALUE)
-            .map(|(key, value)| {
-                if seen_keys.insert(key) {
-                    Ok((key, value))
-                } else {
-                    Err(MerkleError::DuplicateValuesForIndex(
-                        LeafIndex::<SMT_DEPTH>::from(key).value(),
-                    ))
-                }
-            })
-            .collect::<Result<_, _>>()?;
-        if entries.is_empty() {
+        let mut entries_iter = entries.into_iter().peekable();
+
+        // Early return if the iterator is empty
+        if entries_iter.peek().is_none() {
             return Ok(Self::default());
         }
-        let (inner_nodes, leaves) = Self::build_subtrees(entries);
+
+        let entries: Vec<(RpoDigest, Word)> = entries_iter.collect();
+        let (inner_nodes, leaves) = Self::build_subtrees(entries)?;
+
+        // All the leaves are empty
+        if inner_nodes.is_empty() {
+            return Ok(Self::default());
+        }
+
         let root = inner_nodes.get(&NodeIndex::root()).unwrap().hash();
         <Self as SparseMerkleTree<SMT_DEPTH>>::from_raw_parts(inner_nodes, leaves, root)
     }
@@ -80,15 +77,13 @@ impl Smt {
     where
         Self: Sized + Sync,
     {
-        use rayon::prelude::*;
-
         // Collect and sort key-value pairs by their corresponding leaf index
         let mut sorted_kv_pairs: Vec<_> = kv_pairs.into_iter().collect();
         sorted_kv_pairs.par_sort_unstable_by_key(|(key, _)| Self::key_to_leaf_index(key).value());
 
         // Convert sorted pairs into mutated leaves and capture any new pairs
         let (mut subtree_leaves, new_pairs) =
-            self.sorted_pairs_to_mutated_subtree_leaves(sorted_kv_pairs);
+            self.sorted_pairs_to_mutated_subtree_leaves(sorted_kv_pairs).unwrap();
 
         // If no mutations, return an empty mutation set
         if subtree_leaves.is_empty() {
@@ -206,9 +201,11 @@ impl Smt {
 
     /// Computes the raw parts for a new sparse Merkle tree from a set of key-value pairs.
     ///
-    /// `entries` need not be sorted. This function will sort them.
-    fn build_subtrees(mut entries: Vec<(RpoDigest, Word)>) -> (InnerNodes, Leaves) {
-        entries.sort_by_key(|item| {
+    /// `entries` need not be sorted. This function will sort them using parallel sorting.
+    fn build_subtrees(
+        mut entries: Vec<(RpoDigest, Word)>,
+    ) -> Result<(InnerNodes, Leaves), MerkleError> {
+        entries.par_sort_unstable_by_key(|item| {
             let index = Self::key_to_leaf_index(&item.0);
             index.value()
         });
@@ -219,15 +216,20 @@ impl Smt {
     ///
     /// This function is mostly an implementation detail of
     /// [`Smt::with_entries_concurrent()`].
-    fn build_subtrees_from_sorted_entries(entries: Vec<(RpoDigest, Word)>) -> (InnerNodes, Leaves) {
-        use rayon::prelude::*;
-
+    fn build_subtrees_from_sorted_entries(
+        entries: Vec<(RpoDigest, Word)>,
+    ) -> Result<(InnerNodes, Leaves), MerkleError> {
         let mut accumulated_nodes: InnerNodes = Default::default();
 
         let PairComputations {
             leaves: mut leaf_subtrees,
             nodes: initial_leaves,
-        } = Self::sorted_pairs_to_leaves(entries);
+        } = Self::sorted_pairs_to_leaves(entries)?;
+
+        // If there are no leaves, we can return early
+        if initial_leaves.is_empty() {
+            return Ok((accumulated_nodes, initial_leaves));
+        }
 
         for current_depth in (SUBTREE_DEPTH..=SMT_DEPTH).step_by(SUBTREE_DEPTH as usize).rev() {
             let (nodes, mut subtree_roots): (Vec<UnorderedMap<_, _>>, Vec<SubtreeLeaf>) =
@@ -247,7 +249,7 @@ impl Smt {
 
             debug_assert!(!leaf_subtrees.is_empty());
         }
-        (accumulated_nodes, initial_leaves)
+        Ok((accumulated_nodes, initial_leaves))
     }
 
     // LEAF NODE CONSTRUCTION
@@ -263,28 +265,30 @@ impl Smt {
     /// # Panics
     /// With debug assertions on, this function panics if it detects that `pairs` is not correctly
     /// sorted. Without debug assertions, the returned computations will be incorrect.
-    fn sorted_pairs_to_leaves(pairs: Vec<(RpoDigest, Word)>) -> PairComputations<u64, SmtLeaf> {
-        Self::process_sorted_pairs_to_leaves(pairs, |leaf_pairs| {
-            Some(Self::pairs_to_leaf(leaf_pairs))
-        })
+    fn sorted_pairs_to_leaves(
+        pairs: Vec<(RpoDigest, Word)>,
+    ) -> Result<PairComputations<u64, SmtLeaf>, MerkleError> {
+        Self::process_sorted_pairs_to_leaves(pairs, Self::pairs_to_leaf)
     }
 
     /// Constructs a single leaf from an arbitrary amount of key-value pairs.
     /// Those pairs must all have the same leaf index.
-    fn pairs_to_leaf(mut pairs: Vec<(RpoDigest, Word)>) -> SmtLeaf {
+    fn pairs_to_leaf(mut pairs: Vec<(RpoDigest, Word)>) -> Result<Option<SmtLeaf>, MerkleError> {
         assert!(!pairs.is_empty());
 
         if pairs.len() > 1 {
             pairs.sort_by(|(key_1, _), (key_2, _)| leaf::cmp_keys(*key_1, *key_2));
-            SmtLeaf::new_multiple(pairs).unwrap()
+            if let Some(window) = pairs.windows(2).find(|w| w[0].0 == w[1].0) {
+                let col = Self::key_to_leaf_index(&window[0].0).index.value();
+                return Err(MerkleError::DuplicateValuesForIndex(col));
+            }
+            Ok(Some(SmtLeaf::new_multiple(pairs).unwrap()))
         } else {
             let (key, value) = pairs.pop().unwrap();
-            // TODO: should we ever be constructing empty leaves from pairs?
             if value == Self::EMPTY_VALUE {
-                let index = Self::key_to_leaf_index(&key);
-                SmtLeaf::new_empty(index)
+                Ok(None)
             } else {
-                SmtLeaf::new_single(key, value)
+                Ok(Some(SmtLeaf::new_single(key, value)))
             }
         }
     }
@@ -294,7 +298,7 @@ impl Smt {
     fn sorted_pairs_to_mutated_subtree_leaves(
         &self,
         pairs: Vec<(RpoDigest, Word)>,
-    ) -> (MutatedSubtreeLeaves, UnorderedMap<RpoDigest, Word>) {
+    ) -> Result<(MutatedSubtreeLeaves, UnorderedMap<RpoDigest, Word>), MerkleError> {
         // Map to track new key-value pairs for mutated leaves
         let mut new_pairs = UnorderedMap::new();
 
@@ -322,13 +326,13 @@ impl Smt {
 
             if leaf_changed {
                 // Only return the leaf if it actually changed
-                Some(leaf)
+                Ok(Some(leaf))
             } else {
                 // Return None if leaf hasn't changed
-                None
+                Ok(None)
             }
-        });
-        (accumulator.leaves, new_pairs)
+        })?;
+        Ok((accumulator.leaves, new_pairs))
     }
 
     /// Processes sorted key-value pairs to compute leaves for a subtree.
@@ -357,11 +361,10 @@ impl Smt {
     fn process_sorted_pairs_to_leaves<F>(
         pairs: Vec<(RpoDigest, Word)>,
         mut process_leaf: F,
-    ) -> PairComputations<u64, SmtLeaf>
+    ) -> Result<PairComputations<u64, SmtLeaf>, MerkleError>
     where
-        F: FnMut(Vec<(RpoDigest, Word)>) -> Option<SmtLeaf>,
+        F: FnMut(Vec<(RpoDigest, Word)>) -> Result<Option<SmtLeaf>, MerkleError>,
     {
-        use rayon::prelude::*;
         debug_assert!(pairs.is_sorted_by_key(|(key, _)| Self::key_to_leaf_index(key).value()));
 
         let mut accumulator: PairComputations<u64, SmtLeaf> = Default::default();
@@ -392,7 +395,9 @@ impl Smt {
             // Otherwise, the next pair is a different column, or there is no next pair. Either way
             // it's time to swap out our buffer.
             let leaf_pairs = mem::take(&mut current_leaf_buffer);
-            if let Some(leaf) = process_leaf(leaf_pairs) {
+
+            // Process leaf and propagate any errors
+            if let Some(leaf) = process_leaf(leaf_pairs)? {
                 accumulator.nodes.insert(col, leaf);
             }
 
@@ -415,7 +420,7 @@ impl Smt {
         // subtree boundaries as we go. Either way this function is only used at the beginning of a
         // parallel construction, so it should not be a critical path.
         accumulator.leaves = SubtreeLeavesIter::from_leaves(&mut accumulated_leaves).collect();
-        accumulator
+        Ok(accumulator)
     }
 }
 
@@ -539,6 +544,7 @@ fn build_subtree(
         // construction enforces uniqueness. However, when testing or benchmarking
         // `build_subtree()` in isolation, duplicate columns can appear if input
         // constraints are not enforced.
+        use alloc::collections::BTreeSet;
         let mut seen_cols = BTreeSet::new();
         for leaf in &leaves {
             assert!(seen_cols.insert(leaf.col), "Duplicate column found in subtree: {}", leaf.col);

--- a/src/merkle/smt/full/concurrent/mod.rs
+++ b/src/merkle/smt/full/concurrent/mod.rs
@@ -37,14 +37,12 @@ impl Smt {
     pub(crate) fn with_entries_concurrent(
         entries: impl IntoIterator<Item = (RpoDigest, Word)>,
     ) -> Result<Self, MerkleError> {
-        let mut entries_iter = entries.into_iter().peekable();
+        let entries: Vec<(RpoDigest, Word)> = entries.into_iter().collect();
 
-        // Early return if the iterator is empty
-        if entries_iter.peek().is_none() {
+        if entries.is_empty() {
             return Ok(Self::default());
         }
 
-        let entries: Vec<(RpoDigest, Word)> = entries_iter.collect();
         let (inner_nodes, leaves) = Self::build_subtrees(entries)?;
 
         // All the leaves are empty
@@ -83,7 +81,7 @@ impl Smt {
 
         // Convert sorted pairs into mutated leaves and capture any new pairs
         let (mut subtree_leaves, new_pairs) =
-            self.sorted_pairs_to_mutated_subtree_leaves(sorted_kv_pairs).unwrap();
+            self.sorted_pairs_to_mutated_subtree_leaves(sorted_kv_pairs);
 
         // If no mutations, return an empty mutation set
         if subtree_leaves.is_empty() {
@@ -278,7 +276,9 @@ impl Smt {
 
         if pairs.len() > 1 {
             pairs.sort_by(|(key_1, _), (key_2, _)| leaf::cmp_keys(*key_1, *key_2));
+            // Check for duplicates in a sorted list by comparing adjacent pairs
             if let Some(window) = pairs.windows(2).find(|w| w[0].0 == w[1].0) {
+                // If we find a duplicate, return an error
                 let col = Self::key_to_leaf_index(&window[0].0).index.value();
                 return Err(MerkleError::DuplicateValuesForIndex(col));
             }
@@ -298,7 +298,7 @@ impl Smt {
     fn sorted_pairs_to_mutated_subtree_leaves(
         &self,
         pairs: Vec<(RpoDigest, Word)>,
-    ) -> Result<(MutatedSubtreeLeaves, UnorderedMap<RpoDigest, Word>), MerkleError> {
+    ) -> (MutatedSubtreeLeaves, UnorderedMap<RpoDigest, Word>) {
         // Map to track new key-value pairs for mutated leaves
         let mut new_pairs = UnorderedMap::new();
 
@@ -331,8 +331,14 @@ impl Smt {
                 // Return None if leaf hasn't changed
                 Ok(None)
             }
-        })?;
-        Ok((accumulator.leaves, new_pairs))
+        });
+        // The closure is the only possible source of errors.
+        // Since it never returns an error - only `Ok(Some(_))` or `Ok(None)` - we can safely assume
+        // `accumulator` is always `Some(_)`.
+        (
+            accumulator.expect("process_sorted_pairs_to_leaves never fails").leaves,
+            new_pairs,
+        )
     }
 
     /// Processes sorted key-value pairs to compute leaves for a subtree.
@@ -397,8 +403,14 @@ impl Smt {
             let leaf_pairs = mem::take(&mut current_leaf_buffer);
 
             // Process leaf and propagate any errors
-            if let Some(leaf) = process_leaf(leaf_pairs)? {
-                accumulator.nodes.insert(col, leaf);
+            match process_leaf(leaf_pairs) {
+                Ok(Some(leaf)) => {
+                    accumulator.nodes.insert(col, leaf);
+                },
+                Ok(None) => {
+                    // `None` means this leaf should be skipped, which is expected.
+                },
+                Err(e) => return Err(e),
             }
 
             debug_assert!(current_leaf_buffer.is_empty());

--- a/src/merkle/smt/full/concurrent/tests.rs
+++ b/src/merkle/smt/full/concurrent/tests.rs
@@ -403,8 +403,7 @@ fn test_singlethreaded_subtree_mutations() {
     let tree = Smt::with_entries_sequential(entries.clone()).unwrap();
     let control = tree.compute_mutations_sequential(updates.clone());
     let mut node_mutations = NodeMutations::default();
-    let (mut subtree_leaves, new_pairs) =
-        tree.sorted_pairs_to_mutated_subtree_leaves(updates).unwrap();
+    let (mut subtree_leaves, new_pairs) = tree.sorted_pairs_to_mutated_subtree_leaves(updates);
     for current_depth in (SUBTREE_DEPTH..=SMT_DEPTH).step_by(SUBTREE_DEPTH as usize).rev() {
         // There's no flat_map_unzip(), so this is the best we can do.
         let (mutations_per_subtree, mut subtree_roots): (Vec<_>, Vec<_>) = subtree_leaves


### PR DESCRIPTION
## Describe your changes

This PR optimizes duplicate key detection in `Smt::with_entries_concurrent`, reducing unnecessary overhead. The previous implementation relied on a `BTreeSet` to track seen keys, which introduced performance costs. The new approach optimistically detects duplicates within `pairs_to_leaf`, eliminating the need for additional tracking.

## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
