### PR TITLE
Support ECDSA signing/verifying with prehashed messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - [BREAKING] Incremented MSRV to 1.89.
 - Added `AVX512` acceleration for RPO and RPX hash functions, including parallelized E-rounds for RPX ([#551](https://github.com/0xMiden/crypto/pull/551)).
 - [BREAKING] Adds DSA (EdDSA25519) and ECDH (X25519) using Curve25519 ([#537](https://github.com/0xMiden/crypto/pull/537)).
+- Support ECDSA signing/verifying with prehashed messages ([#573](https://github.com/0xMiden/crypto/pull/573)).
 
 ## 0.17.0 (2025-09-12)
 

--- a/miden-crypto/src/dsa/ecdsa_k256_keccak/mod.rs
+++ b/miden-crypto/src/dsa/ecdsa_k256_keccak/mod.rs
@@ -79,7 +79,11 @@ impl SecretKey {
     /// Signs a message (represented as a Word) with this secret key.
     pub fn sign(&mut self, message: Word) -> Signature {
         let message_digest = hash_message(message);
+        self.sign_prehash(message_digest)
+    }
 
+    /// Signs a pre-hashed message with this secret key.
+    pub fn sign_prehash(&mut self, message_digest: [u8; 32]) -> Signature {
         let (signature_inner, recovery_id) = self
             .inner
             .sign_prehash_recoverable(&message_digest)
@@ -121,6 +125,11 @@ impl PublicKey {
     /// Verifies a signature against this public key and message.
     pub fn verify(&self, message: Word, signature: &Signature) -> bool {
         let message_digest = hash_message(message);
+        self.verify_prehash(message_digest, signature)
+    }
+
+    /// Verifies a signature against this public key and pre-hashed message.
+    pub fn verify_prehash(&self, message_digest: [u8; 32], signature: &Signature) -> bool {
         let signature_inner = k256::ecdsa::Signature::from_scalars(*signature.r(), *signature.s());
 
         match signature_inner {


### PR DESCRIPTION
## Describe your changes

Adds `SecretKey::sign_prehash` and `PublicKey::verify_prehash` to ecdsa module

## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
