### PR TITLE
ci: fix docs publishing to only include workspace crates and add index

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,8 +60,9 @@ lint: format fix clippy toml typos-check machete cargo-deny ## Run all linting t
 # --- docs ----------------------------------------------------------------------------------------
 
 .PHONY: doc
-doc: ## Generate and check documentation
-	$(WARNINGS) cargo doc --all-features --keep-going --release
+doc: ## Generate and check documentation for workspace crates only
+	rm -rf "${CARGO_TARGET_DIR:-target}/doc"
+	RUSTDOCFLAGS="--enable-index-page -Zunstable-options -D warnings" cargo +nightly doc --all-features --keep-going --release --no-deps
 
 # --- testing -------------------------------------------------------------------------------------
 


### PR DESCRIPTION
- Add --no-deps flag to only document workspace crates
- Clean target/doc before generating to remove stale dependency docs
- Use --enable-index-page -Zunstable-options to generate workspace index
