### PR TITLE
fix: remove_value semantics and empty-leaf cleanup

### DIFF
--- a/miden-crypto/src/merkle/smt/large/storage/memory.rs
+++ b/miden-crypto/src/merkle/smt/large/storage/memory.rs
@@ -1,5 +1,10 @@
+#[cfg(not(feature = "hashmaps"))]
+use alloc::collections::btree_map::Entry as MapEntry;
 use alloc::{boxed::Box, string::String, vec::Vec};
 use std::sync::{PoisonError, RwLock};
+
+#[cfg(feature = "hashmaps")]
+use hashbrown::hash_map::Entry as MapEntry;
 
 use super::{SmtStorage, StorageError, StorageUpdateParts, StorageUpdates};
 use crate::{
@@ -131,17 +136,17 @@ impl SmtStorage for MemoryStorage {
     fn remove_value(&self, index: u64, key: Word) -> Result<Option<Word>, StorageError> {
         let mut leaves_guard = self.leaves.write()?;
 
-        // Take ownership of the leaf to perform mutation safely, then reinsert if not empty.
-        if let Some(mut leaf) = leaves_guard.remove(&index) {
-            let (old_value, is_empty) = leaf.remove(key);
-            if !is_empty {
-                leaves_guard.insert(index, leaf);
-            }
-            Ok(old_value)
-        } else {
-            // Leaf at index does not exist, so no value could be removed.
-            Ok(None)
-        }
+        let old_value = match leaves_guard.entry(index) {
+            MapEntry::Occupied(mut entry) => {
+                let (old_value, is_empty) = entry.get_mut().remove(key);
+                if is_empty {
+                    entry.remove();
+                }
+                old_value
+            },
+            MapEntry::Vacant(_) => None,
+        };
+        Ok(old_value)
     }
 
     /// Retrieves a single leaf node.


### PR DESCRIPTION
Fix incorrect `remove_value()` semantics in `MemoryStorage` that returned` Some(EMPTY_WORD)` for missing keys and left empty leaves in storage.

Previously, `miden-crypto/src/merkle/smt/large/storage/memory.rs::remove_value()` read the “old value” via `SmtLeaf::get_value(&key)`, which returns `Some(EMPTY_WORD)` when the key maps to the same leaf index but isn’t present. This violated the `SmtStorage` contract (should be None if the key wasn’t found) and diverged from the RocksDB backend. Additionally, the method discarded the result of `SmtLeaf::remove(key)` and never deleted leaves that became empty, allowing `SmtLeaf::Empty(_)` to persist in the leaves map.

That skewed `has_leaves()`/`leaf_count()` and could break `LargeSmt::new()` paths that rely on emptiness checks. The fix removes the leaf from the map, applies `leaf.remove(key)`, reinserts only if it remains non-empty, and returns the `Option<Word>` from `remove()`. 

This aligns the in-memory backend with the trait’s documented behavior and the RocksDB implementation, ensures correct absence signaling (None for missing keys), and prevents storing empty leaves, keeping counts and emptiness checks consistent.