### PR TITLE
ci: opt-in to curated Clippy guardrails

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -8,10 +8,11 @@
 # NOTE: for the `make lint` command to work well, this must contain the same
 # list of lints as the xclippy-fix command below.
 xclippy = [
-  "--",
-  "--all-features",
-  "--all-targets",
+  "clippy",
   "--workspace",
+  "--all-targets",
+  "--all-features",
+  "--",
   "-Dwarnings",
   "-Wclippy::all",
   "-Wclippy::await_holding_lock",
@@ -60,7 +61,6 @@ xclippy = [
   "-Wclippy::useless_transmute",
   "-Wclippy::verbose_file_reads",
   "-Wclippy::zero_sized_map_values",
-  "clippy",
   # The following lints are disabled because they still trigger warnings:
   # -Wclippy::derive_partial_eq_without_eq (4 warnings)
   # -Wclippy::doc_markdown                 (826 warnings)
@@ -92,13 +92,14 @@ xclippy = [
 # NOTE: for the `make lint` command to work well, this must contain the same
 # list of lints as the xclippy setting above.
 xclippy-fix = [
-  "--",
-  "--all-features",
-  "--all-targets",
-  "--allow-dirty",
-  "--allow-staged",
+  "clippy",
   "--fix",
+  "--allow-staged",
+  "--allow-dirty",
   "--workspace",
+  "--all-targets",
+  "--all-features",
+  "--",
   "-Dwarnings",
   "-Wclippy::all",
   "-Wclippy::await_holding_lock",
@@ -147,5 +148,4 @@ xclippy-fix = [
   "-Wclippy::useless_transmute",
   "-Wclippy::verbose_file_reads",
   "-Wclippy::zero_sized_map_values",
-  "clippy",
 ]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,151 @@
+[alias]
+# Collection of project-wide Clippy lints. This is done via aliases because
+# Clippy does not currently support project-wide lint configuration in a
+# dedicated config file.
+#
+# NOTE: Only lints that currently pass in this workspace are enabled.
+# Additional lints can be enabled incrementally as the codebase is cleaned up.
+# NOTE: for the `make lint` command to work well, this must contain the same
+# list of lints as the xclippy-fix command below.
+xclippy = [
+  "--",
+  "--all-features",
+  "--all-targets",
+  "--workspace",
+  "-Dwarnings",
+  "-Wclippy::all",
+  "-Wclippy::await_holding_lock",
+  "-Wclippy::char_lit_as_u8",
+  "-Wclippy::checked_conversions",
+  "-Wclippy::dbg_macro",
+  "-Wclippy::debug_assert_with_mut_call",
+  "-Wclippy::disallowed_methods",
+  "-Wclippy::empty_enum",
+  "-Wclippy::exit",
+  "-Wclippy::expl_impl_clone_on_copy",
+  "-Wclippy::explicit_deref_methods",
+  "-Wclippy::filter_map_next",
+  "-Wclippy::float_cmp_const",
+  "-Wclippy::fn_params_excessive_bools",
+  "-Wclippy::if_let_mutex",
+  "-Wclippy::imprecise_flops",
+  "-Wclippy::inefficient_to_string",
+  "-Wclippy::invalid_upcast_comparisons",
+  "-Wclippy::large_digit_groups",
+  "-Wclippy::large_stack_arrays",
+  "-Wclippy::large_types_passed_by_value",
+  "-Wclippy::let_unit_value",
+  "-Wclippy::linkedlist",
+  "-Wclippy::lossy_float_literal",
+  "-Wclippy::macro_use_imports",
+  "-Wclippy::manual_ok_or",
+  "-Wclippy::map_flatten",
+  "-Wclippy::mem_forget",
+  "-Wclippy::missing_enforced_import_renames",
+  "-Wclippy::mut_mut",
+  "-Wclippy::mutex_integer",
+  "-Wclippy::needless_borrow",
+  "-Wclippy::option_option",
+  "-Wclippy::path_buf_push_overwrite",
+  "-Wclippy::rc_mutex",
+  "-Wclippy::ref_option_ref",
+  "-Wclippy::rest_pat_in_fully_bound_structs",
+  "-Wclippy::same_functions_in_if_condition",
+  "-Wclippy::string_add",
+  "-Wclippy::string_add_assign",
+  "-Wclippy::todo",
+  "-Wclippy::trait_duplication_in_bounds",
+  "-Wclippy::unimplemented",
+  "-Wclippy::unnested_or_patterns",
+  "-Wclippy::useless_transmute",
+  "-Wclippy::verbose_file_reads",
+  "-Wclippy::zero_sized_map_values",
+  "clippy",
+  # The following lints are disabled because they still trigger warnings:
+  # -Wclippy::derive_partial_eq_without_eq (4 warnings)
+  # -Wclippy::doc_markdown                 (826 warnings)
+  # -Wclippy::enum_glob_use               (5 warnings)
+  # -Wclippy::explicit_into_iter_loop     (7 warnings)
+  # -Wclippy::fallible_impl_from          (4 warnings)
+  # -Wclippy::flat_map_option             (1 warning)
+  # -Wclippy::from_iter_instead_of_collect (6 warnings)
+  # -Wclippy::implicit_clone              (2 warnings)
+  # -Wclippy::map_err_ignore              (138 warnings)
+  # -Wclippy::map_unwrap_or               (17 warnings)
+  # -Wclippy::manual_assert               (6 warnings)
+  # -Wclippy::match_same_arms             (16 warnings)
+  # -Wclippy::match_wild_err_arm          (6 warnings)
+  # -Wclippy::match_wildcard_for_single_variants (2 warnings)
+  # -Wclippy::needless_continue           (6 warnings)
+  # -Wclippy::needless_for_each           (10 warnings)
+  # -Wclippy::needless_pass_by_value      (37 warnings)
+  # -Wclippy::ptr_as_ptr                  (12 warnings)
+  # -Wclippy::semicolon_if_nothing_returned (159 warnings)
+  # -Wclippy::single_match_else           (16 warnings)
+  # -Wclippy::string_lit_as_bytes         (1 warning)
+  # -Wclippy::unnecessary_wraps           (9 warnings)
+  # -Wclippy::unused_self                 (8 warnings)
+  # -Wclippy::cast_lossless               (158 warnings)
+]
+
+# Clippy fix with the same lints as xclippy.
+# NOTE: for the `make lint` command to work well, this must contain the same
+# list of lints as the xclippy setting above.
+xclippy-fix = [
+  "--",
+  "--all-features",
+  "--all-targets",
+  "--allow-dirty",
+  "--allow-staged",
+  "--fix",
+  "--workspace",
+  "-Dwarnings",
+  "-Wclippy::all",
+  "-Wclippy::await_holding_lock",
+  "-Wclippy::char_lit_as_u8",
+  "-Wclippy::checked_conversions",
+  "-Wclippy::dbg_macro",
+  "-Wclippy::debug_assert_with_mut_call",
+  "-Wclippy::disallowed_methods",
+  "-Wclippy::empty_enum",
+  "-Wclippy::exit",
+  "-Wclippy::expl_impl_clone_on_copy",
+  "-Wclippy::explicit_deref_methods",
+  "-Wclippy::filter_map_next",
+  "-Wclippy::float_cmp_const",
+  "-Wclippy::fn_params_excessive_bools",
+  "-Wclippy::if_let_mutex",
+  "-Wclippy::imprecise_flops",
+  "-Wclippy::inefficient_to_string",
+  "-Wclippy::invalid_upcast_comparisons",
+  "-Wclippy::large_digit_groups",
+  "-Wclippy::large_stack_arrays",
+  "-Wclippy::large_types_passed_by_value",
+  "-Wclippy::let_unit_value",
+  "-Wclippy::linkedlist",
+  "-Wclippy::lossy_float_literal",
+  "-Wclippy::macro_use_imports",
+  "-Wclippy::manual_ok_or",
+  "-Wclippy::map_flatten",
+  "-Wclippy::mem_forget",
+  "-Wclippy::missing_enforced_import_renames",
+  "-Wclippy::mut_mut",
+  "-Wclippy::mutex_integer",
+  "-Wclippy::needless_borrow",
+  "-Wclippy::option_option",
+  "-Wclippy::path_buf_push_overwrite",
+  "-Wclippy::rc_mutex",
+  "-Wclippy::ref_option_ref",
+  "-Wclippy::rest_pat_in_fully_bound_structs",
+  "-Wclippy::same_functions_in_if_condition",
+  "-Wclippy::string_add",
+  "-Wclippy::string_add_assign",
+  "-Wclippy::todo",
+  "-Wclippy::trait_duplication_in_bounds",
+  "-Wclippy::unimplemented",
+  "-Wclippy::unnested_or_patterns",
+  "-Wclippy::useless_transmute",
+  "-Wclippy::verbose_file_reads",
+  "-Wclippy::zero_sized_map_values",
+  "clippy",
+]

--- a/.taplo.toml
+++ b/.taplo.toml
@@ -1,3 +1,8 @@
+exclude = [
+  # Keep Cargo alias argv order stable; reordering this file breaks `cargo xclippy`.
+  ".cargo/config.toml",
+]
+
 [formatting]
 align_entries         = true
 column_width          = 120

--- a/Makefile
+++ b/Makefile
@@ -12,13 +12,20 @@ WARNINGS=RUSTDOCFLAGS="-D warnings"
 # -- linting --------------------------------------------------------------------------------------
 
 .PHONY: clippy
-clippy: ## Run Clippy with configs
-	cargo clippy --workspace --all-targets --all-features -- -D warnings
+clippy: ## Run Clippy with configs (alias for xclippy)
+	cargo xclippy
 
+.PHONY: xclippy
+xclippy: ## Run Clippy with the curated workspace lint set
+	cargo xclippy
 
 .PHONY: fix
-fix: ## Run Fix with configs
-	cargo +nightly fix --allow-staged --allow-dirty --all-targets --all-features
+fix: ## Run Fix with configs (alias for xclippy-fix)
+	cargo xclippy-fix
+
+.PHONY: xclippy-fix
+xclippy-fix: ## Run Clippy with --fix using the same lint set as xclippy
+	cargo xclippy-fix
 
 
 .PHONY: format
@@ -62,7 +69,7 @@ zeroize-audit: ## Run Zeroize audit using rustdoc JSON
 	cargo run --quiet --manifest-path tools/zeroize-audit/Cargo.toml -- "$$target_dir/doc/miden_crypto.json"
 
 .PHONY: lint
-lint: format fix clippy toml typos-check machete cargo-deny ## Run all linting tasks at once (Clippy, fixing, formatting, machete, cargo-deny)
+lint: clippy fix format toml typos-check machete cargo-deny ## Run all linting tasks at once (Clippy, fixing, formatting, machete, cargo-deny)
 
 # --- docs ----------------------------------------------------------------------------------------
 


### PR DESCRIPTION
Port [the curated xclippy/xclippy-fix workflow from miden-vm](https://github.com/0xMiden/miden-vm/pull/2841) to this workspace.

Enable only the optional Clippy lints that currently pass without code fixes, wire the Make targets and existing lint CI to use that curated set.
