### PR TITLE
fix: make duplicate-key concurrent mutations deterministic

### DIFF
--- a/miden-crypto/src/merkle/smt/full/concurrent/mod.rs
+++ b/miden-crypto/src/merkle/smt/full/concurrent/mod.rs
@@ -105,8 +105,8 @@ impl Smt {
     {
         // Collect and sort key-value pairs by their corresponding leaf index
         let mut sorted_kv_pairs: Vec<_> = kv_pairs.into_iter().collect();
-        sorted_kv_pairs
-            .par_sort_unstable_by_key(|(key, _)| Self::key_to_leaf_index(key).position());
+        // Keep ordering deterministic for duplicate keys by using a stable sort.
+        sorted_kv_pairs.par_sort_by_key(|(key, _)| Self::key_to_leaf_index(key).position());
 
         // Convert sorted pairs into mutated leaves and capture any new pairs
         let (mut subtree_leaves, new_pairs) =

--- a/miden-crypto/src/merkle/smt/full/concurrent/tests.rs
+++ b/miden-crypto/src/merkle/smt/full/concurrent/tests.rs
@@ -473,6 +473,24 @@ fn test_compute_mutations_parallel() {
 }
 
 #[test]
+fn test_compute_mutations_parallel_duplicate_key_order_matches_sequential() {
+    let key = Word::new([ONE, ONE, ONE, Felt::new(16)]);
+    let initial_value = Word::new([ONE, ONE, ONE, Felt::new(1)]);
+    let tree = Smt::with_entries([(key, initial_value)]).unwrap();
+
+    let first = Word::new([ONE, ONE, ONE, Felt::new(10)]);
+    let second = Word::new([ONE, ONE, ONE, Felt::new(20)]);
+    let updates = vec![(key, first), (key, second)];
+
+    let sequential = tree.compute_mutations_sequential(updates.clone()).unwrap();
+    let concurrent = tree.compute_mutations(updates).unwrap();
+
+    assert_eq!(concurrent.new_pairs().get(&key), Some(&second));
+    assert_eq!(concurrent.new_pairs(), sequential.new_pairs());
+    assert_eq!(concurrent.root(), sequential.root());
+}
+
+#[test]
 fn test_smt_construction_with_entries_unsorted() {
     let entries = [
         ([ONE, ONE, Felt::new(2_u64), ONE].into(), [ONE; 4].into()),


### PR DESCRIPTION
## Bug
Fixes #867. `compute_mutations_concurrent()` sorted updates with `par_sort_unstable_by_key()`, which can reorder equal keys non-deterministically. With duplicate key updates, that makes the “last write wins” result non-deterministic.

## Fix
- Switched to stable parallel sorting with `par_sort_by_key()` in `compute_mutations_concurrent()`
- Added a regression test that verifies duplicate-key update ordering in concurrent mutations matches the sequential implementation

## Testing
- Added `test_compute_mutations_parallel_duplicate_key_order_matches_sequential`
- Local test execution was not possible in this environment because `cargo` is not installed

Happy to address any feedback.

Greetings, saschabuehrle
