### PR TITLE
refactor: use Distribution trait for random samplers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [BREAKING] Removed `hashbrown` dependency and `hashmaps` feature; `Map`/`Set` type aliases are now tied to the `std` feature ([#813](https://github.com/0xMiden/crypto/pull/813)).
 - [BREAKING] Renamed `NodeIndex::value()` to `NodeIndex::position()`, `NodeIndex::is_value_odd()` to `NodeIndex::is_position_odd()`, and `LeafIndex::value()` to `LeafIndex::position()` ([#814](https://github.com/0xMiden/crypto/pull/814)).
 - Fixed tuple `min_serialized_size()` to exclude alignment padding, fixing `BudgetedReader` rejecting valid data ([#827](https://github.com/0xMiden/crypto/pull/827)).
+- Refactored random samplers to use `Distribution` trait; implemented `Distribution<Word>` for `StandardUniform` and updated test helpers to use uniform field element sampling ([#824](https://github.com/0xMiden/crypto/pull/824)).
 
 ## 0.22.2 (2026-02-01)
 

--- a/miden-crypto/benches/store.rs
+++ b/miden-crypto/benches/store.rs
@@ -2,22 +2,23 @@ use std::hint::black_box;
 
 use criterion::{BatchSize, BenchmarkId, Criterion, criterion_group, criterion_main};
 use miden_crypto::{
-    Felt, Word,
+    Word,
     merkle::{
         MerkleTree, NodeIndex,
         smt::{LeafIndex, SMT_MAX_DEPTH, SimpleSmt},
         store::MerkleStore,
     },
-    rand::test_utils::{rand_array, rand_value},
+    rand::test_utils::rand_value,
 };
+use rand::Rng;
 
 /// Since MerkleTree can only be created when a power-of-two number of elements is used, the sample
 /// sizes are limited to that.
 static BATCH_SIZES: [usize; 3] = [2usize.pow(4), 2usize.pow(7), 2usize.pow(10)];
 
-/// Generates a random `Word`.
+/// Generates a random `Word` using the `Distribution<Word>` implementation.
 fn random_word() -> Word {
-    rand_array::<Felt, 4>().into()
+    rand::rng().random::<Word>()
 }
 
 /// Generates an index at the specified depth in `0..range`.

--- a/miden-crypto/src/aead/aead_poseidon2/test.rs
+++ b/miden-crypto/src/aead/aead_poseidon2/test.rs
@@ -2,7 +2,10 @@ use proptest::{
     prelude::{any, prop},
     prop_assert_eq, prop_assert_ne, prop_assume, proptest,
 };
-use rand::{RngCore, SeedableRng};
+use rand::{
+    RngCore, SeedableRng,
+    distr::{Distribution, Uniform},
+};
 use rand_chacha::ChaCha20Rng;
 
 use super::*;
@@ -34,12 +37,13 @@ proptest! {
         let key = SecretKey::with_rng(&mut rng);
         let nonce = Nonce::with_rng(&mut rng);
 
-        // Generate random field elements
+        // Generate random field elements uniformly sampled from the Goldilocks field
+        let uni_dist = Uniform::new(0u64, Felt::ORDER_U64).unwrap();
         let associated_data: Vec<Felt> = (0..associated_data_len)
-            .map(|_| Felt::new(rng.next_u64()))
+            .map(|_| Felt::new(uni_dist.sample(&mut rng)))
             .collect();
         let data: Vec<Felt> = (0..data_len)
-            .map(|_| Felt::new(rng.next_u64()))
+            .map(|_| Felt::new(uni_dist.sample(&mut rng)))
             .collect();
 
         let encrypted = key.encrypt_elements_with_nonce(&data, &associated_data, nonce).unwrap();
@@ -59,12 +63,13 @@ proptest! {
         let key = SecretKey::with_rng(&mut rng);
         let nonce = Nonce::with_rng(&mut rng);
 
-        // Generate random field elements
+        // Generate random field elements uniformly sampled from the Goldilocks field
+        let uni_dist = Uniform::new(0u64, Felt::ORDER_U64).unwrap();
         let associated_data: Vec<Felt> = (0..associated_data_len)
-            .map(|_| Felt::new(rng.next_u64()))
+            .map(|_| Felt::new(uni_dist.sample(&mut rng)))
             .collect();
         let data: Vec<Felt> = (0..data_len)
-            .map(|_| Felt::new(rng.next_u64()))
+            .map(|_| Felt::new(uni_dist.sample(&mut rng)))
             .collect();
 
         let encrypted = key.encrypt_elements_with_nonce(&data, &associated_data, nonce).unwrap();

--- a/miden-crypto/src/aead/xchacha/test.rs
+++ b/miden-crypto/src/aead/xchacha/test.rs
@@ -1,8 +1,12 @@
+use p3_field::PrimeField64;
 use proptest::{
     prelude::{any, prop},
     prop_assert_eq, prop_assert_ne, proptest,
 };
-use rand::{Rng, SeedableRng};
+use rand::{
+    Rng, SeedableRng,
+    distr::{Distribution, Uniform},
+};
 use rand_chacha::ChaCha20Rng;
 
 use super::*;
@@ -20,9 +24,10 @@ proptest! {
         let key = SecretKey::with_rng(&mut rng);
         let nonce = Nonce::with_rng(&mut rng);
 
-        // Generate random field elements
+        // Generate random field elements uniformly sampled from the Goldilocks field
+        let uni_dist = Uniform::new(0u64, Felt::ORDER_U64).unwrap();
         let data: Vec<Felt> = (0..data_len)
-            .map(|_| Felt::new(rng.random::<u64>()))
+            .map(|_| Felt::new(uni_dist.sample(&mut rng)))
             .collect();
 
         let encrypted = key.encrypt_elements_with_nonce(&data, &[], nonce).unwrap();
@@ -41,12 +46,13 @@ proptest! {
         let key = SecretKey::with_rng(&mut rng);
         let nonce = Nonce::with_rng(&mut rng);
 
-        // Generate random field elements
+        // Generate random field elements uniformly sampled from the Goldilocks field
+        let uni_dist = Uniform::new(0u64, Felt::ORDER_U64).unwrap();
         let associated_data: Vec<Felt> = (0..associated_data_len)
-            .map(|_| Felt::new(rng.random::<u64>()))
+            .map(|_| Felt::new(uni_dist.sample(&mut rng)))
             .collect();
         let data: Vec<Felt> = (0..data_len)
-            .map(|_| Felt::new(rng.random::<u64>()))
+            .map(|_| Felt::new(uni_dist.sample(&mut rng)))
             .collect();
 
         let encrypted = key.encrypt_elements_with_nonce(&data, &associated_data, nonce).unwrap();

--- a/miden-crypto/src/ies/tests.rs
+++ b/miden-crypto/src/ies/tests.rs
@@ -2,8 +2,12 @@
 
 use alloc::vec::Vec;
 
+use p3_field::PrimeField64;
 use proptest::prelude::*;
-use rand::{RngCore, SeedableRng};
+use rand::{
+    SeedableRng,
+    distr::{Distribution, Uniform},
+};
 use rand_chacha::ChaCha20Rng;
 
 use crate::{
@@ -20,11 +24,14 @@ fn arbitrary_bytes() -> impl Strategy<Value = Vec<u8>> {
     prop::collection::vec(any::<u8>(), 0..500)
 }
 
-/// Generates arbitrary field element vectors for property testing
+/// Generates arbitrary field element vectors for property testing.
+///
+/// Field elements are uniformly sampled from the Goldilocks field.
 fn arbitrary_field_elements() -> impl Strategy<Value = Vec<crate::Felt>> {
     (1usize..100, any::<u64>()).prop_map(|(len, seed)| {
         let mut rng = ChaCha20Rng::seed_from_u64(seed);
-        (0..len).map(|_| crate::Felt::new(rng.next_u64())).collect()
+        let uni_dist = Uniform::new(0u64, crate::Felt::ORDER_U64).unwrap();
+        (0..len).map(|_| crate::Felt::new(uni_dist.sample(&mut rng))).collect()
     })
 }
 

--- a/miden-crypto/src/merkle/smt/partial/tests.rs
+++ b/miden-crypto/src/merkle/smt/partial/tests.rs
@@ -1,7 +1,6 @@
 use alloc::collections::{BTreeMap, BTreeSet};
 
 use assert_matches::assert_matches;
-use p3_field::PrimeField64;
 use proptest::prelude::*;
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha20Rng;
@@ -21,13 +20,11 @@ use crate::{
 
 /// Helper to generate a random Word from a seeded RNG.
 /// This is used for deterministic tests that need reproducible sequences of random values.
+///
+/// Uses the `Distribution<Word> for StandardUniform` implementation which uniformly samples
+/// field elements from the Goldilocks field.
 fn random_word<R: Rng>(rng: &mut R) -> Word {
-    Word::new([
-        Felt::new(rng.random::<u64>() % Felt::ORDER_U64),
-        Felt::new(rng.random::<u64>() % Felt::ORDER_U64),
-        Felt::new(rng.random::<u64>() % Felt::ORDER_U64),
-        Felt::new(rng.random::<u64>() % Felt::ORDER_U64),
-    ])
+    rng.random::<Word>()
 }
 
 /// Tests that a partial SMT constructed from a root is well behaved and returns expected

--- a/miden-crypto/src/rand/mod.rs
+++ b/miden-crypto/src/rand/mod.rs
@@ -129,22 +129,25 @@ pub trait FeltRng: RngCore {
 // RANDOM VALUE GENERATION FOR TESTING
 // ================================================================================================
 
-/// Generates a random field element for testing purposes.
+/// Generates a random field element uniformly sampled from the Goldilocks field for testing
+/// purposes.
 ///
 /// This function is only available with the `std` feature.
 #[cfg(feature = "std")]
 pub fn random_felt() -> Felt {
-    use rand::Rng;
+    use rand::distr::{Distribution, Uniform};
     let mut rng = rand::rng();
-    // Goldilocks field order is 2^64 - 2^32 + 1
-    // Generate a random u64 and reduce modulo the field order
-    Felt::new(rng.random::<u64>())
+    let uni_dist =
+        Uniform::new(0u64, Felt::ORDER_U64).expect("should not fail given the size of the field");
+    Felt::new(uni_dist.sample(&mut rng))
 }
 
-/// Generates a random word (4 field elements) for testing purposes.
+/// Generates a random word (4 field elements) uniformly sampled from the Goldilocks field for
+/// testing purposes.
 ///
 /// This function is only available with the `std` feature.
 #[cfg(feature = "std")]
 pub fn random_word() -> Word {
-    Word::new([random_felt(), random_felt(), random_felt(), random_felt()])
+    use rand::Rng;
+    rand::rng().random::<Word>()
 }

--- a/miden-crypto/src/word/mod.rs
+++ b/miden-crypto/src/word/mod.rs
@@ -281,6 +281,23 @@ impl Randomizable for Word {
     }
 }
 
+// RANDOM SAMPLING
+// ================================================================================================
+
+impl rand::distr::Distribution<Word> for rand::distr::StandardUniform {
+    fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> Word {
+        use rand::distr::Uniform;
+        let uni_dist = Uniform::new(0u64, Felt::ORDER_U64)
+            .expect("should not fail given the size of the field");
+        Word::new([
+            Felt::new(uni_dist.sample(rng)),
+            Felt::new(uni_dist.sample(rng)),
+            Felt::new(uni_dist.sample(rng)),
+            Felt::new(uni_dist.sample(rng)),
+        ])
+    }
+}
+
 // CONVERSIONS: FROM WORD
 // ================================================================================================
 


### PR DESCRIPTION
Closes #722                                                                                                                                                                                                                                                                                                                                                                      
                                                                                                       
This PR refactors random samplers across the codebase to use the `Distribution` trait from the `rand` crate.

## Changes

- Implement `Distribution<Word>` for `StandardUniform`, enabling idiomatic `rng.random::<Word>()` usage
- Update `random_felt()` to use `Uniform::new(0, Felt::ORDER_U64)` for proper uniform sampling over the Goldilocks field
- Update `random_word()` to delegate to the new `Distribution<Word>` impl
- Refactor test helpers in `aead_poseidon2`, `xchacha`, `ies`, and `smt` tests to use uniform field element sampling
- Update benchmark random word generation to use the new Distribution impl

## Notes

- `Felt` is a foreign type alias (`p3_goldilocks::Goldilocks`), so `Distribution<Felt>` cannot be implemented due to the orphan rule. Instead, `Uniform::new(0, Felt::ORDER_U64)` is used directly where needed.
- `Word` is a local type, so `Distribution<Word> for StandardUniform` is implemented in `word/mod.rs`.
- The existing `Distribution` impls for `SecretKey`/`Nonce` in `aead_poseidon2` are kept as-is (out of scope per #722).