### PR TITLE
fix: add #[repr(transparent)] to Blake3Digest and Keccak256Digest

### DIFF
--- a/miden-crypto/src/hash/blake/mod.rs
+++ b/miden-crypto/src/hash/blake/mod.rs
@@ -31,6 +31,7 @@ const DIGEST20_BYTES: usize = 20;
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "serde", serde(into = "String", try_from = "&str"))]
+#[repr(transparent)]
 pub struct Blake3Digest<const N: usize>([u8; N]);
 
 impl<const N: usize> Blake3Digest<N> {

--- a/miden-crypto/src/hash/keccak/mod.rs
+++ b/miden-crypto/src/hash/keccak/mod.rs
@@ -26,6 +26,7 @@ const DIGEST_BYTES: usize = 32;
 
 /// Keccak digest
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[repr(transparent)]
 pub struct Keccak256Digest([u8; DIGEST_BYTES]);
 
 impl Keccak256Digest {


### PR DESCRIPTION
## Summary
  - Add `#[repr(transparent)]` to `Blake3Digest` and `Keccak256Digest` structs
  - This ensures the memory layout guarantee required by the unsafe code in `digests_as_bytes()` functions

  Closes #703

  ## Checklist before requesting a review
  - [x] Repo forked and branch created from `next` according to naming convention.
  - [x] Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
  - [x] Relevant issues are linked in the PR description.
  - [ ] Tests added for new functionality.
  - [x] Documentation/comments updated according to changes.
