### PR TITLE
fix: expected DataType in decrypt_bytes_with_associated_data

### DIFF
--- a/miden-crypto/src/aead/xchacha/mod.rs
+++ b/miden-crypto/src/aead/xchacha/mod.rs
@@ -231,7 +231,7 @@ impl SecretKey {
     ) -> Result<Vec<u8>, EncryptionError> {
         if encrypted_data.data_type != DataType::Bytes {
             return Err(EncryptionError::InvalidDataType {
-                expected: DataType::Elements,
+                expected: DataType::Bytes,
                 found: encrypted_data.data_type,
             });
         }


### PR DESCRIPTION
- Set expected to DataType::Bytes when rejecting mismatched data types.
- Previously used DataType::Elements, which was inconsistent with the method’s purpose and with aead_rpo’s equivalent check.
- This ensures accurate error reporting and consistent API behavior across AEAD implementations