### PR TITLE
chore: `SmtForest` returns earlier when there are no updates

### DIFF
--- a/miden-crypto/src/merkle/smt/forest/store.rs
+++ b/miden-crypto/src/merkle/smt/forest/store.rs
@@ -161,6 +161,11 @@ impl SmtStore {
             leaves_by_index.insert(index, leaf_hash);
         }
 
+        if leaves_by_index.is_empty() {
+            // No leaves were updated, return the original root
+            return Ok(root);
+        }
+
         #[allow(unused_mut)]
         let mut sorted_leaf_indices = leaves_by_index.keys().cloned().collect::<Vec<_>>();
 
@@ -229,10 +234,6 @@ impl SmtStore {
             let new_key = node.hash();
             new_nodes.insert(new_key, node);
             nodes_by_index.insert(index, new_key);
-        }
-
-        if nodes_by_index.is_empty() {
-            return Ok(root);
         }
 
         let new_root = nodes_by_index

--- a/miden-crypto/src/merkle/smt/forest/tests.rs
+++ b/miden-crypto/src/merkle/smt/forest/tests.rs
@@ -70,6 +70,10 @@ fn test_insert_multiple_values() -> Result<(), MerkleError> {
         ]),
     );
 
+    // Inserting the same key-value pair again should return the same root
+    let root_duplicate = forest.insert(new_root, key, value)?;
+    assert_eq!(new_root, root_duplicate);
+
     let key2 = Word::new([ZERO, ONE, ZERO, ONE]);
     let new_root = forest.insert(new_root, key2, value)?;
     assert_eq!(


### PR DESCRIPTION
Follow-up from https://github.com/0xMiden/crypto/pull/608#discussion_r2464861531

The behavior doesn't change at all. When the leaves iterator was empty, or if all leaves were already up-to-date, we wouldn't process anything (`nodes_by_index` and  `leaves_by_index` would both be empty). Performance also doesn't change much – now we skip sorting an empty array.

This PR makes the logic a little clearer though.