### PR TITLE
chore(aead): remove unused ToString import

### DIFF
--- a/miden-crypto/src/aead/xchacha/mod.rs
+++ b/miden-crypto/src/aead/xchacha/mod.rs
@@ -10,7 +10,7 @@
 //! - [`Nonce`]: A 192-bit nonce that should be sampled randomly per encryption operation
 //! - [`EncryptedData`]: Encrypted data
 
-use alloc::{string::ToString, vec::Vec};
+use alloc::vec::Vec;
 
 use chacha20poly1305::{
     XChaCha20Poly1305,


### PR DESCRIPTION
## Describe your changes
Removed the unused `alloc::string::ToString` import from the XChaCha20-Poly1305 implementation module. No functional changes.


## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
