### PR TITLE
fix(utils): correct InvalidChar hex charset to [0-9a-fA-F]

### DIFF
--- a/miden-crypto/src/utils/mod.rs
+++ b/miden-crypto/src/utils/mod.rs
@@ -52,7 +52,7 @@ pub enum HexParseError {
     InvalidLength { expected: usize, actual: usize },
     #[error("hex encoded data must start with 0x prefix")]
     MissingPrefix,
-    #[error("hex encoded data must contain only characters [a-zA-Z0-9]")]
+    #[error("hex encoded data must contain only characters [0-9a-fA-F]")]
     InvalidChar,
     #[error("hex encoded values of a Digest must be inside the field modulus")]
     OutOfRange,


### PR DESCRIPTION
Updated HexParseError::InvalidChar message in miden-crypto/src/utils/mod.rs to state the actual allowed characters “[0-9a-fA-F]”. The previous message “[a-zA-Z0-9]” was misleading since the parser only accepts 0-9 and a-f/A-F. This aligns the error text with the implementation, with Word::parse’s validation, and with standard hex semantics, reducing confusion for users and improving diagnostics. No functional behavior changed.