### PR TITLE
feat(SmtForest): Change history to store full deltas

### DIFF
--- a/miden-crypto/src/merkle/smt/large_forest/backend/memory/mod.rs
+++ b/miden-crypto/src/merkle/smt/large_forest/backend/memory/mod.rs
@@ -6,15 +6,12 @@
 
 mod tests;
 
-use alloc::{
-    collections::{BTreeMap, BTreeSet},
-    vec::Vec,
-};
+use alloc::vec::Vec;
 
 use crate::{
     EMPTY_WORD, Map, Word,
     merkle::smt::{
-        LeafIndex, SMT_DEPTH, Smt, SmtProof, VersionId,
+        Smt, SmtProof, VersionId,
         large_forest::{
             Backend,
             backend::{BackendError, MutationSet, Result},
@@ -110,8 +107,8 @@ impl Backend for InMemoryBackend {
     /// Returns an iterator that yields the populated (key-value) entries for the specified
     /// `lineage`.
     ///
-    /// This iterator yields entries in an order such that they are sorted by their leaf index,
-    /// within which entries that share a leaf index are sorted by key.
+    /// It yields entries in an arbitrary order, and never yields entries where the value is the
+    /// empty word.
     ///
     /// # Errors
     ///
@@ -119,7 +116,7 @@ impl Backend for InMemoryBackend {
     ///   backend.
     fn entries(&self, lineage: LineageId) -> Result<impl Iterator<Item = TreeEntry>> {
         let tree = self.trees.get(&lineage).ok_or(BackendError::UnknownLineage(lineage))?;
-        Ok(InMemoryBackendEntriesIterator::new(&tree.tree))
+        Ok(tree.tree.entries().map(|(k, v)| TreeEntry { key: *k, value: *v }))
     }
 
     /// Adds the provided `lineage` to the forest.
@@ -294,106 +291,4 @@ impl Default for InMemoryBackend {
 struct TreeData {
     version: VersionId,
     tree: Smt,
-}
-
-// ENTRIES ITERATOR
-// ================================================================================================
-
-/// An iterator over entries in a given tree in the backend.
-///
-/// It is guaranteed to yield entries such that they are sorted by their leaf index, and then for
-/// entries that share the same leaf index they are sorted by their key. It should never yield
-/// entries that have `value == EMPTY_WORD`.
-#[derive(Clone, Debug)]
-struct InMemoryBackendEntriesIterator<'backend> {
-    /// A reference to the tree over which the iterator is running.
-    tree: &'backend Smt,
-
-    /// The leaves that are yet to have their entries iterated over.
-    remaining_leaves: BTreeSet<LeafIndex<SMT_DEPTH>>,
-
-    /// The current iteration state of the iterator.
-    state: InMemoryBackendEntriesIteratorState,
-}
-impl<'backend> InMemoryBackendEntriesIterator<'backend> {
-    /// Constructs a new iterator over the entries for a tree.
-    pub fn new(tree: &'backend Smt) -> Self {
-        let remaining_leaves = tree.leaves().map(|(ix, _)| ix).collect::<BTreeSet<_>>();
-        assert!(remaining_leaves.iter().is_sorted());
-
-        let state = InMemoryBackendEntriesIteratorState::NotInLeaf;
-
-        Self { tree, remaining_leaves, state }
-    }
-}
-
-impl<'backend> Iterator for InMemoryBackendEntriesIterator<'backend> {
-    type Item = TreeEntry;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        match &mut self.state {
-            InMemoryBackendEntriesIteratorState::NotInLeaf => {
-                // If we are not inside a leaf we need to see if we can become so.
-                if let Some(ix) = self.remaining_leaves.pop_first() {
-                    // If we can move into a new leaf, we transition the state into that leaf and
-                    // return the entry.
-                    let leaf = self
-                        .tree
-                        .get_leaf_by_index(ix)
-                        .expect("Leaf should exist for index derived from tree");
-
-                    // We can now grab the entries from the leaf, and we know that if it was in the
-                    // source iterator it must have at least one. We smoosh them into a BTreeMap to
-                    // ensure that they are sorted by key as required.
-                    let entries: BTreeMap<_, _> =
-                        leaf.to_entries().map(|(k, v)| (*k, *v)).collect();
-                    let (key, value) = entries.first_key_value()
-                        .expect("The source iterator should have provided only leaves with at least one entry.");
-                    let item = TreeEntry { key: *key, value: *value };
-
-                    self.state =
-                        InMemoryBackendEntriesIteratorState::InEntry { remaining_entries: entries };
-
-                    Some(item)
-                } else {
-                    // If we can't move into a new leaf, the iterator is done.
-                    None
-                }
-            },
-            InMemoryBackendEntriesIteratorState::InEntry { remaining_entries } => {
-                // If we are already inside a leaf when `next` is called, we need to pop the front
-                // value.
-                remaining_entries
-                    .pop_first()
-                    .expect("InEntry implies there should be at least one entry");
-
-                // There are then two cases that can happen.
-                if let Some((k, v)) = remaining_entries.first_key_value() {
-                    // The simple case is that we have another entry in the current leaf. In that
-                    // case, we just re-write the current state to track this.
-                    let item = TreeEntry { key: *k, value: *v };
-
-                    Some(item)
-                } else {
-                    // If we reach here there are no further entries in the leaf, so we are
-                    // implicitly in the `NotInLeaf` state. We make this explicit and then recurse
-                    // the once.
-                    self.state = InMemoryBackendEntriesIteratorState::NotInLeaf;
-                    self.next()
-                }
-            },
-        }
-    }
-}
-
-#[derive(Clone, Debug)]
-enum InMemoryBackendEntriesIteratorState {
-    /// The iterator is currently not in a leaf.
-    NotInLeaf,
-
-    /// The iterator is pointing to a specific entry in a leaf.
-    InEntry {
-        /// The remaining entries in the leaf.
-        remaining_entries: BTreeMap<Word, Word>,
-    },
 }

--- a/miden-crypto/src/merkle/smt/large_forest/backend/memory/tests.rs
+++ b/miden-crypto/src/merkle/smt/large_forest/backend/memory/tests.rs
@@ -396,16 +396,6 @@ fn entries() -> Result<()> {
             .contains(&TreeEntry { key: key_1_3, value: value_1_3 }),
     );
 
-    // Importantly, the iterator should also be sorted in two stages. First by leaf index, and then
-    // by key.
-    assert!(backend.entries(lineage_1)?.is_sorted_by(|l, r| {
-        if l.index() == r.index() {
-            l.key < r.key
-        } else {
-            l.index() < r.index()
-        }
-    }));
-
     Ok(())
 }
 

--- a/miden-crypto/src/merkle/smt/large_forest/backend/mod.rs
+++ b/miden-crypto/src/merkle/smt/large_forest/backend/mod.rs
@@ -116,9 +116,8 @@ where
     /// It is the responsibility of the forest to ensure lineage existence before querying the
     /// backend. The backend must return an error if the lineage does not exist.
     ///
-    /// This iterator must yield entries in an order such that they are sorted by their leaf index,
-    /// and entries that share a leaf index are sorted by key. It must not include key-value pairs
-    /// where the value is the empty word.
+    /// The iterator may yield entries in any arbitrary order, but must not yield entries for which
+    /// the value is the empty word.
     fn entries(&self, lineage: LineageId) -> Result<impl Iterator<Item = TreeEntry>>;
 
     // SINGLE-TREE MODIFIERS

--- a/miden-crypto/src/merkle/smt/large_forest/history/mod.rs
+++ b/miden-crypto/src/merkle/smt/large_forest/history/mod.rs
@@ -2,37 +2,29 @@
 //! historical versions of a given merkle tree.
 //!
 //! This history consists of a series of _deltas_ from the current state of the tree, moving
-//! backward in history away from that current state. These deltas are then used to form a "merged
-//! overlay" that represents the changes to be made on top of the current tree to put it _back_ in
-//! that historical state.
+//! backward in history away from that current state. These deltas are then used to form an overlay
+//! that represents the changes to be made on top of the current tree to put it _back_ in that
+//! historical state.
 //!
 //! It provides functionality for adding new states to the history, as well as for querying the
 //! history at a given point in time.
 //!
 //! # Complexity
 //!
-//! Versions in this structure are _cumulative_. To get the entire picture of an arbitrary node or
-//! leaf at version `v` it may be necessary to check for changes in all versions between `v` and the
-//! current tree state. This gives worst-case complexity `O(v)` when querying a node or leaf for the
-//! version `v`.
-//!
-//! This is acceptable overhead as we assert that newer versions are far more likely to be queried
-//! than older versions. Nevertheless, it may be improved in future using a sharing approach, but
-//! that potential improvement is being ignored for now for the sake of simplicity.
+//! Versions in this structure are _complete_. This means that the data stored for any given
+//! historical version is sufficient to apply atop the current tree to return it to the state
+//! corresponding to that historical version.
 //!
 //! # Performance
 //!
 //! This structure operates entirely in memory, and is hence reasonably quick to query. As of the
-//! current time, no detailed benchmarking has taken place for the history, but based on some basic
-//! profiling the major time taken is in chasing pointers throughout memory due to the use of
-//! [`Map`]s, but this is unavoidable in the current structure and may need to be revisited in
-//! the future.
+//! current time, no detailed benchmarking has taken place for the history.
 
 pub mod error;
 
 mod tests;
 
-use alloc::collections::{BTreeMap, BTreeSet, VecDeque};
+use alloc::collections::VecDeque;
 use core::fmt::Debug;
 
 use error::{HistoryError, Result};
@@ -42,9 +34,9 @@ use crate::{
     merkle::{
         EmptySubtreeRoots, NodeIndex,
         smt::{
-            LeafIndex, NodeMutation, SMT_DEPTH,
+            NodeMutation, SMT_DEPTH,
             large_forest::{
-                root::{RootValue, TreeEntry, VersionId},
+                root::{RootValue, VersionId},
                 utils::MutationSet,
             },
         },
@@ -53,12 +45,6 @@ use crate::{
 
 // UTILITY TYPE ALIASES
 // ================================================================================================
-
-/// A compact leaf is a mapping from full word-length keys to word-length values, intended to be
-/// stored in the leaves of an otherwise shallower merkle tree.
-///
-/// We use a BTreeMap as we need a guaranteed iteration order over the keys.
-pub type CompactLeaf = BTreeMap<Word, Word>;
 
 /// A collection of changes to arbitrary non-leaf nodes in a merkle tree.
 ///
@@ -71,16 +57,9 @@ pub type CompactLeaf = BTreeMap<Word, Word>;
 /// history corresponding to version `v`.
 pub type NodeChanges = Map<NodeIndex, Word>;
 
-/// A collection of changes to arbitrary leaf nodes in a merkle tree.
-///
-/// While represented as a single leaf, it only contains the changes to the leaf as part of the
-/// delta, and still needs to be combined with the actual leaf data for querying.
-///
-/// Note that if in the version of the tree represented by these `LeafChanges` had the default value
-/// at the leaf, this default value must be made concrete in the map. Failure to do so will retain a
-/// newer, non-default value for that leaf, and thus result in incorrect query results at this point
-/// in the history.
-pub type LeafChanges = Map<LeafIndex<SMT_DEPTH>, CompactLeaf>;
+/// The type of the keys that need to be changed by the delta to return the target tree to the state
+/// represented by the delta.
+pub type ChangedKeys = Map<Word, Word>;
 
 // HISTORY
 // ================================================================================================
@@ -102,15 +81,9 @@ pub struct History {
     ///
     /// # Implementation Note
     ///
-    /// As we are targeting small numbers of history items (e.g. 30), having a sequence with an
-    /// allocated capacity equal to the small maximum number of items is perfectly sane. This will
-    /// avoid costly reallocations in the fast path.
-    ///
-    /// We use a [`VecDeque`] instead of a [`alloc::vec::Vec`] or
-    /// [`alloc::collections::LinkedList`] as we
-    /// estimate that the vast majority of removals will be the oldest entries as new ones are
-    /// pushed. This means that we can optimize for those removals along with indexing performance,
-    /// rather than optimizing for more rare removals from the middle of the sequence.
+    /// We use a [`VecDeque`] instead of a [`Vec`] so that we can both have efficient access to any
+    /// delta, while also making removals from the end efficient. As [`Self::truncate`] only ever
+    /// removes some oldest `n` entries, this is the exact behavior we want.
     deltas: VecDeque<Delta>,
 }
 
@@ -119,10 +92,7 @@ impl History {
     /// a tree.
     #[must_use]
     pub fn empty(max_count: usize) -> Self {
-        // We allocate one more than we actually need to store to allow us to insert and THEN
-        // remove, rather than the other way around. This leads to negligible increases in memory
-        // usage while allowing for cleaner code.
-        let deltas = VecDeque::with_capacity(max_count + 1);
+        let deltas = VecDeque::new();
         Self { max_count, deltas }
     }
 
@@ -186,24 +156,38 @@ impl History {
         root: RootValue,
         version_id: VersionId,
         nodes: NodeChanges,
-        leaves: LeafChanges,
+        changed_keys: ChangedKeys,
     ) -> Result<()> {
-        if let Some(v) = self.deltas.iter().last() {
-            if v.version_id < version_id {
-                self.deltas.push_back(Delta::new(root, version_id, nodes, leaves));
-                if self.num_versions() > self.max_versions() {
-                    self.deltas.pop_front();
-                }
-
-                Ok(())
-            } else {
-                Err(HistoryError::NonMonotonicVersions(version_id, v.version_id))
-            }
-        } else {
-            self.deltas.push_back(Delta::new(root, version_id, nodes, leaves));
-
-            Ok(())
+        // We need to fail early if the provided new version is not monotonic with respect to the
+        // latest version in the history.
+        if let Some(v) = self.deltas.iter().last()
+            && v.version_id >= version_id
+        {
+            return Err(HistoryError::NonMonotonicVersions(version_id, v.version_id));
         }
+
+        // We then check if we would exceed our version count limit, and remove the oldest if so.
+        if self.num_versions() >= self.max_versions() {
+            self.deltas.pop_front();
+        }
+
+        // We then need to update all the older deltas with the necessary additional changes
+        // represented in this newly-added version.
+        for delta in &mut self.deltas {
+            // The root and the version remain the same, but we may need to change the nodes and
+            // keys.
+            for (ix, value) in &nodes {
+                delta.nodes.entry(*ix).or_insert(*value);
+            }
+            for (key, value) in &changed_keys {
+                // If the delta has removed something, we never want to re-add it over the top.
+                delta.changed_keys.entry(*key).or_insert(*value);
+            }
+        }
+
+        self.deltas.push_back(Delta::new(root, version_id, nodes, changed_keys));
+
+        Ok(())
     }
 
     /// Adds a version to the history and represented by the changes from the current tree given
@@ -231,11 +215,10 @@ impl History {
         version_id: VersionId,
         mutations: MutationSet,
     ) -> Result<()> {
-        // The leaf changes must be grouped by parent leaf when being inserted, so we do that here.
-        let mut leaf_changes = LeafChanges::default();
-        for (key, val) in mutations.new_pairs {
-            leaf_changes.entry(LeafIndex::from(key)).or_default().insert(key, val);
-        }
+        let mut changed_keys = ChangedKeys::default();
+        mutations.new_pairs.into_iter().for_each(|(k, v)| {
+            changed_keys.insert(k, v);
+        });
 
         // The node changes are more complex, as we have to explicitly handle reversions to empty
         // specially.
@@ -249,7 +232,7 @@ impl History {
             .collect();
 
         // Now we can simply delegate to the standard function.
-        self.add_version(mutations.new_root, version_id, node_changes, leaf_changes)
+        self.add_version(mutations.new_root, version_id, node_changes, changed_keys)
     }
 
     /// Returns the index in the sequence of deltas of the version that corresponds to the provided
@@ -281,6 +264,8 @@ impl History {
             return Err(HistoryError::VersionTooOld);
         }
 
+        // As we want the NEWEST delta that satisfies the version, we look for the position at which
+        // the delta cannot be used and move back by one.
         let ix = self
             .deltas
             .iter()
@@ -362,16 +347,10 @@ impl History {
 // ================================================================================================
 
 /// A read-only view of the history overlay on the tree at a specified place in the history.
-#[derive(Debug)]
+#[derive(Copy, Clone, Debug)]
 pub struct HistoryView<'history> {
-    /// The version of the history pointed to by the history view.
-    version: VersionId,
-
-    /// The index of the target version in the history.
-    version_ix: usize,
-
-    /// The history that actually stores the data that will be queried.
-    history: &'history History,
+    /// The delta corresponding to this overlay.
+    delta: &'history Delta,
 }
 
 impl<'history> HistoryView<'history> {
@@ -389,72 +368,33 @@ impl<'history> HistoryView<'history> {
     ///   coherent overlay for the provided `version`.
     fn new_of(version: VersionId, history: &'history History) -> Result<Self> {
         let version_ix = history.find_latest_corresponding_version(version)?;
-        Ok(Self { version, version_ix, history })
+        let delta = &history.deltas[version_ix];
+        Ok(Self { delta })
     }
 
     /// Gets the value of the node in the history at the provided `index`, or returns `None` if the
     /// version does not overlay the current tree at that node.
-    ///
-    /// # Complexity
-    ///
-    /// The computational complexity of this method is linear in the number of versions due to the
-    /// need to traverse to find the correct overlay value.
     #[must_use]
     pub fn node_value(&self, index: &NodeIndex) -> Option<&Word> {
-        self.history
-            .deltas
-            .iter()
-            .skip(self.version_ix)
-            .find_map(|v| v.nodes.get(index))
-    }
-
-    /// Gets a single leaf that represents the delta from the current version of the tree to the
-    /// point in the history at the specified `index`.
-    ///
-    /// If the specified version does not overlay the current tree at that leaf, it will return an
-    /// empty compact leaf.
-    ///
-    /// # Complexity
-    ///
-    /// The computational complexity of this method is linear in the number of versions due to the
-    /// need to traverse to find the correct overlay value.
-    #[must_use]
-    pub fn leaf_delta(&self, index: &LeafIndex<SMT_DEPTH>) -> CompactLeaf {
-        let mut leaf = CompactLeaf::default();
-
-        // We want to keep the _oldest_ change for any particular key in a leaf.
-        for delta in self.history.deltas.iter().skip(self.version_ix) {
-            if let Some(leaf_delta) = delta.leaves.get(index) {
-                for (key, value) in leaf_delta {
-                    leaf.entry(*key).or_insert(*value);
-                }
-            }
-        }
-
-        leaf
+        self.delta.nodes.get(index)
     }
 
     /// Queries the value of a specific `key` in a leaf in the overlay, returning the value for that
     /// `key` if it has been changed, and [`None`] otherwise.
-    ///
-    /// # Complexity
-    ///
-    /// The computational complexity of this method is linear in the number of versions due to the
-    /// need to traverse to find the correct overlay value.
     #[must_use]
     pub fn value(&self, key: &Word) -> Option<Word> {
-        self.leaf_delta(&LeafIndex::from(*key)).get(key).copied()
+        self.delta.changed_keys.get(key).cloned()
     }
 
-    /// Returns an iterator which yields the entries that are changed by this view.
-    ///
-    /// This iterator yields entries in an order such that they are sorted by their leaf index, and
-    /// entries that share a leaf index are sorted by key. It includes key-value pairs where the
-    /// value is the empty word, as these are necessary for merging with entries in the full tree.
-    pub fn entries(&self) -> impl Iterator<Item = TreeEntry> + 'history {
-        // It is safe to call this directly here as the construction of `HistoryView` has ensured
-        // that we have such a version.
-        HistoricalEntriesIterator::new(self.history, self.version)
+    /// Returns `true` if the key is removed by this delta, and `false` otherwise.
+    #[must_use]
+    pub fn is_key_removed(&self, key: &Word) -> bool {
+        self.delta.changed_keys.get(key).map(Word::is_empty).unwrap_or(false)
+    }
+
+    /// Returns an iterator which yields the entries that are added by this view.
+    pub fn changed_keys(&self) -> impl Iterator<Item = (Word, Word)> + 'history {
+        self.delta.changed_keys.iter().map(|(k, v)| (*k, *v))
     }
 }
 
@@ -492,150 +432,22 @@ struct Delta {
     /// Any changes to the non-leaf nodes in the tree for this delta.
     nodes: NodeChanges,
 
-    /// Any changes to the leaf nodes in the tree for this delta.
-    ///
-    /// Note that the leaf state is **not represented compactly**, and describes the entire state
-    /// of the leaf in the corresponding version.
-    leaves: LeafChanges,
+    /// The keys that need to be changed by the delta to return the target tree to the state
+    /// represented by the delta.
+    changed_keys: ChangedKeys,
 }
 
 impl Delta {
-    /// Creates a new delta with the provided `root`, and representing the provided
-    /// changes to `nodes` and `leaves` in the merkle tree.
+    /// Creates a new delta with the provided `root`, representing the provided changes to the
+    /// `nodes` in the merkle tree, and using `added_keys` and `removed_keys` to represent the
+    /// changes to entries in the tree.
     #[must_use]
     fn new(
         root: RootValue,
         version_id: VersionId,
         nodes: NodeChanges,
-        leaves: LeafChanges,
+        changed_keys: ChangedKeys,
     ) -> Self {
-        Self { root, version_id, nodes, leaves }
+        Self { root, version_id, nodes, changed_keys }
     }
-}
-
-// ENTRIES ITERATOR
-// ================================================================================================
-
-/// An iterator over the historical value for each changed entry at a given point in the history.
-///
-/// This iterator yields entries in an order such that they are sorted by their leaf index, and
-/// entries that share a leaf index are sorted by key. It includes key-value pairs where the value
-/// is the empty word, as these are necessary for merging with entries in the full tree.
-#[derive(Debug)]
-pub struct HistoricalEntriesIterator<'history> {
-    /// The history over which the iterator is defined.
-    history: &'history History,
-
-    /// The version in the history to be working from.
-    version: VersionId,
-
-    /// The set of all changed leaves in the deltas that make up this iterator that have not yet
-    /// been visited by the iterator.
-    ///
-    /// We use a BTreeSet specifically as we need sorted iteration behavior.
-    changed_leaves: BTreeSet<LeafIndex<SMT_DEPTH>>,
-
-    /// The current state of the iterator's iteration behavior.
-    position: HistoricalEntriesIteratorState,
-}
-
-impl<'history> HistoricalEntriesIterator<'history> {
-    /// Creates a new historical entries iterator that represents a coherent set of delta entries at
-    /// the position in the history given by `version_ix`.
-    fn new(history: &'history History, version: VersionId) -> Self {
-        let changed_leaves = history
-            .deltas
-            .iter()
-            .skip(
-                history
-                    .find_latest_corresponding_version(version)
-                    .expect("Caller has guaranteed existence of a corresponding version"),
-            )
-            .flat_map(|d| d.leaves.keys())
-            .copied()
-            .collect();
-
-        // We want to start not pointing to any leaf as we can only advance when `next` is called.
-        let current_leaf_index = HistoricalEntriesIteratorState::NotInLeaf;
-
-        Self {
-            history,
-            version,
-            changed_leaves,
-            position: current_leaf_index,
-        }
-    }
-}
-
-impl<'history> Iterator for HistoricalEntriesIterator<'history> {
-    type Item = TreeEntry;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        match &mut self.position {
-            HistoricalEntriesIteratorState::NotInLeaf => {
-                // If we are not inside a leaf we need to see if we can become so.
-                if let Some(ix) = self.changed_leaves.pop_first() {
-                    // If we can move into a new leaf, we transition the state into that leaf and
-                    // return the entry.
-                    let leaf_delta = self
-                        .history
-                        .get_view_at(self.version)
-                        .expect(
-                            "Version was guaranteed to exist before construction of the iterator",
-                        )
-                        .leaf_delta(&ix);
-
-                    // As we are querying based on `changed_leaves`, each of the `leaf_delta`
-                    // results should contain at least one item.
-                    let (key, value) = leaf_delta
-                        .first_key_value()
-                        .expect("At least one item guaranteed by construction");
-                    let item = TreeEntry { key: *key, value: *value };
-
-                    // At this point we now have the item, but we need to set up the state to point
-                    // to this item as we return it.
-                    self.position = HistoricalEntriesIteratorState::InLeaf { value: leaf_delta };
-
-                    Some(item)
-                } else {
-                    // If we cannot move to a new leaf index, the iterator is done.
-                    None
-                }
-            },
-            HistoricalEntriesIteratorState::InLeaf { value } => {
-                // If we are already inside a leaf, there are two cases that can occur when
-                // advancing.
-                value.pop_first().expect("InLeaf implies there is at least one entry in value");
-                if let Some((k, v)) = value.first_key_value() {
-                    // The first (and simplest) case is that we have another entry in the current
-                    // leaf value. In this case, the item is just the front of the leaf value, and
-                    // we re-write the key to point to it while leaving the leaf index the same.
-                    let item = TreeEntry { key: *k, value: *v };
-
-                    Some(item)
-                } else {
-                    // Here, we have no further entries in the current leaf, so we have to check if
-                    // there is another leaf to move to. In other words, we are implicitly in the
-                    // `NotInLeaf` state, so we can just call `next` recursively.
-                    //
-                    // This is not a stack overflow risk as it should only ever recurse once.
-                    self.position = HistoricalEntriesIteratorState::NotInLeaf;
-                    self.next()
-                }
-            },
-        }
-    }
-}
-
-/// The state that tracks where the iterator is in the iteration process.
-#[derive(Debug)]
-enum HistoricalEntriesIteratorState {
-    /// It currently does not point to any underlying leaf index.
-    NotInLeaf,
-
-    /// It is currently pointing to the specified key within the specified index.
-    InLeaf {
-        /// The combined full delta that represents the compact leaf.
-        value: CompactLeaf,
-    },
 }

--- a/miden-crypto/src/merkle/smt/large_forest/history/tests.rs
+++ b/miden-crypto/src/merkle/smt/large_forest/history/tests.rs
@@ -2,17 +2,15 @@
 //! The functional tests for the history component.
 
 use alloc::vec::Vec;
-use core::iter::once;
 
-use itertools::Itertools;
 use p3_field::PrimeCharacteristicRing;
 
-use super::{CompactLeaf, History, LeafChanges, NodeChanges, error::Result};
+use super::{ChangedKeys, History, NodeChanges, error::Result};
 use crate::{
     EMPTY_WORD, Felt, Word,
     merkle::{
         NodeIndex,
-        smt::{LeafIndex, Smt, VersionId, large_forest::root::TreeEntry},
+        smt::{LeafIndex, Smt, VersionId},
     },
     rand::test_utils::ContinuousRng,
 };
@@ -33,12 +31,12 @@ fn roots() -> Result<()> {
 
     // Set up our test state
     let nodes = NodeChanges::default();
-    let leaves = LeafChanges::default();
+    let changed_keys = ChangedKeys::default();
     let mut history = History::empty(2);
     let root_1: Word = rng.value();
     let root_2: Word = rng.value();
-    history.add_version(root_1, 0, nodes.clone(), leaves.clone())?;
-    history.add_version(root_2, 1, nodes.clone(), leaves.clone())?;
+    history.add_version(root_1, 0, nodes.clone(), changed_keys.clone())?;
+    history.add_version(root_2, 1, nodes.clone(), changed_keys.clone())?;
 
     // We should be able to get all the roots.
     let roots = history.roots().collect::<Vec<_>>();
@@ -55,7 +53,7 @@ fn find_latest_corresponding_version() -> Result<()> {
 
     // Start by setting up our test data.
     let nodes = NodeChanges::default();
-    let leaves = LeafChanges::default();
+    let changed_keys = ChangedKeys::default();
     let mut history = History::empty(5);
 
     let v1 = 10;
@@ -64,11 +62,11 @@ fn find_latest_corresponding_version() -> Result<()> {
     let v4 = 31;
     let v5 = 45;
 
-    history.add_version(rng.value(), v1, nodes.clone(), leaves.clone())?;
-    history.add_version(rng.value(), v2, nodes.clone(), leaves.clone())?;
-    history.add_version(rng.value(), v3, nodes.clone(), leaves.clone())?;
-    history.add_version(rng.value(), v4, nodes.clone(), leaves.clone())?;
-    history.add_version(rng.value(), v5, nodes.clone(), leaves.clone())?;
+    history.add_version(rng.value(), v1, nodes.clone(), changed_keys.clone())?;
+    history.add_version(rng.value(), v2, nodes.clone(), changed_keys.clone())?;
+    history.add_version(rng.value(), v3, nodes.clone(), changed_keys.clone())?;
+    history.add_version(rng.value(), v4, nodes.clone(), changed_keys.clone())?;
+    history.add_version(rng.value(), v5, nodes.clone(), changed_keys.clone())?;
 
     // When we query for a version that is older than the oldest in the history we should get an
     // error.
@@ -99,7 +97,7 @@ fn find_latest_corresponding_version() -> Result<()> {
 #[test]
 fn add_version() -> Result<()> {
     let nodes = NodeChanges::default();
-    let leaves = LeafChanges::default();
+    let changed_keys = ChangedKeys::default();
     let mut rng = ContinuousRng::new([0x15; 32]);
 
     // We start with an empty state, and we should be able to add deltas up until the limit we
@@ -110,18 +108,18 @@ fn add_version() -> Result<()> {
 
     let root_1: Word = rng.value();
     let id_1 = 0;
-    history.add_version(root_1, id_1, nodes.clone(), leaves.clone())?;
+    history.add_version(root_1, id_1, nodes.clone(), changed_keys.clone())?;
     assert_eq!(history.num_versions(), 1);
 
     let root_2: Word = rng.value();
     let id_2 = 1;
-    history.add_version(root_2, id_2, nodes.clone(), leaves.clone())?;
+    history.add_version(root_2, id_2, nodes.clone(), changed_keys.clone())?;
     assert_eq!(history.num_versions(), 2);
 
     // At this point, adding any version should remove the oldest.
     let root_3: Word = rng.value();
     let id_3 = 2;
-    history.add_version(root_3, id_3, nodes.clone(), leaves.clone())?;
+    history.add_version(root_3, id_3, nodes.clone(), changed_keys.clone())?;
     assert_eq!(history.num_versions(), 2);
 
     // If we then query for that first version it won't be there anymore, but the other two
@@ -131,7 +129,7 @@ fn add_version() -> Result<()> {
     assert!(history.get_view_at(id_3).is_ok());
 
     // If we try and add a version with a non-monotonic version number, we should see an error.
-    assert!(history.add_version(root_3, id_1, nodes, leaves).is_err());
+    assert!(history.add_version(root_3, id_1, nodes, changed_keys.clone()).is_err());
 
     Ok(())
 }
@@ -170,10 +168,10 @@ fn add_version_from_mutation_set() -> Result<()> {
 
     // Now we can check that it did things correctly.
     let view = history.get_view_at(version)?;
-    let expected_leaf_1 = CompactLeaf::from([(l1_k1, l1_v1), (l1_k2, l1_v2)]);
-    assert_eq!(view.leaf_delta(&leaf_1_ix), expected_leaf_1);
-    let expected_leaf_2 = CompactLeaf::from([(l2_k1, l2_v1), (l2_k2, l2_v2)]);
-    assert_eq!(view.leaf_delta(&leaf_2_ix), expected_leaf_2);
+    assert_eq!(view.value(&l1_k1), Some(l1_v1));
+    assert_eq!(view.value(&l1_k2), Some(l1_v2));
+    assert_eq!(view.value(&l2_k1), Some(l2_v1));
+    assert_eq!(view.value(&l2_k2), Some(l2_v2));
 
     Ok(())
 }
@@ -186,23 +184,23 @@ fn truncate() -> Result<()> {
     let mut history = History::empty(4);
 
     let nodes = NodeChanges::default();
-    let leaves = LeafChanges::default();
+    let changed_keys = ChangedKeys::default();
 
     let root_1: Word = rng.value();
     let id_1 = 5;
-    history.add_version(root_1, id_1, nodes.clone(), leaves.clone())?;
+    history.add_version(root_1, id_1, nodes.clone(), changed_keys.clone())?;
 
     let root_2: Word = rng.value();
     let id_2 = 10;
-    history.add_version(root_2, id_2, nodes.clone(), leaves.clone())?;
+    history.add_version(root_2, id_2, nodes.clone(), changed_keys.clone())?;
 
     let root_3: Word = rng.value();
     let id_3 = 15;
-    history.add_version(root_3, id_3, nodes.clone(), leaves.clone())?;
+    history.add_version(root_3, id_3, nodes.clone(), changed_keys.clone())?;
 
     let root_4: Word = rng.value();
     let id_4 = 20;
-    history.add_version(root_4, id_4, nodes.clone(), leaves.clone())?;
+    history.add_version(root_4, id_4, nodes.clone(), changed_keys.clone())?;
 
     assert_eq!(history.num_versions(), 4);
 
@@ -238,15 +236,15 @@ fn clear() -> Result<()> {
     let mut history = History::empty(4);
 
     let nodes = NodeChanges::default();
-    let leaves = LeafChanges::default();
+    let changed_keys = ChangedKeys::default();
 
     let root_1: Word = rng.value();
     let id_1 = 0;
-    history.add_version(root_1, id_1, nodes.clone(), leaves.clone())?;
+    history.add_version(root_1, id_1, nodes.clone(), changed_keys.clone())?;
 
     let root_2: Word = rng.value();
     let id_2 = 1;
-    history.add_version(root_2, id_2, nodes.clone(), leaves.clone())?;
+    history.add_version(root_2, id_2, nodes.clone(), changed_keys.clone())?;
 
     assert_eq!(history.num_versions(), 2);
 
@@ -274,27 +272,22 @@ fn view_at() -> Result<()> {
     nodes_1.insert(NodeIndex::new(2, 1).unwrap(), n1_value);
     nodes_1.insert(NodeIndex::new(8, 128).unwrap(), n2_value);
 
-    let mut leaf_1 = CompactLeaf::new();
+    let mut changed_1 = ChangedKeys::default();
+
     let l1_e1_key: Word = rng.value();
     let l1_e1_value: Word = rng.value();
-    let leaf_1_ix = LeafIndex::from(l1_e1_key);
-    leaf_1.insert(l1_e1_key, l1_e1_value);
+    changed_1.insert(l1_e1_key, l1_e1_value);
 
-    let mut leaf_2 = CompactLeaf::new();
     let l2_e1_key: Word = rng.value();
     let l2_e1_value: Word = rng.value();
     let leaf_2_ix = LeafIndex::from(l2_e1_key);
     let mut l2_e2_key: Word = rng.value();
     l2_e2_key[3] = Felt::from_u64(leaf_2_ix.position());
     let l2_e2_value: Word = rng.value();
-    leaf_2.insert(l2_e1_key, l2_e1_value);
-    leaf_2.insert(l2_e2_key, l2_e2_value);
+    changed_1.insert(l2_e1_key, l2_e1_value);
+    changed_1.insert(l2_e2_key, l2_e2_value);
 
-    let mut leaves_1 = LeafChanges::default();
-    leaves_1.insert(leaf_1_ix, leaf_1.clone());
-    leaves_1.insert(leaf_2_ix, leaf_2.clone());
-
-    history.add_version(root_1, id_1, nodes_1.clone(), leaves_1.clone())?;
+    history.add_version(root_1, id_1, nodes_1.clone(), changed_1.clone())?;
     assert_eq!(history.num_versions(), 1);
 
     // We then add another version that overlaps with the older version.
@@ -307,16 +300,14 @@ fn view_at() -> Result<()> {
     nodes_2.insert(NodeIndex::new(2, 1).unwrap(), n3_value);
     nodes_2.insert(NodeIndex::new(10, 256).unwrap(), n4_value);
 
-    let mut leaf_3 = CompactLeaf::new();
+    let mut changed_2 = ChangedKeys::default();
+
     let leaf_3_ix = leaf_2_ix;
     let mut l3_e1_key: Word = rng.value();
     l3_e1_key[3] = Felt::from_u64(leaf_3_ix.position());
     let l3_e1_value: Word = rng.value();
-    leaf_3.insert(l3_e1_key, l3_e1_value);
-
-    let mut leaves_2 = LeafChanges::default();
-    leaves_2.insert(leaf_3_ix, leaf_3.clone());
-    history.add_version(root_2, id_2, nodes_2.clone(), leaves_2.clone())?;
+    changed_2.insert(l3_e1_key, l3_e1_value);
+    history.add_version(root_2, id_2, nodes_2.clone(), changed_2.clone())?;
     assert_eq!(history.num_versions(), 2);
 
     // And another version for the sake of the test.
@@ -327,22 +318,17 @@ fn view_at() -> Result<()> {
     let n5_value: Word = rng.value();
     nodes_3.insert(NodeIndex::new(30, 1).unwrap(), n5_value);
 
-    let mut leaf_4 = CompactLeaf::new();
+    let mut changed_3 = ChangedKeys::default();
+
     let l4_e1_key: Word = rng.value();
     let l4_e1_value: Word = rng.value();
-    let leaf_4_ix = LeafIndex::from(l4_e1_key);
-    leaf_4.insert(l4_e1_key, l4_e1_value);
+    changed_3.insert(l4_e1_key, l4_e1_value);
 
-    let mut leaf_1n = CompactLeaf::new();
     let l1n_e1_key = l1_e1_key;
     let l1n_e1_value: Word = rng.value();
-    leaf_1n.insert(l1n_e1_key, l1n_e1_value);
+    changed_3.insert(l1n_e1_key, l1n_e1_value);
 
-    let mut leaves_3 = LeafChanges::default();
-    leaves_3.insert(leaf_4_ix, leaf_4.clone());
-    leaves_3.insert(leaf_1_ix, leaf_1n);
-
-    history.add_version(root_3, id_3, nodes_3.clone(), leaves_3.clone())?;
+    history.add_version(root_3, id_3, nodes_3.clone(), changed_3.clone())?;
     assert_eq!(history.num_versions(), 3);
 
     // At this point, we can grab a view into the history. If we grab something older than the
@@ -369,33 +355,25 @@ fn view_at() -> Result<()> {
     // Getting a leaf from the targeted version will compose with other (newer) deltas to yield the
     // correct changes. The first test here checks that a value updated in a newer delta is
     // nevertheless reverted to the correct value.
-    assert_eq!(view.leaf_delta(&leaf_1_ix), leaf_1);
+    assert_eq!(view.value(&l1_e1_key), Some(l1_e1_value));
 
-    // This test checks that the delta for a single leaf correctly combines non-overlapping key
+    // This test checks that the delta for a single value correctly combines non-overlapping key
     // reversions.
-    let leaf_2_delta: CompactLeaf = once((l3_e1_key, l3_e1_value))
-        .chain(leaf_2.iter().map(|(k, v)| (*k, *v)))
-        .collect();
-    assert_eq!(view.leaf_delta(&leaf_2_ix), leaf_2_delta);
+    assert_eq!(view.value(&l2_e1_key), Some(l2_e1_value));
+    assert_eq!(view.value(&l2_e2_key), Some(l2_e2_value));
 
-    // But getting a leaf that is not in the target delta directly should result in the same
+    // But getting a value that is not in the target delta directly should result in the same
     // traversal.
-    assert_eq!(view.leaf_delta(&leaf_4_ix), leaf_4);
+    assert_eq!(view.value(&l4_e1_key), Some(l4_e1_value));
 
-    // And getting a leaf that does not exist in any of the versions should return an empty delta.
-    assert!(view.leaf_delta(&LeafIndex::new(1024).unwrap()).is_empty());
+    // And getting a value that does not exist in any of the versions should return an empty delta.
+    assert!(view.value(&rng.value()).is_none());
 
     // Finally, getting a full value from a compact leaf should yield the value directly from
     // the target version if the target version overlays it AND contains it.
     assert_eq!(view.value(&l1_e1_key), Some(l1_e1_value));
     assert_eq!(view.value(&l2_e1_key), Some(l2_e1_value));
     assert_eq!(view.value(&l2_e2_key), Some(l2_e2_value));
-
-    // However, if the leaf exists but does not contain the provided word, it should return the
-    // sentinel `Some(None)`.
-    let mut ne_key_in_existing_leaf: Word = rng.value();
-    ne_key_in_existing_leaf[3] = Felt::from_u64(leaf_1_ix.position());
-    assert_eq!(view.value(&ne_key_in_existing_leaf), None);
 
     // If the leaf is not overlaid, then the lookup should go up the chain just as in the other
     // cases.
@@ -410,20 +388,6 @@ fn view_at() -> Result<()> {
     let view = history.get_view_at(7)?;
     assert_eq!(view.node_value(&NodeIndex::new_unchecked(30, 1)), Some(&n5_value));
     assert!(view.node_value(&NodeIndex::new_unchecked(30, 2)).is_none());
-
-    // We can also get an iterator over the entries for a given view. This should yield all the
-    // correctly-collapsed key-value pairs in the overlay. We start with the most recent view.
-    let view = history.get_view_at(id_3)?;
-    assert_eq!(view.entries().count(), 2);
-    assert!(view.entries().contains(&TreeEntry { key: l4_e1_key, value: l4_e1_value }));
-    assert!(view.entries().contains(&TreeEntry { key: l1n_e1_key, value: l1n_e1_value }));
-    assert!(view.entries().is_sorted_by(|l, r| {
-        if l.index() == r.index() {
-            l.key < r.key
-        } else {
-            l.index() < r.index()
-        }
-    }));
 
     Ok(())
 }
@@ -478,13 +442,10 @@ fn history_from_smt_non_overlapping() -> Result<()> {
     let view_v0 = history.get_view_at(0)?;
     assert_eq!(view_v0.value(&key_1), Some(EMPTY_WORD));
     assert_eq!(view_v0.value(&key_2), Some(EMPTY_WORD));
-    assert_eq!(view_v0.leaf_delta(&key_1.into()).len(), 1);
-    assert_eq!(view_v0.leaf_delta(&key_2.into()).len(), 1);
 
     // When we query version 1 it should only make revert one change on top of the current tree.
     let view_v1 = history.get_view_at(1)?;
     assert_eq!(view_v0.value(&key_2), Some(EMPTY_WORD));
-    assert_eq!(view_v0.leaf_delta(&key_2.into()).len(), 1);
 
     // Verify querying a non-existent key returns None
     let nonexistent_key: Word = rng.value();

--- a/miden-crypto/src/merkle/smt/large_forest/iterator.rs
+++ b/miden-crypto/src/merkle/smt/large_forest/iterator.rs
@@ -20,9 +20,11 @@
 use alloc::boxed::Box;
 use core::iter::Peekable;
 
+use miden_field::Word;
+
 use crate::{
-    EMPTY_WORD,
-    merkle::smt::{LeafIndex, large_forest::root::TreeEntry},
+    Set,
+    merkle::smt::large_forest::{history::HistoryView, root::TreeEntry},
 };
 
 // ENTRIES ITERATOR
@@ -37,6 +39,8 @@ use crate::{
 /// bounds do not allow for this.
 ///
 /// The iterator **must never transition between variants** during the process of iteration.
+///
+/// The order in which the results are yielded is undefined.
 pub(super) enum EntriesIterator<'forest> {
     /// An iterator over a tree in the forest that is formed from a merger of the full tree and a
     /// historical overlay.
@@ -46,17 +50,14 @@ pub(super) enum EntriesIterator<'forest> {
         /// This iterator should never yield any entries where `value == EMPTY_WORD`.
         full_tree_iter: Peekable<Box<dyn Iterator<Item = TreeEntry> + 'forest>>,
 
-        /// The iterator over the entries in the history.
-        ///
-        /// This iterator may yield entries with `value == EMPTY_WORD`. These are explicit
-        /// reversions of entries newly-set in newer versions, and so should be used. While they
-        /// technically should only ever correspond to a case where they _are_ reverting a
-        /// newly-set entry, care must be taken to remove them regardless if they do not match up
-        /// for some reason.
-        history_entries_iter: Peekable<Box<dyn Iterator<Item = TreeEntry> + 'forest>>,
+        /// The view into the history at the correct point.
+        history_view: HistoryView<'forest>,
+
+        /// Tracks the keys in the history that are given values that have already been yielded.
+        yielded_history_keys: Set<Word>,
 
         /// The current state of the iteration state machine.
-        state: EntriesIteratorState,
+        state: EntriesIteratorState<'forest>,
     },
 
     /// An iterator over a tree in the forest that is simply an iterator over the full tree.
@@ -70,23 +71,20 @@ impl<'forest> EntriesIterator<'forest> {
     /// Constructs a new entries iterator pointing to the first item in the designated `tree` in the
     /// `forest`, formed by combining a historical overlay with the current tree.
     ///
-    /// Note that it _does not_ perform checks as to the correctness of the provided iterators. If
-    /// these are not an iterator over the full tree and the historical entries in turn, the results
-    /// the iterator yields will be invalid.
+    /// Note that it _does not_ perform checks as to the correctness of the provided iterators.
     pub(super) fn new_with_history(
         full_tree_iter: impl Iterator<Item = TreeEntry> + 'forest,
-        history_entries_iter: impl Iterator<Item = TreeEntry> + 'forest,
+        history_view: HistoryView<'forest>,
     ) -> Self {
         // This type gymnastics is unfortunately necessary to let us easily store the `Peekable`
         // which we need to avoid carrying additional state in the state machine.
         let full_tree_iter: Box<dyn Iterator<Item = _>> = Box::new(full_tree_iter);
-        let history_entries_iter: Box<dyn Iterator<Item = _>> = Box::new(history_entries_iter);
 
-        // We begin in `NotInLeaf`. This is implicitly `Start -> NotInLeaf`
         Self::WithHistory {
             full_tree_iter: full_tree_iter.peekable(),
-            history_entries_iter: history_entries_iter.peekable(),
-            state: EntriesIteratorState::NotInLeaf,
+            history_view,
+            yielded_history_keys: Set::new(),
+            state: EntriesIteratorState::Initial,
         }
     }
 
@@ -94,7 +92,7 @@ impl<'forest> EntriesIterator<'forest> {
     /// `forest` without any associated history.
     ///
     /// Note that it _does not_ check whether `full_tree_iter` is actually an iterator over the
-    /// full tree. If it is not, the iterator will yield invalid results.
+    /// full tree. If it is not, this iterator will yield invalid results.
     pub(super) fn new_without_history(
         full_tree_iter: impl Iterator<Item = TreeEntry> + 'forest,
     ) -> Self {
@@ -105,11 +103,6 @@ impl<'forest> EntriesIterator<'forest> {
     /// Advances the iterator and returns the next value in the case where it is iterating over a
     /// historical tree version.
     ///
-    /// For the details of the state machine that this implements, please see the documentation for
-    /// the [`EntriesIteratorState`]. It explains the valid state transitions and the conditions
-    /// under which they occur. This implementation does not match them directly in order to
-    /// simplify the logic, but matches the intended semantics.
-    ///
     /// # Panics
     ///
     /// - If the method is called with a `self` that is not in the [`Self::WithHistory`] variant.
@@ -117,7 +110,8 @@ impl<'forest> EntriesIterator<'forest> {
     fn next_with_history(&mut self) -> Option<TreeEntry> {
         let EntriesIterator::WithHistory {
             full_tree_iter,
-            history_entries_iter,
+            history_view,
+            yielded_history_keys,
             state,
         } = self
         else {
@@ -126,183 +120,73 @@ impl<'forest> EntriesIterator<'forest> {
 
         loop {
             match state {
-                EntriesIteratorState::NotInLeaf => {
-                    // Here we are (semantically) not pointing to any specific leaf, so we need to
-                    // work out which of our possible outgoing transitions take
-                    // place. This state does not actually return anything
-                    // except in the `-> End` case.
-                    match (full_tree_iter.peek(), history_entries_iter.peek()) {
-                        (None, None) => {
-                            // No more entries exist in either of the iterators. `NotInLeaf -> End`.
-                            return None;
-                        },
-                        (Some(_), None) => {
-                            // Entries only exist in the full tree iterator. `NotInLeaf -> TreeOnly`
-                            *state = EntriesIteratorState::TreeOnly;
-                            continue;
-                        },
-                        (None, Some(_)) => {
-                            // Entries only exist in the full tree iterator. `NotInLeaf -> HistOnly`
-                            *state = EntriesIteratorState::HistOnly;
-                            continue;
-                        },
-                        (Some(full), Some(hist)) => {
-                            // Entries exist in both, but the exact state transition has not yet
-                            // been determined. We have three other
-                            // possible outgoing edges from `NotInLeaf`.
-                            let full_idx = LeafIndex::from(full.key);
-                            let hist_idx = LeafIndex::from(hist.key);
-
-                            if full_idx == hist_idx {
-                                // We are in the same leaf. `NotInLeaf -> InLeafShared`
-                                *state = EntriesIteratorState::InLeafShared;
-                            } else if full_idx < hist_idx {
-                                // We are in different leaves with full_idx coming first. `NotInLeaf
-                                // -> InLeafTreeOnly`
-                                *state = EntriesIteratorState::InLeafTreeOnly;
-                            } else {
-                                // We are in different leaves with hist_idx coming first. `NotInLeaf
-                                // -> InTreeHistOnly`.
-                                *state = EntriesIteratorState::InLeafHistOnly;
-                            }
-
-                            continue;
-                        },
+                EntriesIteratorState::Initial => {
+                    // In the initial state we need to advance to the appropriate next state.
+                    if full_tree_iter.peek().is_none() {
+                        // If there is nothing left to read from the full-tree iterator, we move
+                        // into the history iteration state.
+                        let iterator = Box::new(
+                            history_view
+                                .changed_keys()
+                                .map(|(key, value)| TreeEntry { key, value }),
+                        );
+                        *state = EntriesIteratorState::ReadingHistory { iterator };
+                    } else {
+                        // Otherwise we proceed with the full tree.
+                        *state = EntriesIteratorState::ReadingFullTree;
                     }
                 },
-                EntriesIteratorState::HistOnly => {
-                    // In this state we simply can continue yielding the history entries iterator
-                    // until it is empty. We just have to check that we're not
-                    // yielding EMPTY_WORD entries directly as these should not
-                    // be seen.
-                    for entry in history_entries_iter.by_ref() {
-                        if entry.value != EMPTY_WORD {
+                EntriesIteratorState::ReadingFullTree => {
+                    // If we are reading the full tree's iterator, we need to keep advancing as long
+                    // as we can, but we have to remove entries using the
+                    // history.
+                    if full_tree_iter.peek().is_none() {
+                        // If we have nothing left to read, we transition into the reading history
+                        // state,
+                        let iterator = Box::new(
+                            history_view
+                                .changed_keys()
+                                .map(|(key, value)| TreeEntry { key, value }),
+                        );
+                        *state = EntriesIteratorState::ReadingHistory { iterator };
+                        return self.next_with_history();
+                    }
+
+                    let Some(entry) = full_tree_iter.next() else {
+                        unreachable!("The iterator is known to have another item available");
+                    };
+
+                    let value = if let Some(v) = history_view.value(&entry.key) {
+                        // If the history has a value for this key, then we need to return that
+                        // instead. We also store the key so we do not return it again by accident.
+                        yielded_history_keys.insert(entry.key);
+
+                        // If it is an empty value we don't want to return it so we continue the
+                        // outer loop.
+                        if v.is_empty() {
+                            continue;
+                        }
+
+                        TreeEntry { key: entry.key, value: v }
+                    } else {
+                        entry
+                    };
+
+                    return Some(value);
+                },
+                EntriesIteratorState::ReadingHistory { iterator } => {
+                    // This is a terminal state. We cannot transition to any other state from here,
+                    // and so the iterator ends when the iterator over the added
+                    // history items does.
+                    for entry in iterator.by_ref() {
+                        if !yielded_history_keys.contains(&entry.key) && !entry.value.is_empty() {
                             return Some(entry);
                         }
+
+                        // Here we have already returned this entry, or it is empty. In both cases
+                        // we want to skip it, so we let the loop continue.
                     }
                     return None;
-                },
-                EntriesIteratorState::TreeOnly => {
-                    // In this state we can simply continue yielding the tree entries iterator until
-                    // it is empty. When it returns `None` we have `TreeOnly ->
-                    // End`
-                    return full_tree_iter.next();
-                },
-                EntriesIteratorState::InLeafHistOnly => {
-                    // Here, we are in a leaf that is only in the history. We technically only want
-                    // to transition out of this state once we have exhausted
-                    // the leaf, but in actuality we can rely on the logic for
-                    // `NotInLeaf` to do the right thing here. We only have to
-                    // skip empty words as these should never be yielded.
-                    let tree_item = full_tree_iter.peek().expect("Entry already checked to exist");
-                    let tree_leaf = LeafIndex::from(tree_item.key);
-
-                    loop {
-                        let Some(hist_item) = history_entries_iter.peek() else {
-                            *state = EntriesIteratorState::NotInLeaf;
-                            break;
-                        };
-
-                        if hist_item.value == EMPTY_WORD {
-                            history_entries_iter.next();
-                            continue;
-                        }
-
-                        let hist_leaf = LeafIndex::from(hist_item.key);
-                        if hist_leaf < tree_leaf {
-                            let hist_item = history_entries_iter
-                                .next()
-                                .expect("Entry already checked to exist");
-                            *state = EntriesIteratorState::NotInLeaf;
-                            return Some(hist_item);
-                        }
-
-                        *state = EntriesIteratorState::NotInLeaf;
-                        break;
-                    }
-                    continue;
-                },
-                EntriesIteratorState::InLeafTreeOnly => {
-                    // Here we are in a leaf that is only in the full tree. We technically only want
-                    // to transition out of this state once we have exhausted
-                    // the leaf, but in actuality we can rely on the logic for
-                    // `NotInleaf` to do the right thing here.
-                    *state = EntriesIteratorState::NotInLeaf;
-                    return full_tree_iter.next();
-                },
-                EntriesIteratorState::InLeafShared => {
-                    // Here we have both iterators in the same LEAF but that does not mean they have
-                    // the same item.
-                    let hist_item =
-                        history_entries_iter.peek().expect("Entry already checked to exist");
-                    let tree_item = full_tree_iter.peek().expect("Entry already checked to exist");
-
-                    if hist_item.key == tree_item.key {
-                        *state = EntriesIteratorState::InLeafBothKeysEq;
-                    } else if hist_item.key < tree_item.key {
-                        *state = EntriesIteratorState::InLeafBothHistPrio;
-                    } else {
-                        *state = EntriesIteratorState::InLeafBothTreePrio;
-                    }
-
-                    continue;
-                },
-                EntriesIteratorState::InLeafBothKeysEq => {
-                    // If the keys are equal we want to pop both entries and only return the
-                    // history's one. We can again rely on `NotInLeaf` to do our
-                    // logic correctly.
-                    *state = EntriesIteratorState::NotInLeaf;
-
-                    // We can discard this entry entirely as it has been overwritten.
-                    full_tree_iter.next();
-
-                    // But this one may or may not need to be returned.
-                    let hist_item =
-                        history_entries_iter.next().expect("Entry already checked to exist");
-                    if hist_item.value == EMPTY_WORD {
-                        // We never want to yield empty items, so we skip them.
-                        continue;
-                    } else {
-                        // Otherwise the item is real and we want to yield it.
-                        return Some(hist_item);
-                    }
-                },
-                EntriesIteratorState::InLeafBothHistPrio => {
-                    // Here we have a history item with a key < the full tree item, so we want to
-                    // return that. We must skip EMPTY_WORD entries, and if
-                    // ordering changes, re-evaluate.
-                    loop {
-                        let Some(hist_item) = history_entries_iter.peek() else {
-                            *state = EntriesIteratorState::NotInLeaf;
-                            break;
-                        };
-
-                        if hist_item.value == EMPTY_WORD {
-                            history_entries_iter.next();
-                            continue;
-                        }
-
-                        let tree_item =
-                            full_tree_iter.peek().expect("Entry already checked to exist");
-                        if hist_item.key < tree_item.key {
-                            let hist_item = history_entries_iter
-                                .next()
-                                .expect("Entry already checked to exist");
-                            *state = EntriesIteratorState::NotInLeaf;
-                            return Some(hist_item);
-                        }
-
-                        *state = EntriesIteratorState::NotInLeaf;
-                        break;
-                    }
-                    continue;
-                },
-                EntriesIteratorState::InLeafBothTreePrio => {
-                    // Here we have a full tree item with a key < the history item, so we want to
-                    // return that. We can again rely on `NotInLeaf` to do our
-                    // logic correctly.
-                    *state = EntriesIteratorState::NotInLeaf;
-                    return full_tree_iter.next();
                 },
             }
         }
@@ -342,172 +226,19 @@ impl Iterator for EntriesIterator<'_> {
 // ================================================================================================
 
 /// The state machine that is the entries iterator for the forest.
-///
-/// We do not represent the ghost states of `Start` and `End`, so [`Self::NotInLeaf`] serves as the
-/// initial state of the machine in practice. A full diagram of the state machine's allowable
-/// transitions can be found below. See the individual variants for the conditions under which these
-/// transitions take place.
-///
-/// ```text
-///                                    ┌─────────┐
-///                                    │  Start  │
-///                                    └─────────┘
-///                                         │
-///                                         │
-///                                         ▼
-///                                   ┌───────────┐
-///        ┌─────────────┬────────────│           │◀──────────────┬──────────────────┐
-///        │             │            │ NotInLeaf │               │                  │
-///        │             │       ┌────│           │────────────┬──┼───────────────┐  │
-///        │             │       │    └───────────┘            │  │               │  │
-///        │             │       │         │  ▲                │  │               │  │
-///        │             │       │         │  │                │  │               │  │
-///        │             │       │         │  │                │  │               │  │
-///        │             │       │         │  │                │  │               │  │
-///        ▼             ▼       │         ▼  │                ▼  │               ▼  │
-///  ┌──────────┐  ┌──────────┐  │  ┌────────────────┐  ┌────────────────┐  ┌──────────────┐
-///  │ TreeOnly │  │ HistOnly │  │  │ InLeafHistOnly │  │ InLeafTreeOnly │  │ InLeafShared │◀─────────────┐
-///  └──────────┘  └──────────┘  │  └────────────────┘  └────────────────┘  └──────────────┘              │
-///        │             │       │                                                  │                     │
-///        │             │       │                                                  │                     │
-///        │             │       │            ┌──────────────────────┬──────────────┴────────┐            │
-///        │             │       │            │                      │                       │            │
-///        │             │       │            ▼                      ▼                       ▼            │
-///        │             │       │  ┌──────────────────┐  ┌────────────────────┐  ┌────────────────────┐  │
-///        └─────────────┴─────┐ │  │ InLeafBothKeysEq │  │ InLeafBothHistPrio │  │ InLeafBothTreePrio │  │
-///                            │ │  └──────────────────┘  └────────────────────┘  └────────────────────┘  │
-///                            │ │            │                      │                       │            │
-///                            │ │            │                      │                       │            │
-///                            │ │            └──────────────────────┴───────────────────────┴────────────┘
-///                            ▼ ▼
-///                        ┌─────────┐
-///                        │   End   │
-///                        └─────────┘
-/// ```
-///
-/// Note that this describes the _semantics_ of the transitions between states, and may not directly
-/// correspond to the implementation in [`EntriesIterator::next_with_history`] for reasons of
-/// performance and maintainability.
-pub(super) enum EntriesIteratorState {
-    /// The iterator is currently not in any leaf.
-    ///
-    /// This state should not advance the underlying iterators directly, and the iterator is not
-    /// intended to return a value for `next` while in this state.
-    ///
-    /// Incoming state transitions:
-    ///
-    /// - `Start -> NotInLeaf`: The state of the state machine.
-    /// - `InLeafHistOnly -> NotInLeaf`: Upon completing the leaf in the history.
-    /// - `InLeafTreeOnly -> NotInLeaf`: Upon completing the leaf in the tree.
-    /// - `InLeafShared -> NotInLeaf`: Upon completing the leaf that exists in both.
-    ///
-    /// Outgoing state transitions:
-    ///
-    /// - `NotInLeaf -> End`: If neither iterator has remaining entries.
-    /// - `NotInLeaf -> HistOnly`: If the tree entries iterator is empty.
-    /// - `NotInLeaf -> TreeOnly`: If the history entries iterator is empty.
-    /// - `NotInLeaf -> InLeafHistOnly`: If the next leaf is only in the history.
-    /// - `NotInLeaf -> InLeafTreeOnly`: If the next leaf is only in the tree.
-    /// - `NotInLeaf -> InLeafShared`: If the leaf exists in both iterators.
-    NotInLeaf,
+pub(super) enum EntriesIteratorState<'forest> {
+    /// The initial state of the iterator, indicating that it has never advanced the underlying
+    /// iterator.
+    Initial,
 
-    /// The iterator over the full tree has no entries, so we can iterate only over the history
-    /// until completion.
-    ///
-    /// Incoming state transitions:
-    ///
-    /// - `NotInLeaf -> HistOnly`: The tree entries iterator is empty.
-    ///
-    /// Outgoing state transitions:
-    ///
-    /// - `HistOnly -> End`: The history entries iterator is empty.
-    HistOnly,
+    /// Indicates that the iterator is currently reading from the full-tree's iterator, and yielding
+    /// results from that.
+    ReadingFullTree,
 
-    /// The iterator over the history has no entries, so we can iterate only over the full tree
-    /// until completion.
-    ///
-    /// Incoming state transitions:
-    ///
-    /// - `NotInLeaf -> TreeOnly`: The history entries iterator is empty.
-    ///
-    /// Outgoing state transitions:
-    ///
-    /// - `TreeOnly -> End`: The tree entries iterator is empty.
-    TreeOnly,
-
-    /// The iterator is operating over a leaf that only exists in the history iterator.
-    ///
-    /// Incoming state transitions:
-    ///
-    /// - `NotInLeaf -> InLeafHistOnly`: The tree entries iterator has items but the latest is not
-    ///   in the same leaf as the history's latest.
-    ///
-    /// Outgoing state transitions:
-    ///
-    /// - `InLeafHistOnly -> NotInLeaf`: Upon completing iteration through the current leaf.
-    InLeafHistOnly,
-
-    /// The iterator is operating over a leaf that only exists in the tree iterator.
-    ///
-    /// Incoming state transitions:
-    ///
-    /// - `NotInLeaf -> InLeafTreeOnly`: The history entries iterator has items but the latest is
-    ///   not in the same leaf as the tree's latest.
-    ///
-    /// Outgoing state transitions:
-    ///
-    /// - `InLeafTreeOnly -> NotInLeaf`: Upon completing iteration through the current leaf.
-    InLeafTreeOnly,
-
-    /// The iterator is operating over a leaf that exists in both iterators.
-    ///
-    /// Incoming state transitions:
-    ///
-    /// - `NotInLeaf -> InLeafShared`: Both iterators have their latest entry in the same leaf.
-    ///
-    /// Outgoing state transitions:
-    ///
-    /// - `InLeafShared -> InLeafBothKeysEq`: If the two keys in the shared leaf are equal.
-    /// - `InLeafShared -> InLeafBothKeysHistPrio`: If the key in the history < the key in the tree.
-    /// - `InLeafShared -> InLeafBothKeysTreePrio`: If the key in the tree < the key in the history.
-    /// - `InLeafShared -> NotInLeaf`: Upon completing iteration through the current leaf.
-    InLeafShared,
-
-    /// The iterator is operating over a leaf that exists in both iterators, and the current keys
-    /// are the same.
-    ///
-    /// Incoming state transitions:
-    ///
-    /// - `InLeafShared -> InLeafBothKeysEq`: If the key in each iterator is the same.
-    ///
-    /// Outgoing state transitions:
-    ///
-    /// - `InLeafBothKeysEq -> InLeafShared`: When needing to check the next element.
-    InLeafBothKeysEq,
-
-    /// The iterator is operating over a leaf that exists in both iterators, and the current key
-    /// in the history is less than the current key in the tree.
-    ///
-    /// Incoming state transitions:
-    ///
-    /// - `InLeafShared -> InLeafBothHistPrio`: If the key in the history iterator < the key in the
-    ///   tree iterator.
-    ///
-    /// Outgoing state transitions:
-    ///
-    /// - `InLeafBothHistPrio -> InLeafShared`: When needing to check the next element.
-    InLeafBothHistPrio,
-
-    /// The iterator is operating over a leaf that exists in both iterators, and the current key in
-    /// the tree is less than the current key in the history.
-    ///
-    /// Incoming state transitions:
-    ///
-    /// - `InLeafShared -> InLeafBothTreePrio`: If the key in the tree iterator < the key in the
-    ///   history iterator.
-    ///
-    /// Outgoing state transitions:
-    ///
-    /// - `InLeafBothTreePrio -> InLeafShared`: When needing to check the next element.
-    InLeafBothTreePrio,
+    /// Indicates that the iterator is currently reading from the additional pairs added by the
+    /// history delta.
+    ReadingHistory {
+        /// The iterator over the entries that are _added_ by the history.
+        iterator: Box<dyn Iterator<Item = TreeEntry> + 'forest>,
+    },
 }

--- a/miden-crypto/src/merkle/smt/large_forest/mod.rs
+++ b/miden-crypto/src/merkle/smt/large_forest/mod.rs
@@ -312,7 +312,7 @@ use crate::{
         smt::{
             LeafIndex, SMT_DEPTH, SmtLeaf, SmtProof,
             large_forest::{
-                history::{CompactLeaf, History, HistoryView},
+                history::{History, HistoryView},
                 iterator::EntriesIterator,
                 lineage::LineageData,
                 root::{RootValue, UniqueRoot},
@@ -597,7 +597,7 @@ impl<B: Backend> LargeSmtForest<B> {
 
         // We compute the new leaf and new path by applying any reversions from the history on
         // top of the current state.
-        let new_leaf = self.merge_leaves(opening.leaf(), &view.leaf_delta(&leaf_index))?;
+        let new_leaf = self.merge_leaves(opening.leaf(), view)?;
         let new_path = self.merge_paths(leaf_index, opening.path(), view)?;
 
         // Finally we can compose our combined opening.
@@ -698,13 +698,7 @@ impl<B: Backend> LargeSmtForest<B> {
 
         // In the general case there is no faster path than doing the iteration to merge the
         // history with the full tree, so we just count the iterator.
-        Ok(
-            EntriesIterator::new_with_history(
-                self.backend.entries(tree.lineage())?,
-                view.entries(),
-            )
-            .count(),
-        )
+        Ok(EntriesIterator::new_with_history(self.backend.entries(tree.lineage())?, view).count())
     }
 
     /// Returns an iterator that yields the entries in the specified `tree`.
@@ -745,10 +739,7 @@ impl<B: Backend> LargeSmtForest<B> {
         };
 
         // If we can serve it from the history we need to instead construct the complex version.
-        Ok(EntriesIterator::new_with_history(
-            self.backend.entries(tree.lineage())?,
-            view.entries(),
-        ))
+        Ok(EntriesIterator::new_with_history(self.backend.entries(tree.lineage())?, view))
     }
 }
 
@@ -995,22 +986,38 @@ impl<B: Backend> LargeSmtForest<B> {
 /// This block contains internal functions that exist to de-duplicate or modularize functionality
 /// within the forest. These should not be exposed.
 impl<B: Backend> LargeSmtForest<B> {
-    /// Applies the provided `historical_delta` on top of the provided `full_tree_leaf` to produce
-    /// the correct leaf for a historical opening.
-    fn merge_leaves(
-        &self,
-        full_tree_leaf: &SmtLeaf,
-        historical_delta: &CompactLeaf,
-    ) -> Result<SmtLeaf> {
+    /// Applies the history delta given by `history_view` on top of the provided `full_tree_leaf` to
+    /// produce the correct leaf for a historical opening.
+    fn merge_leaves(&self, full_tree_leaf: &SmtLeaf, history_view: HistoryView) -> Result<SmtLeaf> {
         // We apply the historical delta on top of the existing entries to perform the reversion
         // back to the previous state.
         let mut leaf_entries = Map::new();
-        leaf_entries.extend(full_tree_leaf.to_entries().map(|(k, v)| (*k, *v)));
-        leaf_entries.extend(historical_delta);
+        for (k, v) in full_tree_leaf.to_entries() {
+            // If the history removes the pair, then we skip adding it to our output leaf entries.
+            if history_view.is_key_removed(k) {
+                continue;
+            }
+
+            leaf_entries.insert(*k, *v);
+        }
+
+        // The delta may have added items that we do not have (due to later removals), so we have to
+        // add those back, but only the ones for the leaf we care about.
+        leaf_entries.extend(
+            history_view
+                .changed_keys()
+                .filter(|(k, v)| LeafIndex::from(*k) == full_tree_leaf.index() && !v.is_empty()),
+        );
+
+        // At this point we should not see any entries with empty values, so in debug builds let's
+        // sanity check this.
+        debug_assert!(
+            leaf_entries.iter().all(|(_, v)| !v.is_empty()),
+            "Leaf entries should not contain entries with "
+        );
 
         // Any entries that are still empty at this point should be removed.
-        let non_empties_only = leaf_entries.into_iter().filter(|(_, v)| *v != EMPTY_WORD).collect();
-        Ok(SmtLeaf::new(non_empties_only, full_tree_leaf.index())?)
+        Ok(SmtLeaf::new(leaf_entries.into_iter().collect(), full_tree_leaf.index())?)
     }
 
     /// Applies any historical changes contained in `history_view` on top of the merkle path

--- a/miden-crypto/src/merkle/smt/large_forest/tests.rs
+++ b/miden-crypto/src/merkle/smt/large_forest/tests.rs
@@ -18,17 +18,16 @@ use crate::{
         EmptySubtreeRoots,
         smt::{
             Backend, ForestInMemoryBackend, ForestOperation, LargeSmtForest, LargeSmtForestError,
-            LeafIndex, RootInfo, Smt, SmtForestUpdateBatch, SmtUpdateBatch, TreeId, VersionId,
+            RootInfo, Smt, SmtForestUpdateBatch, SmtUpdateBatch, TreeId, VersionId,
             large_forest::{
                 LineageData,
-                history::{History, LeafChanges, NodeChanges},
+                history::{ChangedKeys, History, NodeChanges},
                 root::{LineageId, TreeEntry, TreeWithRoot},
             },
         },
     },
     rand::test_utils::{ContinuousRng, rand_value},
 };
-
 // TYPE ALIASES
 // ================================================================================================
 
@@ -742,6 +741,70 @@ fn entries() -> Result<()> {
 }
 
 #[test]
+fn forest_overlays_correctly() -> Result<()> {
+    let backend = ForestInMemoryBackend::new();
+    let mut forest = LargeSmtForest::new(backend)?;
+
+    // We can just make some arbitrary values here for demonstration.
+    let key_1 = Word::parse("0x42").unwrap();
+    let value_1 = Word::parse("0x80").unwrap();
+    let key_2 = Word::parse("0xAB").unwrap();
+    let value_2 = Word::parse("0xCD").unwrap();
+
+    // Operations are most cleanly specified using a builder.
+    let mut operations = SmtUpdateBatch::empty();
+    operations.add_insert(key_1, value_1);
+    operations.add_insert(key_2, value_2);
+
+    // To add a new lineage we also need to give it a lineage ID, and a version.
+    let lineage = LineageId::new([0x42; 32]);
+    let version_1 = 1;
+
+    // Now we can add the lineage to the forest!
+    forest.add_lineage(lineage, version_1, operations)?;
+
+    // Let's make another arbitrary value.
+    let key_3 = Word::parse("0x67").unwrap();
+    let value_3 = Word::parse("0x96").unwrap();
+
+    // And build a batch of operations again.
+    let mut operations = SmtUpdateBatch::empty();
+    operations.add_insert(key_3, value_3);
+    operations.add_remove(key_1);
+
+    // Now we can simply update the tree all in one go with our changes.
+    let version_2 = version_1 + 1;
+    forest.update_tree(lineage, version_2, operations)?;
+
+    // As discussed above, trees are identified by a combination of their lineage and version.
+    let old_tree = TreeId::new(lineage, version_1);
+    let current_tree = TreeId::new(lineage, version_2);
+
+    // The first really useful query is `open`, which gets the opening for the specified key. We can
+    // get openings for the current tree AND the historical trees.
+    assert!(forest.open(old_tree, key_1).is_ok());
+    assert!(forest.open(current_tree, key_3).is_ok());
+
+    // We can also just `get` the value associated with a key, which returns `None` if the key is
+    // not populated.
+    assert_eq!(forest.get(old_tree, key_1)?, Some(value_1));
+    assert_eq!(forest.get(current_tree, key_3)?, Some(value_3));
+    assert!(forest.get(current_tree, key_1)?.is_none());
+
+    // We can also get an iterator over all the entries in the tree.
+    let entries_old: Vec<_> = forest.entries(old_tree)?.collect();
+    let entries_current: Vec<_> = forest.entries(current_tree)?.collect();
+    assert!(entries_old.contains(&TreeEntry { key: key_1, value: value_1 }));
+    assert!(entries_old.contains(&TreeEntry { key: key_2, value: value_2 }));
+    assert!(!entries_old.contains(&TreeEntry { key: key_3, value: value_3 }));
+    assert!(!entries_current.contains(&TreeEntry { key: key_1, value: value_1 }));
+    assert!(entries_current.contains(&TreeEntry { key: key_2, value: value_2 }));
+    assert!(entries_current.contains(&TreeEntry { key: key_3, value: value_3 }));
+
+    Ok(())
+}
+
+#[test]
 fn entries_never_returns_empty_entry() -> Result<()> {
     // We risk yielding empty entries in a few situations, but all of those situations involve
     // iterating over the history on its own. Let's go through them one by one.
@@ -990,9 +1053,9 @@ fn update_tree() -> Result<()> {
     // If we query for each value, we should see the correct reversions.
     let view = history.get_view_at(version_1)?;
 
-    assert_eq!(view.leaf_delta(&LeafIndex::from(key_1)).get(&key_1), Some(&value_1));
-    assert_eq!(view.leaf_delta(&LeafIndex::from(key_2)).get(&key_2), Some(&EMPTY_WORD));
-    assert_eq!(view.leaf_delta(&LeafIndex::from(key_3)).get(&key_3), Some(&EMPTY_WORD));
+    assert_eq!(view.value(&key_1), Some(value_1));
+    assert_eq!(view.value(&key_2), Some(EMPTY_WORD));
+    assert_eq!(view.value(&key_3), Some(EMPTY_WORD));
 
     // We should also now see this lineage listed as having a non-empty history.
     assert!(forest.get_non_empty_histories().contains(&lineage_1));
@@ -1181,8 +1244,8 @@ fn truncate_removes_emptied_lineages_from_non_empty_histories() {
     // Build a lineage with one historical version at version 5, and a latest version of 10.
     let mut history = History::empty(4);
     let nodes = NodeChanges::default();
-    let leaves = LeafChanges::default();
-    history.add_version(rand_value(), 5, nodes, leaves).unwrap();
+    let changed_keys = ChangedKeys::default();
+    history.add_version(rand_value(), 5, nodes, changed_keys).unwrap();
     assert_eq!(history.num_versions(), 1);
 
     let lineage_data = LineageData {
@@ -1225,9 +1288,13 @@ fn truncate_retains_non_empty_lineages_in_non_empty_histories() {
     // Build a lineage with two historical versions (5 and 8), latest version 15.
     let mut history = History::empty(4);
     let nodes = NodeChanges::default();
-    let leaves = LeafChanges::default();
-    history.add_version(rand_value(), 5, nodes.clone(), leaves.clone()).unwrap();
-    history.add_version(rand_value(), 8, nodes, leaves).unwrap();
+    let changed_keys = ChangedKeys::default();
+    history
+        .add_version(rand_value(), 5, nodes.clone(), changed_keys.clone())
+        .unwrap();
+    history
+        .add_version(rand_value(), 8, nodes.clone(), changed_keys.clone())
+        .unwrap();
     assert_eq!(history.num_versions(), 2);
 
     let lineage_data = LineageData {


### PR DESCRIPTION
## Describe your changes

The `History` container used by `LargeSmtForest` now stores all of the information in each delta that is required to revert the current tree into the correct historical state. This trades increased memory usage for much faster history queries and simpler entries iteration behavior in the forest.

The iterator in `LargeSmtForest` has been greatly simplified, as has the iterator for the `InMemoryBackend`.

Closes #831. I don't think this needs a changelog as this doesn't change the external forest API.

## Checklist before requesting a review

- [x] Repo forked and branch created from `next` according to naming convention.
- [x] Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- [x] Relevant issues are linked in the PR description.
- [x] Tests added for new functionality.
- [x] Documentation/comments updated according to changes.
