### PR TITLE
fix/`LargeSmt`: always flush wal for subtree updates in `RocksDbStorage`

### DIFF
--- a/miden-crypto/src/merkle/smt/large/storage/rocksdb.rs
+++ b/miden-crypto/src/merkle/smt/large/storage/rocksdb.rs
@@ -698,8 +698,6 @@ impl SmtStorage for RocksDbStorage {
     /// - Returns `StorageError::Backend` if any column family lookup or RocksDB write fails.
     fn set_subtrees(&self, subtrees: Vec<Subtree>) -> Result<(), StorageError> {
         let depth24_cf = self.cf_handle(DEPTH_24_CF)?;
-        let mut write_opts = WriteOptions::default();
-        write_opts.disable_wal(true);
         let mut batch = WriteBatch::default();
 
         for subtree in subtrees {
@@ -716,7 +714,7 @@ impl SmtStorage for RocksDbStorage {
             }
         }
 
-        self.db.write_opt(batch, &write_opts)?;
+        self.db.write(batch)?;
         Ok(())
     }
 


### PR DESCRIPTION
Targets `version/0.19.x`

## Describe your changes

Always write directly to the wal, to avoid any issues with i.e. SIGINT and `fn RocksDbStorage::sync` _not_ being called. https://github.com/0xMiden/miden-node/issues/1558