### PR TITLE
fix: replace undefined `BaseElement` with `Felt` in rescue arch optimizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Added `compute_challenge_k()` and `verify_with_unchecked_k()` methods to separate hashing and EC logic in EdDSA over Ed25519 ([#602](https://github.com/0xMiden/crypto/pull/602)).
 - Refactored `LargeSmt::apply_mutations_with_reversion` to use batched storage operations ([#613](https://github.com/0xMiden/crypto/pull/613)).
 - Fixed IES sealed box deserialization ([#616](https://github.com/0xMiden/crypto/pull/616)).
+- Fixed undefined `BaseElement` in rescue arch optimizations ([#644](https://github.com/0xMiden/crypto/pull/644)).
 
 ## 0.18.1 (2025-11-05)
 

--- a/miden-crypto/src/hash/algebraic_sponge/rescue/arch/mod.rs
+++ b/miden-crypto/src/hash/algebraic_sponge/rescue/arch/mod.rs
@@ -81,7 +81,7 @@ pub mod optimized {
     ) -> bool {
         add_constants(state, ark);
         unsafe {
-            apply_sbox(core::mem::transmute::<&mut [BaseElement; 12], &mut [u64; 12]>(state));
+            apply_sbox(core::mem::transmute::<&mut [Felt; 12], &mut [u64; 12]>(state));
         }
         true
     }
@@ -93,7 +93,7 @@ pub mod optimized {
     ) -> bool {
         add_constants(state, ark);
         unsafe {
-            apply_inv_sbox(core::mem::transmute::<&mut [BaseElement; 12], &mut [u64; 12]>(state));
+            apply_inv_sbox(core::mem::transmute::<&mut [Felt; 12], &mut [u64; 12]>(state));
         }
         true
     }
@@ -105,7 +105,7 @@ pub mod optimized {
     ) -> bool {
         add_constants(state, ark);
         unsafe {
-            apply_ext_round(core::mem::transmute::<&mut [BaseElement; 12], &mut [u64; 12]>(state));
+            apply_ext_round(core::mem::transmute::<&mut [Felt; 12], &mut [u64; 12]>(state));
         }
         true
     }
@@ -132,7 +132,7 @@ pub mod optimized {
     ) -> bool {
         add_constants(state, ark);
         unsafe {
-            apply_sbox(core::mem::transmute::<&mut [BaseElement; 12], &mut [u64; 12]>(state));
+            apply_sbox(core::mem::transmute::<&mut [Felt; 12], &mut [u64; 12]>(state));
         }
         true
     }
@@ -144,7 +144,7 @@ pub mod optimized {
     ) -> bool {
         add_constants(state, ark);
         unsafe {
-            apply_inv_sbox(core::mem::transmute::<&mut [BaseElement; 12], &mut [u64; 12]>(state));
+            apply_inv_sbox(core::mem::transmute::<&mut [Felt; 12], &mut [u64; 12]>(state));
         }
         true
     }
@@ -156,7 +156,7 @@ pub mod optimized {
     ) -> bool {
         add_constants(state, ark);
         unsafe {
-            apply_ext_round(core::mem::transmute::<&mut [BaseElement; 12], &mut [u64; 12]>(state));
+            apply_ext_round(core::mem::transmute::<&mut [Felt; 12], &mut [u64; 12]>(state));
         }
         true
     }


### PR DESCRIPTION
## Describe your changes

`BaseElement` was referenced in `AVX2` and `AVX512` rescue arch modules but not in scope, causing compilation errors when building with target features enabled.

## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
