### PR TITLE
Replace panic/expect with proper error returns in with_entries and compute_mutations

### DIFF
--- a/miden-crypto/src/merkle/smt/large/mod.rs
+++ b/miden-crypto/src/merkle/smt/large/mod.rs
@@ -291,7 +291,10 @@ impl<S: SmtStorage> LargeSmt<S> {
         let entries: Vec<(Word, Word)> = entries.into_iter().collect();
 
         if storage.has_leaves()? {
-            panic!("Cannot create SMT with non-empty storage");
+            return Err(StorageError::Unsupported(
+                "Cannot create SMT with non-empty storage".into(),
+            )
+            .into());
         }
         let mut tree = LargeSmt::new(storage)?;
         if entries.is_empty() {
@@ -463,8 +466,7 @@ impl<S: SmtStorage> LargeSmt<S> {
         leaf_indices.sort_unstable();
 
         // Get leaves from storage
-        let leaves_from_storage =
-            self.storage.get_leaves(&leaf_indices).expect("Failed to get leaves");
+        let leaves_from_storage = self.storage.get_leaves(&leaf_indices)?;
 
         // Map leaf indices to their corresponding leaves
         let leaf_map: Map<u64, SmtLeaf> = leaf_indices


### PR DESCRIPTION
- with_entries: return StorageError::Unsupported when storage is non-empty instead of panicking.
- compute_mutations: propagate get_leaves errors using ? instead of expect.

These updates align error handling with the module’s existing Result-based API (LargeSmtError), improve robustness against backend I/O failures (e.g., RocksDB), and prevent crashing the process on recoverable storage errors. Methods constrained by the SparseMerkleTree trait’s infallible signatures remain unchanged.