### PR TITLE
Remove `merge_with_int()` from algebraic hashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,6 @@
 - [BREAKING] Fixed `NodeIndex::to_scalar_index()` overflow at depth 64 by returning `Result<u64, MerkleError>` ([#865](https://github.com/0xMiden/crypto/issues/865)).
 - [BREAKING] Removed `RpoRandomCoin` and `RpxRandomCoin` and introduced a Poseidon2-based `RandomCoin` ([#871](https://github.com/0xMiden/crypto/pull/871)).
 - Harden MerkleStore deserialization and fuzz coverage ([#878](https://github.com/0xMiden/crypto/pull/878)).
-- [BREAKING] Fixed `NodeIndex::to_scalar_index()` overflow at depth 64 by returning `Result<u64, MerkleError>` ([#865](https://github.com/0xMiden/crypto/issues/865)).
 - [BREAKING] Upgraded Plonky3 from 0.4.2 to 0.5.0 and replaced `p3-miden-air`, `p3-miden-fri`, and `p3-miden-prover` with the unified `p3-miden-lifted-stark` crate. The `stark` module now re-exports the Lifted STARK proving system from [p3-miden](https://github.com/0xMiden/p3-miden).
 
 ## 0.22.4 (2026-03-03)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - [BREAKING] Removed `RpoRandomCoin` and `RpxRandomCoin` and introduced a Poseidon2-based `RandomCoin` ([#871](https://github.com/0xMiden/crypto/pull/871)).
 - Harden MerkleStore deserialization and fuzz coverage ([#878](https://github.com/0xMiden/crypto/pull/878)).
 - [BREAKING] Fixed `NodeIndex::to_scalar_index()` overflow at depth 64 by returning `Result<u64, MerkleError>` ([#865](https://github.com/0xMiden/crypto/issues/865)).
+- [BREAKING] Removed `AlgebraicSponge::merge_with_int()` method ([#894](https://github.com/0xMiden/crypto/pull/894)).
 
 ## 0.22.4 (2026-03-03)
 

--- a/miden-crypto/benches/common/config.rs
+++ b/miden-crypto/benches/common/config.rs
@@ -54,14 +54,6 @@ pub const MERGE_INPUT_SIZES: &[usize] = &[
     512, // 512 bytes
 ];
 
-/// Integer sizes for merge_with_int tests
-pub const MERGE_INT_SIZES: &[usize] = &[
-    1, // Single byte integer
-    2, // 16-bit integer
-    4, // 32-bit integer
-    8, // 64-bit integer
-];
-
 // === Field Operations Configuration ===
 /// Field element counts for batch operations
 pub const FIELD_BATCH_SIZES: &[usize] = &[

--- a/miden-crypto/benches/common/macros.rs
+++ b/miden-crypto/benches/common/macros.rs
@@ -258,34 +258,6 @@ macro_rules! benchmark_hash_merge_domain {
     };
 }
 
-// Creates a benchmark for hash merge with int operations
-#[macro_export]
-macro_rules! benchmark_hash_merge_with_int {
-    ($func_name:ident, $hasher_name:literal, $sizes:expr, $int_sizes:expr, $closure:expr) => {
-        fn $func_name(c: &mut Criterion) {
-            let mut group = c.benchmark_group(concat!("hash-", $hasher_name, "-merge-int"));
-            group.sample_size(10);
-
-            for size_ref in $sizes {
-                let size = *size_ref;
-                for int_size_ref in $int_sizes {
-                    let int_size = *int_size_ref;
-                    group.bench_with_input(
-                        criterion::BenchmarkId::new("merge_with_int", format!("{size}_{int_size}")),
-                        &(size, int_size),
-                        |b: &mut criterion::Bencher, param_ref: &(usize, usize)| {
-                            let (size_param, int_size_param) = *param_ref;
-                            $closure(b, (size_param, int_size_param))
-                        },
-                    );
-                }
-            }
-
-            group.finish();
-        }
-    };
-}
-
 // Creates a benchmark for hash merge many operations
 #[macro_export]
 macro_rules! benchmark_hash_merge_many {

--- a/miden-crypto/src/hash/algebraic_sponge/mod.rs
+++ b/miden-crypto/src/hash/algebraic_sponge/mod.rs
@@ -192,29 +192,6 @@ pub(crate) trait AlgebraicSponge {
         Self::hash_elements(elements)
     }
 
-    /// Returns hash(`seed` || `value`). This method is intended for use in PRNG and PoW contexts.
-    fn merge_with_int(seed: Word, value: u64) -> Word {
-        // initialize the state as follows:
-        // - seed is copied into the first 4 elements of the rate portion of the state.
-        // - if the value fits into a single field element, copy it into the fifth rate element and
-        //   set the first capacity element to 5.
-        // - if the value doesn't fit into a single field element, split it into two field elements,
-        //   copy them into rate elements 5 and 6 and set the first capacity element to 6.
-        let mut state = [ZERO; STATE_WIDTH];
-        state[RATE0_RANGE].copy_from_slice(seed.as_elements());
-        state[RATE1_RANGE.start] = Felt::new(value);
-        if value < Felt::ORDER {
-            state[CAPACITY_RANGE.start] = Felt::from_u8(5_u8);
-        } else {
-            state[RATE1_RANGE.start + 1] = Felt::new(value / Felt::ORDER);
-            state[CAPACITY_RANGE.start] = Felt::from_u8(6_u8);
-        }
-
-        // apply the permutation and return the digest portion of the rate
-        Self::apply_permutation(&mut state);
-        Word::new(state[DIGEST_RANGE].try_into().unwrap())
-    }
-
     // DOMAIN IDENTIFIER HASHING
     // --------------------------------------------------------------------------------------------
 

--- a/miden-crypto/src/hash/algebraic_sponge/poseidon2/mod.rs
+++ b/miden-crypto/src/hash/algebraic_sponge/poseidon2/mod.rs
@@ -164,12 +164,6 @@ impl Poseidon2 {
         <Self as AlgebraicSponge>::merge_many(values)
     }
 
-    /// Returns a hash of a digest and a u64 value.
-    #[inline(always)]
-    pub fn merge_with_int(seed: Word, value: u64) -> Word {
-        <Self as AlgebraicSponge>::merge_with_int(seed, value)
-    }
-
     /// Returns a hash of two digests and a domain identifier.
     #[inline(always)]
     pub fn merge_in_domain(values: &[Word; 2], domain: Felt) -> Word {

--- a/miden-crypto/src/hash/algebraic_sponge/poseidon2/mod.rs
+++ b/miden-crypto/src/hash/algebraic_sponge/poseidon2/mod.rs
@@ -35,12 +35,11 @@ mod test;
 /// and it can be serialized into 32 bytes (256 bits).
 ///
 /// ## Hash output consistency
-/// Functions [hash_elements()](Poseidon2::hash_elements), [merge()](Poseidon2::merge), and
-/// [merge_with_int()](Poseidon2::merge_with_int) are internally consistent. That is, computing
-/// a hash for the same set of elements using these functions will always produce the same
-/// result. For example, merging two digests using [merge()](Poseidon2::merge) will produce the
-/// same result as hashing 8 elements which make up these digests using
-/// [hash_elements()](Poseidon2::hash_elements) function.
+/// Functions [hash_elements()](Poseidon2::hash_elements), and [merge()](Poseidon2::merge), are
+/// internally consistent. That is, computing a hash for the same set of elements using these
+/// functions will always produce the same result. For example, merging two digests using
+/// [merge()](Poseidon2::merge) will produce the same result as hashing 8 elements which make up
+/// these digests using [hash_elements()](Poseidon2::hash_elements) function.
 ///
 /// However, [hash()](Poseidon2::hash) function is not consistent with functions mentioned above.
 /// For example, if we take two field elements, serialize them to bytes and hash them using

--- a/miden-crypto/src/hash/algebraic_sponge/rescue/rpo/mod.rs
+++ b/miden-crypto/src/hash/algebraic_sponge/rescue/rpo/mod.rs
@@ -148,12 +148,6 @@ impl Rpo256 {
         <Self as AlgebraicSponge>::merge_many(values)
     }
 
-    /// Returns a hash of a digest and a u64 value.
-    #[inline(always)]
-    pub fn merge_with_int(seed: Word, value: u64) -> Word {
-        <Self as AlgebraicSponge>::merge_with_int(seed, value)
-    }
-
     /// Returns a hash of two digests and a domain identifier.
     #[inline(always)]
     pub fn merge_in_domain(values: &[Word; 2], domain: Felt) -> Word {

--- a/miden-crypto/src/hash/algebraic_sponge/rescue/rpo/mod.rs
+++ b/miden-crypto/src/hash/algebraic_sponge/rescue/rpo/mod.rs
@@ -29,11 +29,10 @@ mod tests;
 /// and it can be serialized into 32 bytes (256 bits).
 ///
 /// ## Hash output consistency
-/// Functions [hash_elements()](Rpo256::hash_elements), [merge()](Rpo256::merge), and
-/// [merge_with_int()](Rpo256::merge_with_int) are internally consistent. That is, computing
-/// a hash for the same set of elements using these functions will always produce the same
-/// result. For example, merging two digests using [merge()](Rpo256::merge) will produce the
-/// same result as hashing 8 elements which make up these digests using
+/// Functions [hash_elements()](Rpo256::hash_elements), and [merge()](Rpo256::merge), are internally
+/// consistent. That is, computing a hash for the same set of elements using these functions will
+/// always produce the same result. For example, merging two digests using [merge()](Rpo256::merge)
+/// will produce the same result as hashing 8 elements which make up these digests using
 /// [hash_elements()](Rpo256::hash_elements) function.
 ///
 /// However, [hash()](Rpo256::hash) function is not consistent with functions mentioned above.

--- a/miden-crypto/src/hash/algebraic_sponge/rescue/rpo/tests.rs
+++ b/miden-crypto/src/hash/algebraic_sponge/rescue/rpo/tests.rs
@@ -14,9 +14,7 @@ const ALPHA: u64 = 7;
 const INV_ALPHA: u64 = 10540996611094048183;
 use crate::{
     ONE, Word, ZERO,
-    hash::algebraic_sponge::{
-        AlgebraicSponge, BINARY_CHUNK_SIZE, CAPACITY_RANGE, RATE_RANGE, RATE_WIDTH,
-    },
+    hash::algebraic_sponge::{BINARY_CHUNK_SIZE, CAPACITY_RANGE, RATE_RANGE, RATE_WIDTH},
     rand::test_utils::rand_value,
 };
 
@@ -85,33 +83,6 @@ fn merge_vs_merge_in_domain() {
 
     let merge_in_domain_result = Rpo256::merge_in_domain(&digests, domain);
     assert_ne!(merge_result, merge_in_domain_result);
-}
-
-#[test]
-fn hash_elements_vs_merge_with_int() {
-    let tmp = [Felt::new(rand_value()); 4];
-    let seed = Word::new(tmp);
-
-    // ----- value fits into a field element ------------------------------------------------------
-    let val: Felt = Felt::new(rand_value());
-    let m_result = <Rpo256 as AlgebraicSponge>::merge_with_int(seed, val.as_canonical_u64());
-
-    let mut elements = seed.as_elements().to_vec();
-    elements.push(val);
-    let h_result = Rpo256::hash_elements(&elements);
-
-    assert_eq!(m_result, h_result);
-
-    // ----- value does not fit into a field element ----------------------------------------------
-    let val = Felt::ORDER + 2;
-    let m_result = <Rpo256 as AlgebraicSponge>::merge_with_int(seed, val);
-
-    let mut elements = seed.as_elements().to_vec();
-    elements.push(Felt::new(val));
-    elements.push(ONE);
-    let h_result = Rpo256::hash_elements(&elements);
-
-    assert_eq!(m_result, h_result);
 }
 
 #[test]

--- a/miden-crypto/src/hash/algebraic_sponge/rescue/rpx/mod.rs
+++ b/miden-crypto/src/hash/algebraic_sponge/rescue/rpx/mod.rs
@@ -149,12 +149,6 @@ impl Rpx256 {
         <Self as AlgebraicSponge>::merge_many(values)
     }
 
-    /// Returns a hash of a digest and a u64 value.
-    #[inline(always)]
-    pub fn merge_with_int(seed: Word, value: u64) -> Word {
-        <Self as AlgebraicSponge>::merge_with_int(seed, value)
-    }
-
     /// Returns a hash of two digests and a domain identifier.
     #[inline(always)]
     pub fn merge_in_domain(values: &[Word; 2], domain: Felt) -> Word {

--- a/miden-crypto/src/hash/algebraic_sponge/rescue/rpx/mod.rs
+++ b/miden-crypto/src/hash/algebraic_sponge/rescue/rpx/mod.rs
@@ -32,11 +32,10 @@ mod tests;
 /// and it can be serialized into 32 bytes (256 bits).
 ///
 /// ## Hash output consistency
-/// Functions [hash_elements()](Rpx256::hash_elements), [merge()](Rpx256::merge), and
-/// [merge_with_int()](Rpx256::merge_with_int) are internally consistent. That is, computing
-/// a hash for the same set of elements using these functions will always produce the same
-/// result. For example, merging two digests using [merge()](Rpx256::merge) will produce the
-/// same result as hashing 8 elements which make up these digests using
+/// Functions [hash_elements()](Rpx256::hash_elements), and [merge()](Rpx256::merge), are internally
+/// consistent. That is, computing a hash for the same set of elements using these functions will
+/// always produce the same result. For example, merging two digests using [merge()](Rpx256::merge)
+/// will produce the same result as hashing 8 elements which make up these digests using
 /// [hash_elements()](Rpx256::hash_elements) function.
 ///
 /// However, [hash()](Rpx256::hash) function is not consistent with functions mentioned above.

--- a/miden-crypto/src/hash/algebraic_sponge/rescue/rpx/tests.rs
+++ b/miden-crypto/src/hash/algebraic_sponge/rescue/rpx/tests.rs
@@ -4,9 +4,7 @@ use alloc::{collections::BTreeSet, vec::Vec};
 use proptest::prelude::*;
 
 use super::{Felt, Rpx256};
-use crate::{
-    ONE, Word, ZERO, hash::algebraic_sponge::AlgebraicSponge, rand::test_utils::rand_value,
-};
+use crate::{ONE, Word, ZERO, rand::test_utils::rand_value};
 
 // The number of iterations to run the `ext_round_matches_reference_many` test.
 #[cfg(all(
@@ -57,33 +55,6 @@ fn merge_vs_merge_in_domain() {
 
     let merge_in_domain_result = Rpx256::merge_in_domain(&digests, domain);
     assert_ne!(merge_result, merge_in_domain_result);
-}
-
-#[test]
-fn hash_elements_vs_merge_with_int() {
-    let tmp = [Felt::new(rand_value()); 4];
-    let seed = Word::new(tmp);
-
-    // ----- value fits into a field element ------------------------------------------------------
-    let val: Felt = Felt::new(rand_value());
-    let m_result = <Rpx256 as AlgebraicSponge>::merge_with_int(seed, val.as_canonical_u64());
-
-    let mut elements = seed.as_elements().to_vec();
-    elements.push(val);
-    let h_result = Rpx256::hash_elements(&elements);
-
-    assert_eq!(m_result, h_result);
-
-    // ----- value does not fit into a field element ----------------------------------------------
-    let val = Felt::ORDER + 2;
-    let m_result = <Rpx256 as AlgebraicSponge>::merge_with_int(seed, val);
-
-    let mut elements = seed.as_elements().to_vec();
-    elements.push(Felt::new(val));
-    elements.push(ONE);
-    let h_result = Rpx256::hash_elements(&elements);
-
-    assert_eq!(m_result, h_result);
 }
 
 #[test]

--- a/miden-crypto/src/hash/blake/mod.rs
+++ b/miden-crypto/src/hash/blake/mod.rs
@@ -48,22 +48,12 @@ impl Blake3_256 {
         Digest::new(blake3::hash(bytes).into())
     }
 
-    // Note: merge/merge_many/merge_with_int methods were previously trait delegations
-    // (<Self as Hasher>::merge). They're now direct implementations as part of removing
-    // the Winterfell Hasher trait dependency. These are public API used in benchmarks.
     pub fn merge(values: &[Digest256; 2]) -> Digest256 {
         Self::hash(Digest::digests_as_bytes(values))
     }
 
     pub fn merge_many(values: &[Digest256]) -> Digest256 {
         Digest::new(blake3::hash(Digest::digests_as_bytes(values)).into())
-    }
-
-    pub fn merge_with_int(seed: Digest256, value: u64) -> Digest256 {
-        let mut hasher = blake3::Hasher::new();
-        hasher.update(seed.as_bytes());
-        hasher.update(&value.to_le_bytes());
-        Digest::new(hasher.finalize().into())
     }
 
     /// Returns a hash of the provided field elements.
@@ -114,13 +104,6 @@ impl Blake3_192 {
 
     pub fn merge(values: &[Digest192; 2]) -> Digest192 {
         Self::hash(Digest::digests_as_bytes(values))
-    }
-
-    pub fn merge_with_int(seed: Digest192, value: u64) -> Digest192 {
-        let mut hasher = blake3::Hasher::new();
-        hasher.update(seed.as_bytes());
-        hasher.update(&value.to_le_bytes());
-        Digest::new(shrink_array(hasher.finalize().into()))
     }
 
     /// Returns a hash of the provided field elements.

--- a/miden-crypto/src/hash/keccak/mod.rs
+++ b/miden-crypto/src/hash/keccak/mod.rs
@@ -65,13 +65,6 @@ impl Keccak256 {
         Keccak256Digest::from(<[u8; DIGEST256_BYTES]>::from(hasher.finalize()))
     }
 
-    pub fn merge_with_int(seed: Keccak256Digest, value: u64) -> Keccak256Digest {
-        let mut hasher = sha3::Keccak256::new();
-        hasher.update(&*seed);
-        hasher.update(value.to_le_bytes());
-        Keccak256Digest::from(<[u8; DIGEST256_BYTES]>::from(hasher.finalize()))
-    }
-
     /// Returns a hash of the provided field elements.
     #[inline(always)]
     pub fn hash_elements<E>(elements: &[E]) -> Keccak256Digest

--- a/miden-crypto/src/hash/sha2/mod.rs
+++ b/miden-crypto/src/hash/sha2/mod.rs
@@ -61,13 +61,6 @@ impl Sha256 {
         Sha256Digest::from(<[u8; DIGEST256_BYTES]>::from(hasher.finalize()))
     }
 
-    pub fn merge_with_int(seed: Sha256Digest, value: u64) -> Sha256Digest {
-        let mut hasher = sha2::Sha256::new();
-        hasher.update(&*seed);
-        hasher.update(value.to_le_bytes());
-        Sha256Digest::from(<[u8; DIGEST256_BYTES]>::from(hasher.finalize()))
-    }
-
     /// Returns a hash of the provided field elements.
     #[inline(always)]
     pub fn hash_elements<E: BasedVectorSpace<Felt>>(elements: &[E]) -> Sha256Digest {


### PR DESCRIPTION
This PR removes `AlgebraicSponge::merge_with_int()` method as we no longer have a use for it.