### PR TITLE
fix: unify RNG usage in xchacha encryption methods

### DIFF
--- a/miden-crypto/src/aead/xchacha/mod.rs
+++ b/miden-crypto/src/aead/xchacha/mod.rs
@@ -135,7 +135,8 @@ impl SecretKey {
         data: &[u8],
         associated_data: &[u8],
     ) -> Result<EncryptedData, EncryptionError> {
-        let mut rng = rand::rng();
+        use rand::{SeedableRng, rngs::StdRng};
+        let mut rng = StdRng::from_os_rng();
         let nonce = Nonce::with_rng(&mut rng);
 
         self.encrypt_bytes_with_nonce(data, associated_data, nonce)


### PR DESCRIPTION
Standardize random number generator usage across xchacha encryption methods. 

Replace rand::rng() with StdRng::from_os_rng() in encrypt_bytes_with_associated_data to match the pattern used in encrypt_elements_with_associated_data. 

This ensures consistent cryptographic behavior and follows the same RNG pattern used in the aead_rpo module.