### PR TITLE
refactor: reduce panics in cryptographic operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -284,6 +284,7 @@ checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
 dependencies = [
  "glob",
  "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -868,6 +869,16 @@ name = "libc"
 version = "0.2.177"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+
+[[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
 
 [[package]]
 name = "libm"

--- a/miden-crypto/src/dsa/falcon512_rpo/keys/secret_key.rs
+++ b/miden-crypto/src/dsa/falcon512_rpo/keys/secret_key.rs
@@ -365,7 +365,9 @@ impl Deserializable for SecretKey {
         let chunk_size_g = ((n * WIDTH_SMALL_POLY_COEFFICIENT) + 7) >> 3;
         let chunk_size_big_f = ((n * WIDTH_BIG_POLY_COEFFICIENT) + 7) >> 3;
 
-        let f = decode_i8(&byte_vector[1..chunk_size_f + 1], WIDTH_SMALL_POLY_COEFFICIENT).unwrap();
+        let f = decode_i8(&byte_vector[1..chunk_size_f + 1], WIDTH_SMALL_POLY_COEFFICIENT).ok_or(
+            DeserializationError::InvalidValue("Failed to decode f coefficients".to_string()),
+        )?;
         let g = decode_i8(
             &byte_vector[chunk_size_f + 1..(chunk_size_f + chunk_size_g + 1)],
             WIDTH_SMALL_POLY_COEFFICIENT,

--- a/miden-crypto/src/merkle/error.rs
+++ b/miden-crypto/src/merkle/error.rs
@@ -1,3 +1,5 @@
+use alloc::string::{String, ToString};
+
 use thiserror::Error;
 
 use super::{MAX_LEAF_ENTRIES, NodeIndex, Word};
@@ -34,4 +36,16 @@ pub enum MerkleError {
     RootNotInStore(Word),
     #[error("partial smt does not track the merkle path for key {0}")]
     UntrackedKey(Word),
+    #[error("internal error: {0}")]
+    InternalError(String),
+}
+
+#[cfg(feature = "concurrent")]
+impl From<crate::merkle::LargeSmtError> for MerkleError {
+    fn from(err: crate::merkle::LargeSmtError) -> Self {
+        match err {
+            crate::merkle::LargeSmtError::Merkle(me) => me,
+            crate::merkle::LargeSmtError::Storage(se) => MerkleError::InternalError(se.to_string()),
+        }
+    }
 }

--- a/miden-crypto/src/merkle/mmr/full.rs
+++ b/miden-crypto/src/merkle/mmr/full.rs
@@ -167,7 +167,7 @@ impl Mmr {
             .collect();
 
         // Safety: the invariant is maintained by the [Mmr]
-        let peaks = MmrPeaks::new(forest, peaks).unwrap();
+        let peaks = MmrPeaks::new(forest, peaks)?;
 
         Ok(peaks)
     }

--- a/miden-crypto/src/merkle/smt/large/smt_trait.rs
+++ b/miden-crypto/src/merkle/smt/large/smt_trait.rs
@@ -6,8 +6,8 @@ use super::{
 use crate::{
     EMPTY_WORD, Word,
     merkle::{
-        EmptySubtreeRoots, InnerNode, LeafIndex, MerkleError, NodeIndex, SmtLeaf, SmtLeafError,
-        SmtProof, SparseMerklePath,
+        EmptySubtreeRoots, InnerNode, LargeSmtError, LeafIndex, MerkleError, NodeIndex, SmtLeaf,
+        SmtLeafError, SmtProof, SparseMerklePath,
         smt::{
             Map, SparseMerkleTree,
             large::{is_empty_parent, to_memory_index},
@@ -110,9 +110,7 @@ impl<S: SmtStorage> SparseMerkleTree<SMT_DEPTH> for LargeSmt<S> {
             return Ok(value);
         }
 
-        let mutations = self
-            .compute_mutations([(key, value)])
-            .expect("Failed to compute mutations in insert");
+        let mutations = self.compute_mutations([(key, value)])?;
         self.apply_mutations(mutations).expect("Failed to apply mutations in insert");
 
         Ok(old_value)
@@ -136,7 +134,7 @@ impl<S: SmtStorage> SparseMerkleTree<SMT_DEPTH> for LargeSmt<S> {
                 },
             }
         } else {
-            Ok(self.storage.remove_value(index, key).expect("Failed to remove value"))
+            Ok(self.storage.remove_value(index, key).map_err(LargeSmtError::from)?)
         }
     }
 

--- a/miden-crypto/src/merkle/smt/large/storage/memory.rs
+++ b/miden-crypto/src/merkle/smt/large/storage/memory.rs
@@ -106,7 +106,7 @@ impl SmtStorage for MemoryStorage {
         let mut leaves_guard = self.leaves.write()?;
 
         match leaves_guard.get_mut(&index) {
-            Some(leaf) => Ok(leaf.insert(key, value).expect("Failed to insert value")),
+            Some(leaf) => Ok(leaf.insert(key, value)?),
             None => {
                 leaves_guard.insert(index, SmtLeaf::Single((key, value)));
                 Ok(None)


### PR DESCRIPTION
Replace .unwrap() calls with proper error handling in production code where sensible. Avoids failures in deserialization where adversary-controlled inputs could panic the node.

- Add InternalError variant to MerkleError with From<LargeSmtError> implementation
- Convert Option handling from .unwrap() to ok_or() with meaningful errors
- Fix type conversion issues in AEAD, Falcon512, and SMT implementations
- Improve error propagation chain: StorageError -> LargeSmtError -> MerkleError
