### PR TITLE
fix(smt): avoid corrupting `SmtStore` when registering empty root

### DIFF
--- a/miden-crypto/src/merkle/smt/forest/mod.rs
+++ b/miden-crypto/src/merkle/smt/forest/mod.rs
@@ -202,7 +202,13 @@ impl SmtForest {
                 self.leaves.insert(leaf_hash, leaf);
             }
         }
-        self.roots.insert(new_root);
+        // Never register the empty tree root in self.roots, as it is always implicitly valid
+        // and the empty hash nodes are pre-populated infrastructure in the SmtStore.
+        // Adding it here would let `pop_smts` walk and destroy those nodes,
+        // corrupting the store for all future operations.
+        if new_root != *EmptySubtreeRoots::entry(SMT_DEPTH, 0) {
+            self.roots.insert(new_root);
+        }
 
         Ok(new_root)
     }

--- a/miden-crypto/src/merkle/smt/forest/tests.rs
+++ b/miden-crypto/src/merkle/smt/forest/tests.rs
@@ -277,3 +277,27 @@ fn test_removing_empty_smt_from_forest() {
     // Popping the empty root should be a no-op (no panic or error)
     forest.pop_smts(vec![empty_tree_root]);
 }
+
+#[test]
+fn test_empty_root_never_removed() -> Result<(), MerkleError> {
+    // Verify that the empty tree root is never registered in self.roots and that
+    // popping it does not corrupt the store.
+    let mut forest = SmtForest::new();
+    let empty_root = *EmptySubtreeRoots::entry(SMT_DEPTH, 0);
+    let key = Word::new([ZERO; WORD_SIZE]);
+    let value = Word::new([ONE; WORD_SIZE]);
+
+    // batch_insert with no entries returns the empty root — it must not be registered
+    let root = forest.batch_insert(empty_root, vec![])?;
+    assert_eq!(root, empty_root);
+
+    // Popping the empty root would corrupt the store if it were in self.roots.
+    forest.pop_smts(vec![empty_root]);
+
+    // The forest should still be fully functional
+    let new_root = forest.insert(empty_root, key, value)?;
+    let proof = forest.open(new_root, key)?;
+    assert!(proof.verify_membership(&key, &value, &new_root));
+
+    Ok(())
+}


### PR DESCRIPTION
## Description
The empty tree root is always implicitly valid because it is the root of the scaffolding of the `SmtStore` that enables inserting new nodes, these are the pre-populated empty hash nodes.
There's an edge case in which if we have an empty tree and we perform a no-op on it, like inserting an empty k/v pair, we can get the empty tree root into `self.roots` without even incrementing the `rc` counters in the `SmtStore`. The consequence of this is that we'll then be able to `pop_smts` and those nodes that had `rc` 1 will have `rc` 0 and they'll be removed, thus corrupting the `SmtStore`, because those nodes are needed as a base for insertion.

The fix I suggest is to just avoid inserting the empty root into `self.roots` because this one is implicit. If it cannot be inserted, it can't be popped either. Added test fails without the fix.
Suggestions on any other approach to fix this (or even test this) are welcome.

PS: This PR is pointed to 0.19.x because it's the current version that we are using in miden-client, but if you think it should point to another branch instead we can change it. Thanks.