### PR TITLE
fix(blake3): make merge_many for 192/160 hash exactly N bytes per digest

### DIFF
--- a/miden-crypto/src/hash/blake/mod.rs
+++ b/miden-crypto/src/hash/blake/mod.rs
@@ -187,8 +187,8 @@ impl Hasher for Blake3_192 {
     }
 
     fn merge_many(values: &[Self::Digest]) -> Self::Digest {
-        let bytes: Vec<u8> = values.iter().flat_map(|v| v.as_bytes()).collect();
-        Blake3Digest(*shrink_bytes(&blake3::hash(&bytes).into()))
+        let bytes = Blake3Digest::digests_as_bytes(values);
+        Blake3Digest(*shrink_bytes(&blake3::hash(bytes).into()))
     }
 
     fn merge(values: &[Self::Digest; 2]) -> Self::Digest {
@@ -260,8 +260,8 @@ impl Hasher for Blake3_160 {
     }
 
     fn merge_many(values: &[Self::Digest]) -> Self::Digest {
-        let bytes: Vec<u8> = values.iter().flat_map(|v| v.as_bytes()).collect();
-        Blake3Digest(*shrink_bytes(&blake3::hash(&bytes).into()))
+        let bytes = Blake3Digest::digests_as_bytes(values);
+        Blake3Digest(*shrink_bytes(&blake3::hash(bytes).into()))
     }
 
     fn merge_with_int(seed: Self::Digest, value: u64) -> Self::Digest {


### PR DESCRIPTION
Problem: Blake3_192 and Blake3_160 merge_many built input using Digest::as_bytes(), which always returns 32 bytes. For 24/20-byte digests this adds zero-padding, so merge_many effectively concatenated 32 bytes per digest, while merge used exactly N bytes via prepare_merge. This inconsistency changes hashing semantics and diverges from Blake3_256 and Keccak256, where merge_many uses exactly N bytes per digest.
Fix: Replace values.iter().flat_map(|v| v.as_bytes()) with Blake3Digest::digests_as_bytes(values) in merge_many for 192/160. This zero-copies exactly N bytes per digest, aligning behavior with merge, Blake3_256, and Keccak256.