### PR TITLE
ci: force nightly for fuzz jobs

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -31,13 +31,15 @@ jobs:
       - name: Cleanup large tools for build space
         uses: ./.github/actions/cleanup-runner
       - uses: dtolnay/rust-toolchain@nightly
+        with:
+          toolchain: nightly
       - uses: Swatinem/rust-cache@v2
       - name: Install cargo-fuzz
-        run: cargo install cargo-fuzz --locked
+        run: cargo +nightly install cargo-fuzz --locked
       - name: Run fuzz target (smoke test)
         working-directory: miden-serde-utils
         run: |
-          cargo fuzz run ${{ matrix.target }} -- -max_total_time=60 -runs=10000
+          cargo +nightly fuzz run ${{ matrix.target }} -- -max_total_time=60 -runs=10000
 
   fuzz-miden-crypto:
     name: fuzz miden-crypto (${{ matrix.target }})
@@ -52,12 +54,14 @@ jobs:
       - name: Cleanup large tools for build space
         uses: ./.github/actions/cleanup-runner
       - uses: dtolnay/rust-toolchain@nightly
+        with:
+          toolchain: nightly
       - uses: Swatinem/rust-cache@v2
       - name: Install cargo-fuzz
-        run: cargo install cargo-fuzz --locked
+        run: cargo +nightly install cargo-fuzz --locked
       - name: Run fuzz target (smoke test)
         run: |
           # Build the fuzz target first
-          cargo fuzz build --fuzz-dir miden-crypto-fuzz ${{ matrix.target }}
+          cargo +nightly fuzz build --fuzz-dir miden-crypto-fuzz ${{ matrix.target }}
           # Run directly to avoid cargo-fuzz wrapper SIGPIPE issue
           miden-crypto-fuzz/target/x86_64-unknown-linux-gnu/release/${{ matrix.target }} -max_total_time=60 -runs=10000


### PR DESCRIPTION
Use +nightly for cargo-fuzz install/build/run to avoid stable toolchain -Z sanitizer failures in scheduled fuzz CI.
