### PR TITLE
refactor: [1/2] move rocksdb to miden-node

### DIFF
--- a/miden-crypto/src/merkle/smt/full/concurrent/mod.rs
+++ b/miden-crypto/src/merkle/smt/full/concurrent/mod.rs
@@ -349,7 +349,7 @@ impl Smt {
 // ================================================================================================
 
 /// A subtree is of depth 8.
-pub const SUBTREE_DEPTH: u8 = 8;
+pub(in crate::merkle::smt) const SUBTREE_DEPTH: u8 = 8;
 
 /// A depth-8 subtree contains 256 "columns" that can possibly be occupied.
 pub(in crate::merkle::smt) const COLS_PER_SUBTREE: u64 = u64::pow(2, SUBTREE_DEPTH as u32);
@@ -576,7 +576,7 @@ fn build_subtrees_from_sorted_entries(
 /// more entries than can fit in a depth-8 subtree, if `leaves` contains leaves belonging to
 /// different depth-8 subtrees, if `bottom_depth` is lower in the tree than the specified
 /// maximum depth (`DEPTH`), or if `leaves` is not sorted.
-pub fn build_subtree(
+pub(crate) fn build_subtree(
     mut leaves: Vec<SubtreeLeaf>,
     tree_depth: u8,
     bottom_depth: u8,

--- a/miden-crypto/src/merkle/smt/full/mod.rs
+++ b/miden-crypto/src/merkle/smt/full/mod.rs
@@ -19,7 +19,7 @@ use crate::utils::{ByteReader, ByteWriter, Deserializable, DeserializationError,
 
 // Concurrent implementation
 #[cfg(feature = "concurrent")]
-pub mod concurrent;
+pub(in crate::merkle::smt) mod concurrent;
 
 #[cfg(test)]
 mod tests;

--- a/miden-crypto/src/merkle/smt/mod.rs
+++ b/miden-crypto/src/merkle/smt/mod.rs
@@ -19,9 +19,7 @@ pub use full::{MAX_LEAF_ENTRIES, SMT_DEPTH, Smt, SmtLeaf, SmtLeafError, SmtProof
 #[cfg(feature = "concurrent")]
 mod large;
 #[cfg(feature = "internal")]
-pub use full::concurrent::build_subtree_for_bench;
-#[cfg(feature = "concurrent")]
-pub use full::concurrent::{SUBTREE_DEPTH, SubtreeLeaf, build_subtree};
+pub use full::concurrent::{SubtreeLeaf, build_subtree_for_bench};
 #[cfg(feature = "concurrent")]
 pub use large::{
     LargeSmt, LargeSmtError, MemoryStorage, SmtStorage, StorageUpdateParts, StorageUpdates,
@@ -80,7 +78,7 @@ type NodeMutations = Map<NodeIndex, NodeMutation>;
 /// must accommodate all keys that map to the same leaf.
 ///
 /// [SparseMerkleTree] currently doesn't support optimizations that compress Merkle proofs.
-pub trait SparseMerkleTree<const DEPTH: u8> {
+pub(crate) trait SparseMerkleTree<const DEPTH: u8> {
     /// The type for a key
     type Key: Clone + Ord + Eq + Hash;
     /// The type for a value


### PR DESCRIPTION
## Describe your changes

General statement: Pulling in rocksdb as a dependency behind a feature flag feels awkward/wrong for a foundational crypto crate. Instead we should externalize these heavy dependencies to be only present at the highest/latest point possible to minimize friction.

For this to be possible we need to provide a _public_ interface for sake of extensability.

The PR exposes

- `trait SparseMerkleTree` (was `pub(crate)`) — interface custom backends must implement for storage/retrieval
- `fn build_subtree` (was `pub(crate)`) — computes 8-level subtree chunks, avoids duplicating logic
- `struct SubtreeLeaf` (already pub, now exported from `smt` module) — data type for passing inputs/outputs between `build_subtree` calls
- `SUBTREE_DEPTH` (was `pub(in crate::merkle::smt)`) — constant for 8-level partitioning granularity
- `concurrent` module (was `pub(in crate::merkle::smt)`) — namespace for parallel construction primitives

## Next Steps

Remove the rocksdb backend entirely from miden crypto.