### PR TITLE
Switch ecdsa `PublicKeyCommitment` to be evm compatible

### DIFF
--- a/miden-crypto/src/dsa/ecdsa_k256_keccak/tests.rs
+++ b/miden-crypto/src/dsa/ecdsa_k256_keccak/tests.rs
@@ -1,3 +1,6 @@
+use core::str::FromStr;
+
+use k256::{SecretKey as K256SecretKey, elliptic_curve::ScalarPrimitive};
 use rand::rng;
 
 use super::*;
@@ -110,4 +113,29 @@ fn test_secret_key_debug_redaction() {
     // Verify Display impl also elides
     let display_output = format!("{secret_key}");
     assert_eq!(display_output, "<elided secret for SecretKey>");
+}
+
+#[test]
+fn test_publick_key_commitment() {
+    let sk = K256SecretKey::new(
+        ScalarPrimitive::from_str(
+            "0101010101010101010101010101010101010101010101010101010101010101",
+        )
+        .unwrap(),
+    );
+    let sk = SecretKey { inner: SigningKey::from(sk) };
+
+    let pk_comm = sk.public_key().to_commitment().to_hex();
+    let pk_comm_should_be = "0x1a642f0e3c3af545e7acbd38b07251b3990914f1";
+
+    // remove zeroes from pk commitment
+    let formated_pk = format!(
+        "0x{}{}{}{}",
+        pk_comm[0..18].strip_prefix("0x000000").unwrap(),
+        pk_comm[18..34].strip_prefix("000000").unwrap(),
+        pk_comm[34..50].strip_prefix("000000").unwrap(),
+        pk_comm[50..66].strip_prefix("000000").unwrap()
+    );
+
+    assert_eq!(formated_pk, pk_comm_should_be)
 }


### PR DESCRIPTION
So I was working on the miden-para integration for that I require the `PublicKeyCommitment` for ecdsa to be an evm compatable address i.e `keccak256` hash of the public key, currently it is the `rpo_hash`. 

This is required for two reasons

1. In creating accounts with para they generate an evm wallet, so when adding account to the client using the build we need to provide `with_auth_component()` with a public key commitment.
2. The `TransactionAuthenticator` also uses the `PublicKeyCommitment` now for para we need this to be an evm address or atleast the `keccak256` hash

I can work around 1 but i don't think there is anything I can do for 2.

I have made the changes but I am not certain if this breaks any `miden-base` code like  `AuthEcdsaK256Keccak` and the masm related to that. So I am marking this as draft.

cc @Dominik1999 