### PR TITLE
expose `Word -> LeafIndex` deriv fn; add `fn get_leaf_by_index` accessor

### DIFF
--- a/miden-crypto/src/merkle/smt/mod.rs
+++ b/miden-crypto/src/merkle/smt/mod.rs
@@ -39,6 +39,12 @@ pub const SMT_MAX_DEPTH: u8 = 64;
 // SPARSE MERKLE TREE
 // ================================================================================================
 
+/// Derive a leaf index from the key of the key-value-pair stored
+pub fn word_to_leaf_index(key: &Word) -> LeafIndex<SMT_DEPTH> {
+    let most_significant_felt = key[3];
+    LeafIndex::new_max_depth(most_significant_felt.as_int())
+}
+
 type InnerNodes = Map<NodeIndex, InnerNode>;
 type Leaves<T> = Map<u64, T>;
 type NodeMutations = Map<NodeIndex, NodeMutation>;
@@ -457,8 +463,11 @@ pub(crate) trait SparseMerkleTree<const DEPTH: u8> {
     /// updated is associated with [`Self::EMPTY_VALUE`].
     fn get_value(&self, key: &Self::Key) -> Self::Value;
 
-    /// Returns the leaf at the specified index.
+    /// Returns the leaf at the specified index derived from _any one_ key that maps to the leaf.
     fn get_leaf(&self, key: &Self::Key) -> Self::Leaf;
+
+    /// Access a leaf by leaf index.
+    fn get_leaf_by_index(&self, leaf_index: &LeafIndex<DEPTH>) -> Self::Leaf;
 
     /// Returns the hash of a leaf
     fn hash_leaf(leaf: &Self::Leaf) -> Word;

--- a/miden-crypto/src/merkle/smt/simple/mod.rs
+++ b/miden-crypto/src/merkle/smt/simple/mod.rs
@@ -145,7 +145,6 @@ impl<const DEPTH: u8> SimpleSmt<DEPTH> {
     pub fn num_leaves(&self) -> usize {
         self.leaves.len()
     }
-
     /// Returns the leaf at the specified index.
     pub fn get_leaf(&self, key: &LeafIndex<DEPTH>) -> Word {
         <Self as SparseMerkleTree<DEPTH>>::get_leaf(self, key)
@@ -418,6 +417,10 @@ impl<const DEPTH: u8> SparseMerkleTree<DEPTH> for SimpleSmt<DEPTH> {
             Some(word) => *word,
             None => Self::EMPTY_VALUE,
         }
+    }
+
+    fn get_leaf_by_index(&self, leaf_index: &LeafIndex<DEPTH>) -> Self::Leaf {
+        self.get_leaf(leaf_index)
     }
 
     fn hash_leaf(leaf: &Word) -> Word {


### PR DESCRIPTION
## Describe your changes

Extend the `struct Smt` by `get_leaf_by_index` and a free floating `fn word_to_leaf_index` to avoid having to pull `SmtWithHistory` into `miden-crypto`, but allow it to live in `miden-base`.

I'd keep this open until I am sure how to partition all pieces, and only then expose more API.

## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
