### PR TITLE
feat(SmtForest): Make the `entries` iterator fallible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - [BREAKING] Removed `RpoRandomCoin` and `RpxRandomCoin` and introduced a Poseidon2-based `RandomCoin` ([#871](https://github.com/0xMiden/crypto/pull/871)).
 - Harden MerkleStore deserialization and fuzz coverage ([#878](https://github.com/0xMiden/crypto/pull/878)).
 - [BREAKING] Upgraded Plonky3 from 0.4.2 to 0.5.0 and replaced `p3-miden-air`, `p3-miden-fri`, and `p3-miden-prover` with the unified `p3-miden-lifted-stark` crate. The `stark` module now re-exports the Lifted STARK proving system from [p3-miden](https://github.com/0xMiden/p3-miden).
+- [BREAKING] Changed the `LargeSmtForest::entries` iterator to be fallible by explicitly returning `Result<TreeEntry>` as the iterator item.
 
 ## 0.22.4 (2026-03-03)
 

--- a/miden-crypto/benches/large_smt_forest.rs
+++ b/miden-crypto/benches/large_smt_forest.rs
@@ -134,6 +134,56 @@ benchmark_with_setup_data! {
     },
 }
 
+// Measures iteration over the latest version of a tree (the WithoutHistory fast path).
+benchmark_with_setup_data! {
+    large_smt_forest_persistent_entries_current_tree,
+    DEFAULT_MEASUREMENT_TIME,
+    DEFAULT_SAMPLE_SIZE,
+    "large_smt_forest_persistent_entries_current_tree",
+    || {
+        let mut setup = ForestSetup::new_persistent();
+        let batch = generate_tree_update_batch(BATCH_SIZE);
+        let lineage = LineageId::new([0x42; 32]);
+        let version = 0;
+        setup.forest.add_lineage(lineage, version, batch).unwrap();
+        let tree = TreeId::new(lineage, version);
+        (setup, tree)
+    },
+    |b: &mut criterion::Bencher, (setup, tree): &(ForestSetup<_>, TreeId)| {
+        b.iter(|| {
+            hint::black_box(
+                setup.forest.entries(*tree).unwrap().map(|e| e.unwrap()).collect::<Vec<_>>()
+            );
+        })
+    }
+}
+
+// Measures iteration over a historical version of a tree (the WithHistory state machine path).
+benchmark_with_setup_data! {
+    large_smt_forest_persistent_entries_historical_tree,
+    DEFAULT_MEASUREMENT_TIME,
+    DEFAULT_SAMPLE_SIZE,
+    "large_smt_forest_persistent_entries_historical_tree",
+    || {
+        let mut setup = ForestSetup::new_persistent();
+        let initial_batch = generate_tree_update_batch(BATCH_SIZE);
+        let lineage = LineageId::new([0x42; 32]);
+        let version = 0;
+        setup.forest.add_lineage(lineage, version, initial_batch).unwrap();
+        let update_batch = generate_tree_update_batch(BATCH_SIZE);
+        setup.forest.update_tree(lineage, version + 1, update_batch).unwrap();
+        let tree = TreeId::new(lineage, version);
+        (setup, tree)
+    },
+    |b: &mut criterion::Bencher, (setup, tree): &(ForestSetup<_>, TreeId)| {
+        b.iter(|| {
+            hint::black_box(
+                setup.forest.entries(*tree).unwrap().map(|e| e.unwrap()).collect::<Vec<_>>()
+            );
+        })
+    },
+}
+
 // Roughly equivalent to large_smt::large_smt_insert_batch_to_empty_tree in functionality.
 benchmark_batch! {
     large_smt_forest_persistent_add_lineage,
@@ -220,6 +270,8 @@ criterion_group!(
     large_smt_forest_persistent_group,
     large_smt_forest_persistent_open_full_tree,
     large_smt_forest_persistent_open_historical_tree,
+    large_smt_forest_persistent_entries_current_tree,
+    large_smt_forest_persistent_entries_historical_tree,
     large_smt_forest_persistent_add_lineage,
     large_smt_forest_persistent_update_tree,
     large_smt_forest_persistent_update_forest,

--- a/miden-crypto/src/merkle/smt/large_forest/backend/memory/mod.rs
+++ b/miden-crypto/src/merkle/smt/large_forest/backend/memory/mod.rs
@@ -113,9 +113,9 @@ impl Backend for InMemoryBackend {
     ///
     /// - [`BackendError::UnknownLineage`] if the provided `lineage` is one not known by this
     ///   backend.
-    fn entries(&self, lineage: LineageId) -> Result<impl Iterator<Item = TreeEntry>> {
+    fn entries(&self, lineage: LineageId) -> Result<impl Iterator<Item = Result<TreeEntry>>> {
         let tree = self.trees.get(&lineage).ok_or(BackendError::UnknownLineage(lineage))?;
-        Ok(tree.tree.entries().map(|(k, v)| TreeEntry { key: *k, value: *v }))
+        Ok(tree.tree.entries().map(|(k, v)| Ok(TreeEntry { key: *k, value: *v })))
     }
 
     /// Adds the provided `lineage` to the forest.

--- a/miden-crypto/src/merkle/smt/large_forest/backend/memory/property_tests.rs
+++ b/miden-crypto/src/merkle/smt/large_forest/backend/memory/property_tests.rs
@@ -226,7 +226,10 @@ proptest! {
         let backend_entries = backend
             .entries(target_lineage)
             .map_err(to_fail)?
-            .map(|e| (e.key, e.value))
+            .map(|e| e.map(|e| (e.key, e.value)))
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(to_fail)?
+            .into_iter()
             .sorted()
             .collect_vec();
         let tree_entries = tree.entries().copied().sorted().collect_vec();

--- a/miden-crypto/src/merkle/smt/large_forest/backend/memory/tests.rs
+++ b/miden-crypto/src/merkle/smt/large_forest/backend/memory/tests.rs
@@ -5,6 +5,8 @@
 //! existing [`Smt`] implementation, comparing the results of the in-memory backend against it
 //! wherever relevant.
 
+use alloc::vec::Vec;
+
 use assert_matches::assert_matches;
 use itertools::Itertools;
 
@@ -385,22 +387,11 @@ fn entries() -> Result<()> {
     backend.update_tree(lineage_1, version, operations)?;
 
     // Now, the iterator should yield the expected three items.
-    assert_eq!(backend.entries(lineage_1)?.count(), 3);
-    assert!(
-        backend
-            .entries(lineage_1)?
-            .contains(&TreeEntry { key: key_1_1, value: value_1_1 }),
-    );
-    assert!(
-        backend
-            .entries(lineage_1)?
-            .contains(&TreeEntry { key: key_1_2, value: value_1_2 }),
-    );
-    assert!(
-        backend
-            .entries(lineage_1)?
-            .contains(&TreeEntry { key: key_1_3, value: value_1_3 }),
-    );
+    let entries = backend.entries(lineage_1)?.collect::<Result<Vec<_>>>()?;
+    assert_eq!(entries.len(), 3);
+    assert!(entries.contains(&TreeEntry { key: key_1_1, value: value_1_1 }));
+    assert!(entries.contains(&TreeEntry { key: key_1_2, value: value_1_2 }));
+    assert!(entries.contains(&TreeEntry { key: key_1_3, value: value_1_3 }));
 
     Ok(())
 }

--- a/miden-crypto/src/merkle/smt/large_forest/backend/mod.rs
+++ b/miden-crypto/src/merkle/smt/large_forest/backend/mod.rs
@@ -121,7 +121,17 @@ where
     ///
     /// The iterator may yield entries in any arbitrary order, but must not yield entries for which
     /// the value is the empty word.
-    fn entries(&self, lineage: LineageId) -> Result<impl Iterator<Item = TreeEntry>>;
+    ///
+    /// # Expected Behavior
+    ///
+    /// Implementations must guarantee the following behavior in addition to the global invariants:
+    ///
+    /// - If any kind of error occurs during iteration that should be signaled to the user, the
+    ///   iterator must return `Some(Err(...))`. The caller should stop iteration after receiving an
+    ///   error as the iterator state is no longer valid.
+    /// - `None` will be returned upon successful completion, or at any time after an error has been
+    ///   returned.
+    fn entries(&self, lineage: LineageId) -> Result<impl Iterator<Item = Result<TreeEntry>>>;
 
     // SINGLE-TREE MODIFIERS
     // ============================================================================================

--- a/miden-crypto/src/merkle/smt/large_forest/backend/persistent/iterator.rs
+++ b/miden-crypto/src/merkle/smt/large_forest/backend/persistent/iterator.rs
@@ -39,7 +39,7 @@ impl<'db> PersistentBackendEntriesIterator<'db> {
     /// Constructs a new such iterator in the starting state.
     ///
     /// The provided `iterator` must yield items where the key decodes to a `LeafKey` and the value
-    /// decodes to an `SmtLeaf`. If this is not the case, iteration will panic.
+    /// decodes to an `SmtLeaf`. If this is not the case, iteration will yield an error.
     ///
     /// For performance, this iterator should be passed a prefix iterator over the database with the
     /// correct prefix (corresponding to the provided `lineage`) set, but it will still function
@@ -61,26 +61,38 @@ enum PersistentBackendEntriesIteratorState {
         /// The iterator over the current leaf's entries.
         leaf_entries: Box<dyn Iterator<Item = (Word, Word)>>,
     },
+
+    /// The iterator has encountered an error and will yield no further items.
+    Faulted,
 }
 
 impl<'db> Iterator for PersistentBackendEntriesIterator<'db> {
-    type Item = TreeEntry;
+    type Item = super::Result<TreeEntry>;
 
     /// Advances the iterator and returns the next item if present.
-    ///
-    /// # Panics
-    ///
-    /// - If unable to read from the underlying database.
     fn next(&mut self) -> Option<Self::Item> {
         loop {
             match &mut self.state {
+                PersistentBackendEntriesIteratorState::Faulted => return None,
                 PersistentBackendEntriesIteratorState::NotInLeaf => {
                     // Here we are not in a leaf of the targeted tree, so we have to see if we _can_
                     // be.
                     if let Some(entry) = self.iterator.next() {
-                        let (key_bytes, value_bytes) = entry.expect("Able to read from the DB");
-                        let key = LeafKey::read_from_bytes(&key_bytes)
-                            .expect("Leaf key data read from disk is not corrupt");
+                        let (key_bytes, value_bytes) = match entry {
+                            Ok((key_bytes, value_bytes)) => (key_bytes, value_bytes),
+                            Err(e) => {
+                                self.state = PersistentBackendEntriesIteratorState::Faulted;
+                                return Some(Err(e.into()));
+                            },
+                        };
+
+                        let key = match LeafKey::read_from_bytes(&key_bytes) {
+                            Ok(key) => key,
+                            Err(e) => {
+                                self.state = PersistentBackendEntriesIteratorState::Faulted;
+                                return Some(Err(e.into()));
+                            },
+                        };
 
                         // If the key isn't for the correct lineage (which can happen even with the
                         // bloom filter), we need to advance by returning to the loop.
@@ -90,8 +102,13 @@ impl<'db> Iterator for PersistentBackendEntriesIterator<'db> {
 
                         // If the key is valid, we need to read out the leaf itself and then start
                         // iterating over that.
-                        let leaf = SmtLeaf::read_from_bytes(&value_bytes)
-                            .expect("Leaf data read from disk is not corrupt");
+                        let leaf = match SmtLeaf::read_from_bytes(&value_bytes) {
+                            Ok(leaf) => leaf,
+                            Err(e) => {
+                                self.state = PersistentBackendEntriesIteratorState::Faulted;
+                                return Some(Err(e.into()));
+                            },
+                        };
                         let mut leaf_entries = leaf.into_entries();
                         leaf_entries.sort_by_key(|(k, _)| *k);
 
@@ -106,7 +123,7 @@ impl<'db> Iterator for PersistentBackendEntriesIterator<'db> {
                 PersistentBackendEntriesIteratorState::InLeaf { leaf_entries } => {
                     if let Some((key, value)) = leaf_entries.next() {
                         // Here we have an entry in the leaf, so we simply need to return it.
-                        return Some(TreeEntry { key, value });
+                        return Some(Ok(TreeEntry { key, value }));
                     } else {
                         // If we've run out of entries in the leaf itself, we need to see if there
                         // is another valid leaf. We do this by changing state and looping to use

--- a/miden-crypto/src/merkle/smt/large_forest/backend/persistent/mod.rs
+++ b/miden-crypto/src/merkle/smt/large_forest/backend/persistent/mod.rs
@@ -340,7 +340,7 @@ impl Backend for PersistentBackend {
     ///
     /// - [`BackendError::UnknownLineage`] if the provided `lineage` is not one known by this
     ///   backend.
-    fn entries(&self, lineage: LineageId) -> Result<impl Iterator<Item = TreeEntry>> {
+    fn entries(&self, lineage: LineageId) -> Result<impl Iterator<Item = Result<TreeEntry>>> {
         if !self.lineages.contains_key(&lineage) {
             return Err(BackendError::UnknownLineage(lineage));
         }

--- a/miden-crypto/src/merkle/smt/large_forest/backend/persistent/property_tests.rs
+++ b/miden-crypto/src/merkle/smt/large_forest/backend/persistent/property_tests.rs
@@ -217,7 +217,9 @@ proptest! {
         // And we should have the same number of entries in each.
         let backend_entries = backend
             .entries(target_lineage)?
-            .map(|e| (e.key, e.value))
+            .map(|e| e.map(|e| (e.key, e.value)))
+            .collect::<std::result::Result<Vec<_>, _>>()?
+            .into_iter()
             .sorted()
             .collect_vec();
         let tree_entries = tree.entries().copied().sorted().collect_vec();

--- a/miden-crypto/src/merkle/smt/large_forest/backend/persistent/tests.rs
+++ b/miden-crypto/src/merkle/smt/large_forest/backend/persistent/tests.rs
@@ -5,6 +5,8 @@
 //! existing [`Smt`] implementation, comparing the results of the persistent backend against it
 //! wherever relevant.
 
+use alloc::vec::Vec;
+
 use assert_matches::assert_matches;
 use itertools::Itertools;
 use tempfile::{TempDir, tempdir};
@@ -126,7 +128,12 @@ fn load_extant() -> Result<()> {
     assert_eq!(l2_value, Some(t2_value));
 
     // ...and entries.
-    let l1_entries = backend.entries(lineage_1)?.sorted().collect_vec();
+    let l1_entries = backend
+        .entries(lineage_1)?
+        .collect::<std::result::Result<Vec<_>, _>>()?
+        .into_iter()
+        .sorted()
+        .collect_vec();
     let t1_entries = tree_1
         .entries()
         .sorted()
@@ -134,7 +141,12 @@ fn load_extant() -> Result<()> {
         .collect_vec();
     assert_eq!(l1_entries, t1_entries);
 
-    let l2_entries = backend.entries(lineage_2)?.sorted().collect_vec();
+    let l2_entries = backend
+        .entries(lineage_2)?
+        .collect::<std::result::Result<Vec<_>, _>>()?
+        .into_iter()
+        .sorted()
+        .collect_vec();
     let t2_entries = tree_2
         .entries()
         .sorted()
@@ -493,22 +505,11 @@ fn entries() -> Result<()> {
     backend.update_tree(lineage_1, version, operations)?;
 
     // Now, the iterator should yield the expected three items.
-    assert_eq!(backend.entries(lineage_1)?.count(), 3);
-    assert!(
-        backend
-            .entries(lineage_1)?
-            .contains(&TreeEntry { key: key_1_1, value: value_1_1 }),
-    );
-    assert!(
-        backend
-            .entries(lineage_1)?
-            .contains(&TreeEntry { key: key_1_2, value: value_1_2 }),
-    );
-    assert!(
-        backend
-            .entries(lineage_1)?
-            .contains(&TreeEntry { key: key_1_3, value: value_1_3 }),
-    );
+    let entries = backend.entries(lineage_1)?.collect::<Result<Vec<_>>>()?;
+    assert_eq!(entries.len(), 3);
+    assert!(entries.contains(&TreeEntry { key: key_1_1, value: value_1_1 }));
+    assert!(entries.contains(&TreeEntry { key: key_1_2, value: value_1_2 }));
+    assert!(entries.contains(&TreeEntry { key: key_1_3, value: value_1_3 }));
 
     Ok(())
 }

--- a/miden-crypto/src/merkle/smt/large_forest/iterator.rs
+++ b/miden-crypto/src/merkle/smt/large_forest/iterator.rs
@@ -22,6 +22,7 @@ use core::iter::Peekable;
 
 use miden_field::Word;
 
+use super::Result;
 use crate::{
     Set,
     merkle::smt::large_forest::{history::HistoryView, root::TreeEntry},
@@ -32,6 +33,12 @@ use crate::{
 
 /// An iterator over the entries of an arbitrary tree in the forest, yielding entries in an
 /// arbitrary order.
+///
+/// - If any error occurs during iteration, this is signaled to the user by the iterator yielding
+///   `Some(Err(...))`. The user should stop on first error, as the iterator will be in an
+///   inconsistent state afterward.
+/// - `None` is returned if the true end of the iterator is reached successfully, or at any point
+///   after an error has been yielded.
 ///
 /// It is split into two variants for performance, as iterating over a full tree is significantly
 /// simpler than iterating over a historical tree. While it would be nice to be able to return one
@@ -48,7 +55,8 @@ pub(super) enum EntriesIterator<'forest> {
         /// The iterator over the entries in the full tree.
         ///
         /// This iterator should never yield any entries where `value == EMPTY_WORD`.
-        full_tree_iter: Peekable<Box<dyn Iterator<Item = TreeEntry> + 'forest>>,
+        full_tree_iter:
+            Peekable<Box<dyn Iterator<Item = super::backend::Result<TreeEntry>> + 'forest>>,
 
         /// The view into the history at the correct point.
         history_view: HistoryView<'forest>,
@@ -64,7 +72,10 @@ pub(super) enum EntriesIterator<'forest> {
     /// An iterator over a tree in the forest that is simply an iterator over the full tree.
     WithoutHistory {
         /// The iterator over the entries in the full tree.
-        full_tree_iter: Box<dyn Iterator<Item = TreeEntry> + 'forest>,
+        full_tree_iter: Box<dyn Iterator<Item = super::backend::Result<TreeEntry>> + 'forest>,
+
+        /// Whether the iterator has encountered an error and should yield no more items.
+        faulted: bool,
     },
 }
 
@@ -74,7 +85,7 @@ impl<'forest> EntriesIterator<'forest> {
     ///
     /// Note that it _does not_ perform checks as to the correctness of the provided iterators.
     pub(super) fn new_with_history(
-        full_tree_iter: impl Iterator<Item = TreeEntry> + 'forest,
+        full_tree_iter: impl Iterator<Item = super::backend::Result<TreeEntry>> + 'forest,
         history_view: HistoryView<'forest>,
     ) -> Self {
         // This type gymnastics is unfortunately necessary to let us easily store the `Peekable`
@@ -95,10 +106,10 @@ impl<'forest> EntriesIterator<'forest> {
     /// Note that it _does not_ check whether `full_tree_iter` is actually an iterator over the
     /// full tree. If it is not, this iterator will yield invalid results.
     pub(super) fn new_without_history(
-        full_tree_iter: impl Iterator<Item = TreeEntry> + 'forest,
+        full_tree_iter: impl Iterator<Item = super::backend::Result<TreeEntry>> + 'forest,
     ) -> Self {
         let full_tree_iter = Box::new(full_tree_iter);
-        Self::WithoutHistory { full_tree_iter }
+        Self::WithoutHistory { full_tree_iter, faulted: false }
     }
 
     /// Advances the iterator and returns the next value in the case where it is iterating over a
@@ -108,7 +119,7 @@ impl<'forest> EntriesIterator<'forest> {
     ///
     /// - If the method is called with a `self` that is not in the [`Self::WithHistory`] variant.
     #[inline(always)] // To help the optimizer eliminate the redundant check in Iterator::next()
-    fn next_with_history(&mut self) -> Option<TreeEntry> {
+    fn next_with_history(&mut self) -> Option<Result<TreeEntry>> {
         let EntriesIterator::WithHistory {
             full_tree_iter,
             history_view,
@@ -121,6 +132,7 @@ impl<'forest> EntriesIterator<'forest> {
 
         loop {
             match state {
+                EntriesIteratorState::Faulted => return None,
                 EntriesIteratorState::Initial => {
                     // In the initial state we need to advance to the appropriate next state.
                     if full_tree_iter.peek().is_none() {
@@ -157,6 +169,13 @@ impl<'forest> EntriesIterator<'forest> {
                     let Some(entry) = full_tree_iter.next() else {
                         unreachable!("The iterator is known to have another item available");
                     };
+                    let entry = match entry {
+                        Ok(entry) => entry,
+                        Err(e) => {
+                            *state = EntriesIteratorState::Faulted;
+                            return Some(Err(e.into()));
+                        },
+                    };
 
                     let value = if let Some(v) = history_view.value(&entry.key) {
                         // If the history has a value for this key, then we need to return that
@@ -174,7 +193,7 @@ impl<'forest> EntriesIterator<'forest> {
                         entry
                     };
 
-                    return Some(value);
+                    return Some(Ok(value));
                 },
                 EntriesIteratorState::ReadingHistory { iterator } => {
                     // This is a terminal state. We cannot transition to any other state from here,
@@ -182,7 +201,7 @@ impl<'forest> EntriesIterator<'forest> {
                     // history items does.
                     for entry in iterator.by_ref() {
                         if !yielded_history_keys.contains(&entry.key) && !entry.value.is_empty() {
-                            return Some(entry);
+                            return Some(Ok(entry));
                         }
 
                         // Here we have already returned this entry, or it is empty. In both cases
@@ -201,12 +220,23 @@ impl<'forest> EntriesIterator<'forest> {
     ///
     /// - If the method is called with a `self` that is not the [`Self::WithoutHistory`] variant.
     #[inline(always)] // To help the optimizer eliminate the redundant check in Iterator::next()
-    fn next_without_history(&mut self) -> Option<TreeEntry> {
-        let EntriesIterator::WithoutHistory { full_tree_iter } = self else {
+    fn next_without_history(&mut self) -> Option<Result<TreeEntry>> {
+        // Note that the inner iterator yields items of type `backend::Result` while this one
+        // yields the outer result. Conversion happening via the standard `Into::into` conversion
+        // for Result.
+        let EntriesIterator::WithoutHistory { full_tree_iter, faulted } = self else {
             panic!("EntriesIterator::next_without_history called with history")
         };
 
-        full_tree_iter.next()
+        if *faulted {
+            return None;
+        }
+
+        let result = full_tree_iter.next().map(|e| e.map_err(Into::into));
+        if matches!(&result, Some(Err(_))) {
+            *faulted = true;
+        }
+        result
     }
 }
 
@@ -214,7 +244,7 @@ impl<'forest> EntriesIterator<'forest> {
 // ================================================================================================
 
 impl Iterator for EntriesIterator<'_> {
-    type Item = TreeEntry;
+    type Item = Result<TreeEntry>;
 
     fn next(&mut self) -> Option<Self::Item> {
         match self {
@@ -243,4 +273,7 @@ pub(super) enum EntriesIteratorState<'forest> {
         /// The iterator over the entries that are _added_ by the history.
         iterator: Box<dyn Iterator<Item = TreeEntry> + 'forest>,
     },
+
+    /// The iterator has encountered an error and will yield no more items.
+    Faulted,
 }

--- a/miden-crypto/src/merkle/smt/large_forest/mod.rs
+++ b/miden-crypto/src/merkle/smt/large_forest/mod.rs
@@ -282,8 +282,8 @@
 //! assert!(forest.get(current_tree, key_1)?.is_none());
 //!
 //! // We can also get an iterator over all the entries in the tree.
-//! let entries_old: Vec<_> = forest.entries(old_tree)?.collect();
-//! let entries_current: Vec<_> = forest.entries(current_tree)?.collect();
+//! let entries_old = forest.entries(old_tree)?.collect::<Result<Vec<_>, _>>()?;
+//! let entries_current = forest.entries(current_tree)?.collect::<Result<Vec<_>, _>>()?;
 //! assert!(entries_old.contains(&TreeEntry { key: key_1, value: value_1 }));
 //! assert!(entries_old.contains(&TreeEntry { key: key_2, value: value_2 }));
 //! assert!(!entries_old.contains(&TreeEntry { key: key_3, value: value_3 }));
@@ -717,10 +717,26 @@ impl<B: Backend> LargeSmtForest<B> {
 
         // In the general case there is no faster path than doing the iteration to merge the
         // history with the full tree, so we just count the iterator.
-        Ok(EntriesIterator::new_with_history(self.backend.entries(tree.lineage())?, view).count())
+        //
+        // We have to do it this way to avoid silently swallowing errors during iteration.
+        let iterator =
+            EntriesIterator::new_with_history(self.backend.entries(tree.lineage())?, view);
+        let mut count = 0;
+        for entry in iterator {
+            entry?;
+            count += 1;
+        }
+
+        Ok(count)
     }
 
     /// Returns an iterator that yields the entries in the specified `tree`.
+    ///
+    /// - If any error occurs during iteration, this is signaled to the user by the iterator
+    ///   yielding `Some(Err(...))`. The user should stop on first error, as the iterator will be in
+    ///   an inconsistent state afterward.
+    /// - `None` is returned if the true end of the iterator is reached successfully, or at any
+    ///   point after an error has been yielded.
     ///
     /// # Performance
     ///
@@ -736,7 +752,7 @@ impl<B: Backend> LargeSmtForest<B> {
     ///   not one known by the forest.
     /// - [`LargeSmtForestError::UnknownTree`] if the provided `tree` refers to a tree that is not a
     ///   member of the forest.
-    pub fn entries(&self, tree: TreeId) -> Result<impl Iterator<Item = TreeEntry>> {
+    pub fn entries(&self, tree: TreeId) -> Result<impl Iterator<Item = Result<TreeEntry>>> {
         // We start by yielding an error if we cannot get the lineage data for the specified tree.
         let Some(lineage_data) = self.lineage_data.get(&tree.lineage()) else {
             return Err(LargeSmtForestError::UnknownLineage(tree.lineage()));

--- a/miden-crypto/src/merkle/smt/large_forest/property_tests.rs
+++ b/miden-crypto/src/merkle/smt/large_forest/property_tests.rs
@@ -51,7 +51,14 @@ proptest! {
         // Iterating over the historical version of the lineage in the forest should produce exactly
         // the same entries as iterating over V1 of our test tree.
         let old_version = TreeId::new(lineage, version);
-        let forest_entries = forest.entries(old_version).map_err(to_fail)?.sorted().collect_vec();
+        let forest_entries = forest
+            .entries(old_version)
+            .map_err(to_fail)?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(to_fail)?
+            .into_iter()
+            .sorted()
+            .collect_vec();
         let tree_entries = tree_v1
             .entries()
             .map(|(k, v)| TreeEntry { key: *k, value: *v })
@@ -66,7 +73,14 @@ proptest! {
         } else {
             TreeId::new(lineage, tree_info.version())
         };
-        let forest_entries = forest.entries(current_version).map_err(to_fail)?.sorted().collect_vec();
+        let forest_entries = forest
+            .entries(current_version)
+            .map_err(to_fail)?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(to_fail)?
+            .into_iter()
+            .sorted()
+            .collect_vec();
         let tree_entries = tree_v2
             .entries()
             .map(|(k, v)| TreeEntry { key: *k, value: *v })
@@ -92,7 +106,12 @@ proptest! {
         // Iterating over the historical version of the lineage in the forest should produce exactly
         // the same entries as iterating over V1 of our test tree.
         let old_version = TreeId::new(lineage, version);
-        prop_assert!(forest.entries(old_version).map_err(to_fail)?.all(|e| e.value != EMPTY_WORD));
+        let entries = forest
+            .entries(old_version)
+            .map_err(to_fail)?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(to_fail)?;
+        prop_assert!(entries.iter().all(|e| e.value != EMPTY_WORD), "EMPTY_WORD entry encountered");
 
         // Iterating over the newest version of the lineage in the forest should provide exactly the
         // same entries as iterating over V2 of our test tree.
@@ -101,6 +120,11 @@ proptest! {
         } else {
             TreeId::new(lineage, root_2.version())
         };
-        prop_assert!(forest.entries(current_version).map_err(to_fail)?.all(|e| e.value != EMPTY_WORD));
+        let entries = forest
+            .entries(current_version)
+            .map_err(to_fail)?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(to_fail)?;
+        prop_assert!(entries.iter().all(|e| e.value != EMPTY_WORD), "EMPTY_WORD entry encountered");
     }
 }

--- a/miden-crypto/src/merkle/smt/large_forest/test_utils.rs
+++ b/miden-crypto/src/merkle/smt/large_forest/test_utils.rs
@@ -10,8 +10,13 @@ use proptest::prelude::*;
 use crate::{
     EMPTY_WORD, Map, ONE, ZERO,
     merkle::smt::{
-        ForestOperation, LeafIndex, LineageId, MAX_LEAF_ENTRIES, SMT_DEPTH, SmtUpdateBatch,
-        VersionId,
+        Backend, ForestInMemoryBackend, ForestOperation, LeafIndex, LineageId, MAX_LEAF_ENTRIES,
+        SMT_DEPTH, SmtForestUpdateBatch, SmtProof, SmtUpdateBatch, VersionId,
+        large_forest::{
+            backend::{BackendError, Result as BackendResult},
+            root::{TreeEntry, TreeWithRoot},
+            utils::MutationSet,
+        },
     },
 };
 
@@ -103,4 +108,104 @@ pub fn arbitrary_batch() -> impl Strategy<Value = SmtUpdateBatch> {
             }
         }))
     })
+}
+
+// FALLIBLE ENTRIES BACKEND
+// ================================================================================================
+
+/// A wrapper around [`ForestInMemoryBackend`] that injects an error on the 3rd item yielded by
+/// the `entries` iterator, to exercise the error-propagation path.
+#[derive(Debug)]
+pub struct FallibleEntriesBackend {
+    inner: ForestInMemoryBackend,
+}
+
+impl FallibleEntriesBackend {
+    /// Constructs a new `FallibleEntriesBackend` wrapping a fresh [`ForestInMemoryBackend`].
+    pub fn new() -> Self {
+        Self { inner: ForestInMemoryBackend::new() }
+    }
+}
+
+/// An iterator that yields the first 2 items from the inner iterator as `Ok(...)`, then yields
+/// a single `Err(BackendError::Unspecified(...))`, then yields `None` forever.
+pub struct FallibleIter<I> {
+    inner: I,
+    count: usize,
+}
+
+impl<I: Iterator<Item = BackendResult<TreeEntry>>> Iterator for FallibleIter<I> {
+    type Item = BackendResult<TreeEntry>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.count >= 3 {
+            return None;
+        }
+        self.count += 1;
+        if self.count <= 2 {
+            self.inner.next()
+        } else {
+            Some(Err(BackendError::Unspecified("simulated read failure".into())))
+        }
+    }
+}
+
+impl Backend for FallibleEntriesBackend {
+    fn open(&self, lineage: LineageId, key: Word) -> BackendResult<SmtProof> {
+        self.inner.open(lineage, key)
+    }
+
+    fn get(&self, lineage: LineageId, key: Word) -> BackendResult<Option<Word>> {
+        self.inner.get(lineage, key)
+    }
+
+    fn version(&self, lineage: LineageId) -> BackendResult<VersionId> {
+        self.inner.version(lineage)
+    }
+
+    fn lineages(&self) -> BackendResult<impl Iterator<Item = LineageId>> {
+        self.inner.lineages()
+    }
+
+    fn trees(&self) -> BackendResult<impl Iterator<Item = TreeWithRoot>> {
+        self.inner.trees()
+    }
+
+    fn entry_count(&self, lineage: LineageId) -> BackendResult<usize> {
+        self.inner.entry_count(lineage)
+    }
+
+    fn entries(
+        &self,
+        lineage: LineageId,
+    ) -> BackendResult<impl Iterator<Item = BackendResult<TreeEntry>>> {
+        let inner_iter = self.inner.entries(lineage)?;
+        Ok(FallibleIter { inner: inner_iter, count: 0 })
+    }
+
+    fn add_lineage(
+        &mut self,
+        lineage: LineageId,
+        version: VersionId,
+        updates: SmtUpdateBatch,
+    ) -> BackendResult<TreeWithRoot> {
+        self.inner.add_lineage(lineage, version, updates)
+    }
+
+    fn update_tree(
+        &mut self,
+        lineage: LineageId,
+        new_version: VersionId,
+        updates: SmtUpdateBatch,
+    ) -> BackendResult<MutationSet> {
+        self.inner.update_tree(lineage, new_version, updates)
+    }
+
+    fn update_forest(
+        &mut self,
+        new_version: VersionId,
+        updates: SmtForestUpdateBatch,
+    ) -> BackendResult<Vec<(LineageId, MutationSet)>> {
+        self.inner.update_forest(new_version, updates)
+    }
 }

--- a/miden-crypto/src/merkle/smt/large_forest/tests.rs
+++ b/miden-crypto/src/merkle/smt/large_forest/tests.rs
@@ -11,7 +11,6 @@
 use alloc::vec::Vec;
 
 use assert_matches::assert_matches;
-use itertools::Itertools;
 
 use super::{Config, Result};
 use crate::{
@@ -25,6 +24,7 @@ use crate::{
                 LineageData,
                 history::{ChangedKeys, History, NodeChanges},
                 root::{LineageId, TreeEntry, TreeWithRoot},
+                test_utils::FallibleEntriesBackend,
             },
         },
     },
@@ -694,51 +694,21 @@ fn entries() -> Result<()> {
 
     // Grabbing the entries for the latest version in a lineage should do the right thing.
     let current_tree = TreeId::new(lineage_1, version_2);
-    assert_eq!(forest.entries(current_tree)?.count(), 3);
-    assert!(
-        forest
-            .entries(current_tree)?
-            .contains(&TreeEntry { key: key_1, value: value_1_v2 })
-    );
-    assert!(
-        forest
-            .entries(current_tree)?
-            .contains(&TreeEntry { key: key_2, value: value_2_v1 })
-    );
-    assert!(
-        forest
-            .entries(current_tree)?
-            .contains(&TreeEntry { key: key_4, value: value_4_v1 })
-    );
-    assert!(
-        !forest
-            .entries(current_tree)?
-            .contains(&TreeEntry { key: key_3, value: value_3_v1 })
-    );
+    let current_entries = forest.entries(current_tree)?.collect::<Result<Vec<_>>>()?;
+    assert_eq!(current_entries.len(), 3);
+    assert!(current_entries.contains(&TreeEntry { key: key_1, value: value_1_v2 }));
+    assert!(current_entries.contains(&TreeEntry { key: key_2, value: value_2_v1 }));
+    assert!(current_entries.contains(&TreeEntry { key: key_4, value: value_4_v1 }));
+    assert!(!current_entries.contains(&TreeEntry { key: key_3, value: value_3_v1 }));
 
     // If we ask for a historical version, things are more complex but should still work.
     let historical_tree = TreeId::new(lineage_1, version_1);
-    assert_eq!(forest.entries(historical_tree)?.count(), 3);
-    assert!(
-        forest
-            .entries(historical_tree)?
-            .contains(&TreeEntry { key: key_1, value: value_1_v1 })
-    );
-    assert!(
-        forest
-            .entries(historical_tree)?
-            .contains(&TreeEntry { key: key_2, value: value_2_v1 })
-    );
-    assert!(
-        forest
-            .entries(historical_tree)?
-            .contains(&TreeEntry { key: key_3, value: value_3_v1 })
-    );
-    assert!(
-        !forest
-            .entries(historical_tree)?
-            .contains(&TreeEntry { key: key_4, value: value_4_v1 })
-    );
+    let historical_entries = forest.entries(historical_tree)?.collect::<Result<Vec<_>>>()?;
+    assert_eq!(historical_entries.len(), 3);
+    assert!(historical_entries.contains(&TreeEntry { key: key_1, value: value_1_v1 }));
+    assert!(historical_entries.contains(&TreeEntry { key: key_2, value: value_2_v1 }));
+    assert!(historical_entries.contains(&TreeEntry { key: key_3, value: value_3_v1 }));
+    assert!(!historical_entries.contains(&TreeEntry { key: key_4, value: value_4_v1 }));
 
     Ok(())
 }
@@ -795,8 +765,8 @@ fn forest_overlays_correctly() -> Result<()> {
     assert!(forest.get(current_tree, key_1)?.is_none());
 
     // We can also get an iterator over all the entries in the tree.
-    let entries_old: Vec<_> = forest.entries(old_tree)?.collect();
-    let entries_current: Vec<_> = forest.entries(current_tree)?.collect();
+    let entries_old = forest.entries(old_tree)?.collect::<Result<Vec<_>>>()?;
+    let entries_current = forest.entries(current_tree)?.collect::<Result<Vec<_>>>()?;
     assert!(entries_old.contains(&TreeEntry { key: key_1, value: value_1 }));
     assert!(entries_old.contains(&TreeEntry { key: key_2, value: value_2 }));
     assert!(!entries_old.contains(&TreeEntry { key: key_3, value: value_3 }));
@@ -863,8 +833,9 @@ fn entries_never_returns_empty_entry() -> Result<()> {
     // Now, when we query for entries on the historical version, we should only see one entry, and
     // no entries should be the empty word.
     let historical_tree = TreeId::new(lineage_2, version_1);
-    assert_eq!(forest.entries(historical_tree)?.count(), 1);
-    assert!(forest.entries(historical_tree)?.all(|e| e.value != EMPTY_WORD));
+    let entries = forest.entries(historical_tree)?.collect::<Result<Vec<_>>>()?;
+    assert_eq!(entries.len(), 1);
+    assert!(entries.iter().all(|e| e.value != EMPTY_WORD));
 
     // The third scenario is where entries are added within a shared leaf, where we should only see
     // the historical leaf entries and not their reversions.
@@ -888,8 +859,9 @@ fn entries_never_returns_empty_entry() -> Result<()> {
 
     // Now when we query the historical version, we should only see one entry, and no reversions.
     let historical_tree = TreeId::new(lineage_3, version_1);
-    assert_eq!(forest.entries(historical_tree)?.count(), 1);
-    assert!(forest.entries(historical_tree)?.all(|e| e.value != EMPTY_WORD));
+    let entries = forest.entries(historical_tree)?.collect::<Result<Vec<_>>>()?;
+    assert_eq!(entries.len(), 1);
+    assert!(entries.iter().all(|e| e.value != EMPTY_WORD));
 
     Ok(())
 }
@@ -938,7 +910,7 @@ fn entries_history_empty_values_do_not_reorder() -> Result<()> {
     )?;
 
     let historical_tree = TreeId::new(lineage, version_1);
-    let entries: Vec<_> = forest.entries(historical_tree)?.collect();
+    let entries = forest.entries(historical_tree)?.collect::<Result<Vec<_>>>()?;
     assert_eq!(entries.len(), 2);
     assert_eq!(entries[0], TreeEntry { key: key_a, value: value_a });
     assert_eq!(entries[1], TreeEntry { key: key_c, value: value_c_v1 });
@@ -1328,4 +1300,105 @@ fn truncate_retains_non_empty_lineages_in_non_empty_histories() {
         forest.non_empty_histories.contains(&lineage),
         "lineage with remaining history must stay in non_empty_histories"
     );
+}
+
+// ENTRIES UNHAPPY PATH TESTS
+// ================================================================================================
+
+#[test]
+fn entries_with_fallible_backend() -> Result<()> {
+    let backend = FallibleEntriesBackend::new();
+    let mut forest = LargeSmtForest::new(backend)?;
+    let mut rng = ContinuousRng::new([0xfa; 32]);
+
+    // Add a lineage with more than 3 entries so we can verify that entries beyond the failure
+    // point are never returned.
+    let lineage: LineageId = rng.value();
+    let version: VersionId = rng.value();
+    let key_1: Word = rng.value();
+    let value_1: Word = rng.value();
+    let key_2: Word = rng.value();
+    let value_2: Word = rng.value();
+    let key_3: Word = rng.value();
+    let value_3: Word = rng.value();
+    let key_4: Word = rng.value();
+    let value_4: Word = rng.value();
+    let key_5: Word = rng.value();
+    let value_5: Word = rng.value();
+
+    let mut operations = SmtUpdateBatch::empty();
+    operations.add_insert(key_1, value_1);
+    operations.add_insert(key_2, value_2);
+    operations.add_insert(key_3, value_3);
+    operations.add_insert(key_4, value_4);
+    operations.add_insert(key_5, value_5);
+
+    forest.add_lineage(lineage, version, operations)?;
+
+    // Query entries on the current version (WithoutHistory path).
+    let tree_id = TreeId::new(lineage, version);
+    let mut iter = forest.entries(tree_id)?;
+
+    // First two items should be Ok.
+    let first = iter.next();
+    assert!(matches!(first, Some(Ok(_))), "expected first item to be Some(Ok(...))");
+    let second = iter.next();
+    assert!(matches!(second, Some(Ok(_))), "expected second item to be Some(Ok(...))");
+
+    // Third item should be the simulated error.
+    let third = iter.next();
+    assert_matches!(&third, Some(Err(LargeSmtForestError::Unspecified(msg))) if msg == "simulated read failure");
+
+    // After faulting, the iterator must yield None — the remaining entries (4th, 5th) are never
+    // returned.
+    assert!(iter.next().is_none(), "expected None after error");
+    assert!(iter.next().is_none(), "expected iterator to remain exhausted");
+
+    Ok(())
+}
+
+#[test]
+fn entry_count_with_fallible_backend() -> Result<()> {
+    let backend = FallibleEntriesBackend::new();
+    let mut forest = LargeSmtForest::new(backend)?;
+    let mut rng = ContinuousRng::new([0xfb; 32]);
+
+    // Add a lineage with more than 3 entries at version V1 so we can verify that the iteration
+    // stops at the failure point and does not silently count additional entries.
+    let lineage: LineageId = rng.value();
+    let version_1: VersionId = rng.value();
+    let key_1: Word = rng.value();
+    let value_1: Word = rng.value();
+    let key_2: Word = rng.value();
+    let value_2: Word = rng.value();
+    let key_3: Word = rng.value();
+    let value_3: Word = rng.value();
+    let key_4: Word = rng.value();
+    let value_4: Word = rng.value();
+    let key_5: Word = rng.value();
+    let value_5: Word = rng.value();
+
+    let mut operations = SmtUpdateBatch::empty();
+    operations.add_insert(key_1, value_1);
+    operations.add_insert(key_2, value_2);
+    operations.add_insert(key_3, value_3);
+    operations.add_insert(key_4, value_4);
+    operations.add_insert(key_5, value_5);
+
+    forest.add_lineage(lineage, version_1, operations)?;
+
+    // Update the tree at V2 so V1 becomes historical.
+    let version_2: VersionId = version_1 + 1;
+    let key_6: Word = rng.value();
+    let value_6: Word = rng.value();
+    let mut operations = SmtUpdateBatch::empty();
+    operations.add_insert(key_6, value_6);
+    forest.update_tree(lineage, version_2, operations)?;
+
+    // Query entry_count for the historical version V1.
+    // This takes the WithHistory iteration path, which will hit our fallible iterator.
+    let result = forest.entry_count(TreeId::new(lineage, version_1));
+    assert_matches!(result, Err(LargeSmtForestError::Unspecified(msg)) if msg == "simulated read failure");
+
+    Ok(())
 }


### PR DESCRIPTION
## Describe your changes

This changes `LargeSmtForest::entries` to return an iterator over items that are `Result<TreeEntry>` instead of bare `TreeEntry`, ensuring that the potential failure of iteration in the backend is communicated clearly to the caller performing the iteration.

We also add benchmarks to the iteration in order to confirm that the changes incur no performance impact.

Closes #887.

## Checklist before requesting a review

- [x] Repo forked and branch created from `next` according to naming convention.
- [x] Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- [x] Relevant issues are linked in the PR description.
- [x] Tests added for new functionality.
- [x] Documentation/comments updated according to changes.
