### PR TITLE
feat(SmtForest): Add `add_lineages` batch endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - [BREAKING] Removed `AlgebraicSponge::merge_with_int()` method ([#894](https://github.com/0xMiden/crypto/pull/894)).
 - Added the ability to configure the sync-to-disk behavior of the persistent backend using its config ([#912](https://github.com/0xMiden/crypto/pull/912)).
+- Adds `LargeSmtForest::add_lineages` which provides an efficient means of adding multiple new lineages at once ([#910](https://github.com/0xMiden/crypto/pull/910)).
 
 ## 0.23.0 (2026-03-11)
 

--- a/miden-crypto/benches/large_smt_forest.rs
+++ b/miden-crypto/benches/large_smt_forest.rs
@@ -7,6 +7,7 @@ use std::hint;
 
 use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
 use miden_crypto::{
+    Map,
     merkle::smt::{
         Backend, ForestPersistentBackend, LargeSmtForest, LineageId, PersistentBackendConfig,
         SmtForestUpdateBatch, SmtUpdateBatch, TreeId,
@@ -184,6 +185,105 @@ benchmark_with_setup_data! {
     },
 }
 
+// Roughly equivalent to large_smt::large_smt_get in functionality.
+benchmark_with_setup_data! {
+    large_smt_forest_persistent_get_full_tree,
+    DEFAULT_MEASUREMENT_TIME,
+    DEFAULT_SAMPLE_SIZE,
+    "large_smt_forest_persistent_get_full_tree",
+    || {
+        let mut setup = ForestSetup::new_persistent();
+        let batch = generate_tree_update_batch(BATCH_SIZE);
+        let lineage = LineageId::new([0x42; 32]);
+        let version = 0;
+        setup.forest.add_lineage(lineage, version, batch).unwrap();
+        let keys = generate_test_keys_sequential(10);
+        let tree = TreeId::new(lineage, version);
+        (setup, keys, tree)
+    },
+    |b: &mut criterion::Bencher, (setup, keys, tree): &(ForestSetup<_>, Vec<Word>, TreeId)| {
+        b.iter(|| {
+            for key in keys {
+                hint::black_box(setup.forest.get(*tree, *key).unwrap());
+            }
+        })
+    }
+}
+
+// Benchmarks `get` on a historical tree version.
+benchmark_with_setup_data! {
+    large_smt_forest_persistent_get_historical_tree,
+    DEFAULT_MEASUREMENT_TIME,
+    DEFAULT_SAMPLE_SIZE,
+    "large_smt_forest_persistent_get_historical_tree",
+    || {
+        let mut setup = ForestSetup::new_persistent();
+        let initial_batch = generate_tree_update_batch(BATCH_SIZE);
+        let lineage = LineageId::new([0x42; 32]);
+        let version = 0;
+        setup.forest.add_lineage(lineage, version, initial_batch).unwrap();
+        let update_batch = generate_tree_update_batch(BATCH_SIZE);
+        setup.forest.update_tree(lineage, 1, update_batch).unwrap();
+
+        let keys = generate_test_keys_sequential(10);
+        let tree = TreeId::new(lineage, version);
+        (setup, keys, tree)
+    },
+    |b: &mut criterion::Bencher, (setup, keys, tree): &(ForestSetup<_>, Vec<Word>, TreeId)| {
+        b.iter(|| {
+            for key in keys {
+                hint::black_box(setup.forest.get(*tree, *key).unwrap());
+            }
+        })
+    },
+}
+
+// Measures `entry_count` on the latest version of a tree.
+benchmark_with_setup_data! {
+    large_smt_forest_persistent_entry_count_current_tree,
+    DEFAULT_MEASUREMENT_TIME,
+    DEFAULT_SAMPLE_SIZE,
+    "large_smt_forest_persistent_entry_count_current_tree",
+    || {
+        let mut setup = ForestSetup::new_persistent();
+        let batch = generate_tree_update_batch(BATCH_SIZE);
+        let lineage = LineageId::new([0x42; 32]);
+        let version = 0;
+        setup.forest.add_lineage(lineage, version, batch).unwrap();
+        let tree = TreeId::new(lineage, version);
+        (setup, tree)
+    },
+    |b: &mut criterion::Bencher, (setup, tree): &(ForestSetup<_>, TreeId)| {
+        b.iter(|| {
+            hint::black_box(setup.forest.entry_count(*tree).unwrap());
+        })
+    }
+}
+
+// Measures `entry_count` on a historical version of a tree.
+benchmark_with_setup_data! {
+    large_smt_forest_persistent_entry_count_historical_tree,
+    DEFAULT_MEASUREMENT_TIME,
+    DEFAULT_SAMPLE_SIZE,
+    "large_smt_forest_persistent_entry_count_historical_tree",
+    || {
+        let mut setup = ForestSetup::new_persistent();
+        let initial_batch = generate_tree_update_batch(BATCH_SIZE);
+        let lineage = LineageId::new([0x42; 32]);
+        let version = 0;
+        setup.forest.add_lineage(lineage, version, initial_batch).unwrap();
+        let update_batch = generate_tree_update_batch(BATCH_SIZE);
+        setup.forest.update_tree(lineage, version + 1, update_batch).unwrap();
+        let tree = TreeId::new(lineage, version);
+        (setup, tree)
+    },
+    |b: &mut criterion::Bencher, (setup, tree): &(ForestSetup<_>, TreeId)| {
+        b.iter(|| {
+            hint::black_box(setup.forest.entry_count(*tree).unwrap());
+        })
+    },
+}
+
 // Roughly equivalent to large_smt::large_smt_insert_batch_to_empty_tree in functionality.
 benchmark_batch! {
     large_smt_forest_persistent_add_lineage,
@@ -232,7 +332,59 @@ benchmark_batch! {
     |size| Some(criterion::Throughput::Elements(size as u64))
 }
 
-// Has no direct equivalent in the large smt, but should be broadly equivalent workwise to the
+// Benchmarks the addition of multiple lineages in a single batch through repeated calls to
+// `add_lineage` and thereby provides a point of comparison for the actual parallel `add_lineage`
+// implementation.
+benchmark_batch! {
+    large_smt_forest_persistent_add_lineages_sequential,
+    &[10, 100, 1000],
+    |b: &mut criterion::Bencher, lineage_count: usize| {
+        let lineages = generate_lineages(lineage_count);
+
+        b.iter_batched(
+            || {
+                let setup = ForestSetup::new_persistent();
+                let batch = generate_forest_update_batch(&lineages, BATCH_SIZE)
+                    .consume()
+                    .into_iter()
+                    .map(|(l, b)| (l, SmtUpdateBatch::new(b.into_iter())))
+                    .collect::<Map<_, _>>();
+                (setup, batch)
+            },
+            |(mut setup, batches)| {
+                for (lineage, batch) in batches {
+                    hint::black_box(setup.forest.add_lineage(lineage, 0, batch).unwrap());
+                }
+            },
+            BatchSize::LargeInput
+        )
+    },
+    |size| Some(criterion::Throughput::Elements(size as u64))
+}
+
+// Benchmarks the addition of multiple lineages in a single batch.
+benchmark_batch! {
+    large_smt_forest_persistent_add_lineages,
+    &[10, 100, 1000],
+    |b: &mut criterion::Bencher, lineage_count: usize| {
+        let lineages = generate_lineages(lineage_count);
+
+        b.iter_batched(
+            || {
+                let setup = ForestSetup::new_persistent();
+                let batch = generate_forest_update_batch(&lineages, BATCH_SIZE);
+                (setup, batch)
+            },
+            |(mut setup, batch)| {
+                hint::black_box(setup.forest.add_lineages(0, batch).unwrap())
+            },
+            BatchSize::LargeInput
+        )
+    },
+    |size| Some(criterion::Throughput::Elements(size as u64))
+}
+
+// Has no direct equivalent in the large smt, but should be broadly equivalent work-wise to the
 // large_smt_forest_persistent_update_tree above in time as we try and do as much in parallel as
 // possible.
 benchmark_batch! {
@@ -270,9 +422,15 @@ criterion_group!(
     large_smt_forest_persistent_group,
     large_smt_forest_persistent_open_full_tree,
     large_smt_forest_persistent_open_historical_tree,
+    large_smt_forest_persistent_get_full_tree,
+    large_smt_forest_persistent_get_historical_tree,
+    large_smt_forest_persistent_entry_count_current_tree,
+    large_smt_forest_persistent_entry_count_historical_tree,
     large_smt_forest_persistent_entries_current_tree,
     large_smt_forest_persistent_entries_historical_tree,
     large_smt_forest_persistent_add_lineage,
+    large_smt_forest_persistent_add_lineages_sequential,
+    large_smt_forest_persistent_add_lineages,
     large_smt_forest_persistent_update_tree,
     large_smt_forest_persistent_update_forest,
 );

--- a/miden-crypto/src/merkle/smt/large_forest/backend/memory/mod.rs
+++ b/miden-crypto/src/merkle/smt/large_forest/backend/memory/mod.rs
@@ -47,7 +47,7 @@ impl Backend for InMemoryBackend {
     ///
     /// # Errors
     ///
-    /// - [`BackendError::UnknownLineage`] If the provided `lineage` is one not known by this
+    /// - [`BackendError::UnknownLineage`] if the provided `lineage` is one not known by this
     ///   backend.
     fn open(&self, lineage: LineageId, key: Word) -> Result<SmtProof> {
         let tree = self.trees.get(&lineage).ok_or(BackendError::UnknownLineage(lineage))?;
@@ -203,6 +203,70 @@ impl Backend for InMemoryBackend {
         tree_data.version = new_version;
 
         Ok(reversion_set)
+    }
+
+    /// Adds multiple new `lineages` to the tree, creating an empty tree for each and applying the
+    /// provided modifications to it, with the result being given the specified `version`.
+    ///
+    /// If the provide batch of modifications is empty for any given lineage, then the **empty tree
+    /// will be added** as the first version in that lineage.
+    ///
+    /// # Errors
+    ///
+    /// - [`BackendError::DuplicateLineage`] if any provided lineage conflicts with an already-known
+    ///   lineage. No data is changed in this case.
+    /// - [`BackendError::Merkle`] if any of the provided updates cannot be applied on top of the
+    ///   empty tree.
+    fn add_lineages(
+        &mut self,
+        version: VersionId,
+        lineages: SmtForestUpdateBatch,
+    ) -> Result<Vec<(LineageId, TreeWithRoot)>> {
+        // We start by checking that all lineages referred to in the batch of `updates` are valid,
+        // failing early with an error if need be.
+        let updates = lineages
+            .into_iter()
+            .map(|(lineage, ops)| {
+                if self.trees.contains_key(&lineage) {
+                    return Err(BackendError::DuplicateLineage(lineage));
+                }
+                Ok((lineage, ops))
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        // Next, we compute all the relevant mutations to each tree, also failing with an error
+        // where relevant.
+        let mutations = updates
+            .into_iter()
+            .map(|(lineage, ops)| {
+                let tree = Smt::new();
+                let mutations = tree.compute_mutations(ops.into_iter().map(|o| o.into()))?;
+                Ok((lineage, tree, mutations))
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        // With the preconditions checked, we can unconditionally perform the changes on all trees.
+        // We apply all mutations first without modifying self.trees, so that if any mutation
+        // fails, no data is changed.
+        let applied = mutations
+            .into_iter()
+            .map(|(lineage, mut tree, mutations)| {
+                tree.apply_mutations(mutations).map_err(BackendError::internal_from)?;
+                Ok((lineage, tree))
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        // Once they have all succeeded, we then modify the data in memory.
+        let results = applied
+            .into_iter()
+            .map(|(lineage, tree)| {
+                let root = tree.root();
+                self.trees.insert(lineage, TreeData { version, tree });
+                (lineage, TreeWithRoot::new(lineage, version, root))
+            })
+            .collect::<Vec<_>>();
+
+        Ok(results)
     }
 
     /// Performs the provided `updates` on the entire forest, returning the mutation sets that would

--- a/miden-crypto/src/merkle/smt/large_forest/backend/memory/property_tests.rs
+++ b/miden-crypto/src/merkle/smt/large_forest/backend/memory/property_tests.rs
@@ -264,6 +264,46 @@ proptest! {
     }
 
     #[test]
+    fn add_lineages_correct(
+        lineages in prop::collection::vec(arbitrary_lineage(), 0..30),
+        version in arbitrary_version(),
+        entries in prop::collection::vec(arbitrary_batch(), 0..30),
+    ) {
+        let mut backend = InMemoryBackend::new();
+        let pairs = lineages.into_iter().unique().zip(entries).collect_vec();
+        let mut batch = SmtForestUpdateBatch::empty();
+        for (lineage, entries) in &pairs {
+            *batch.operations(*lineage) = entries.clone();
+        }
+
+        // Add all lineages in one call.
+        let results = backend.add_lineages(version, batch).map_err(to_fail)?;
+
+        // Verify each result against a reference tree.
+        for (lineage, entries) in &pairs {
+            let mut tree = Smt::new();
+            let tree_mutations =
+                tree.compute_mutations(Vec::from(entries.clone()).into_iter()).map_err(to_fail)?;
+            tree.apply_mutations(tree_mutations).map_err(to_fail)?;
+
+            let (_, result) = results.iter().find(|(l, _)| l == lineage).unwrap();
+            prop_assert_eq!(result.root(), tree.root());
+            prop_assert_eq!(result.version(), version);
+            prop_assert_eq!(result.lineage(), *lineage);
+
+            // Verify cross-lineage gets.
+            for op in entries.clone().into_iter() {
+                let (key, value) = op.into();
+                let backend_value = backend.get(*lineage, key).map_err(to_fail)?;
+                let expected = if value == EMPTY_WORD { None } else { Some(value) };
+                prop_assert_eq!(backend_value, expected);
+            }
+        }
+
+        prop_assert_eq!(backend.lineages().map_err(to_fail)?.count(), pairs.len());
+    }
+
+    #[test]
     fn update_lineage_correct(
         lineage_1 in arbitrary_lineage(),
         lineage_2 in arbitrary_lineage(),

--- a/miden-crypto/src/merkle/smt/large_forest/backend/memory/tests.rs
+++ b/miden-crypto/src/merkle/smt/large_forest/backend/memory/tests.rs
@@ -437,6 +437,130 @@ fn add_lineage() -> Result<()> {
 }
 
 #[test]
+fn add_lineages() -> Result<()> {
+    let mut backend = InMemoryBackend::new();
+    let mut rng = ContinuousRng::new([0xa1; 32]);
+
+    // An empty batch should return an empty result and leave the backend unchanged.
+    let version: VersionId = rng.value();
+    let result = backend.add_lineages(version, SmtForestUpdateBatch::empty())?;
+    assert!(result.is_empty());
+    assert_eq!(backend.lineages()?.count(), 0);
+    assert_eq!(backend.trees()?.count(), 0);
+
+    // A single lineage with two inserts should work correctly.
+    let lineage_1: LineageId = rng.value();
+    let key_1_1: Word = rng.value();
+    let value_1_1: Word = rng.value();
+    let key_1_2: Word = rng.value();
+    let value_1_2: Word = rng.value();
+
+    let mut batch = SmtForestUpdateBatch::empty();
+    batch.operations(lineage_1).add_insert(key_1_1, value_1_1);
+    batch.operations(lineage_1).add_insert(key_1_2, value_1_2);
+
+    let result = backend.add_lineages(version, batch)?;
+    assert_eq!(result.len(), 1);
+
+    let mut ref_tree_1 = Smt::new();
+    ref_tree_1.insert(key_1_1, value_1_1)?;
+    ref_tree_1.insert(key_1_2, value_1_2)?;
+
+    assert_eq!(result[0].1.root(), ref_tree_1.root());
+    assert_eq!(backend.get(lineage_1, key_1_1)?, Some(value_1_1));
+    assert_eq!(backend.get(lineage_1, key_1_2)?, Some(value_1_2));
+
+    // Reset backend for multi-lineage test.
+    let mut backend = InMemoryBackend::new();
+
+    let lineage_a: LineageId = rng.value();
+    let lineage_b: LineageId = rng.value();
+    let lineage_c: LineageId = rng.value();
+
+    let key_a_1: Word = rng.value();
+    let value_a_1: Word = rng.value();
+    let key_a_2: Word = rng.value();
+    let value_a_2: Word = rng.value();
+    let key_b_1: Word = rng.value();
+    let value_b_1: Word = rng.value();
+    let key_b_2: Word = rng.value();
+    let value_b_2: Word = rng.value();
+    let key_c_1: Word = rng.value();
+    let value_c_1: Word = rng.value();
+    let key_c_2: Word = rng.value();
+    let value_c_2: Word = rng.value();
+
+    let mut batch = SmtForestUpdateBatch::empty();
+    batch.operations(lineage_a).add_insert(key_a_1, value_a_1);
+    batch.operations(lineage_a).add_insert(key_a_2, value_a_2);
+    batch.operations(lineage_b).add_insert(key_b_1, value_b_1);
+    batch.operations(lineage_b).add_insert(key_b_2, value_b_2);
+    batch.operations(lineage_c).add_insert(key_c_1, value_c_1);
+    batch.operations(lineage_c).add_insert(key_c_2, value_c_2);
+
+    let result = backend.add_lineages(version, batch)?;
+    assert_eq!(result.len(), 3);
+
+    // Build reference trees and verify roots.
+    let mut ref_a = Smt::new();
+    ref_a.insert(key_a_1, value_a_1)?;
+    ref_a.insert(key_a_2, value_a_2)?;
+
+    let mut ref_b = Smt::new();
+    ref_b.insert(key_b_1, value_b_1)?;
+    ref_b.insert(key_b_2, value_b_2)?;
+
+    let mut ref_c = Smt::new();
+    ref_c.insert(key_c_1, value_c_1)?;
+    ref_c.insert(key_c_2, value_c_2)?;
+
+    // Find each lineage in the results and check the root.
+    let root_a = result.iter().find(|(l, _)| *l == lineage_a).unwrap().1.root();
+    let root_b = result.iter().find(|(l, _)| *l == lineage_b).unwrap().1.root();
+    let root_c = result.iter().find(|(l, _)| *l == lineage_c).unwrap().1.root();
+    assert_eq!(root_a, ref_a.root());
+    assert_eq!(root_b, ref_b.root());
+    assert_eq!(root_c, ref_c.root());
+    assert_eq!(backend.lineages()?.count(), 3);
+
+    // Cross-lineage gets should work correctly.
+    assert_eq!(backend.get(lineage_a, key_a_1)?, Some(value_a_1));
+    assert_eq!(backend.get(lineage_b, key_b_2)?, Some(value_b_2));
+    assert_eq!(backend.get(lineage_c, key_c_1)?, Some(value_c_1));
+
+    // Verify gets spanning all three lineages.
+    assert_eq!(backend.get(lineage_a, key_a_1)?, Some(value_a_1));
+    assert_eq!(backend.get(lineage_b, key_b_1)?, Some(value_b_1));
+    assert_eq!(backend.get(lineage_c, key_c_2)?, Some(value_c_2));
+
+    // Duplicate lineage error and atomicity: pre-add one lineage, then try a batch containing it.
+    let mut backend = InMemoryBackend::new();
+    let existing_lineage: LineageId = rng.value();
+    let new_lineage: LineageId = rng.value();
+
+    let mut ops = SmtUpdateBatch::default();
+    ops.add_insert(rng.value(), rng.value());
+    backend.add_lineage(existing_lineage, version, ops)?;
+    let backend_before = backend.clone();
+
+    let mut batch = SmtForestUpdateBatch::empty();
+    batch.operations(existing_lineage).add_insert(rng.value(), rng.value());
+    batch.operations(new_lineage).add_insert(rng.value(), rng.value());
+
+    let result = backend.add_lineages(version, batch);
+    assert!(result.is_err());
+    assert_matches!(
+        result.unwrap_err(),
+        BackendError::DuplicateLineage(l) if l == existing_lineage
+    );
+
+    // Backend state should be unchanged (atomicity).
+    assert_eq!(backend, backend_before);
+
+    Ok(())
+}
+
+#[test]
 fn update_tree() -> Result<()> {
     let mut backend = InMemoryBackend::new();
     let mut rng = ContinuousRng::new([0x76; 32]);

--- a/miden-crypto/src/merkle/smt/large_forest/backend/mod.rs
+++ b/miden-crypto/src/merkle/smt/large_forest/backend/mod.rs
@@ -173,6 +173,22 @@ where
     // MULTI-TREE MODIFIERS
     // ============================================================================================
 
+    /// Adds multiple new `lineages` to the backend with the provided `version` and sets the
+    /// associated SMTs to have the value created by applying the provided updates to the empty
+    /// tree, returning the new root of that tree.
+    ///
+    /// # Expected Behavior
+    ///
+    /// Implementations must guarantee the following behavior in addition to the global invariants:
+    ///
+    /// - If any provided lineage conflicts with an already-existing lineage in the backend, it must
+    ///   return [`BackendError::DuplicateLineage`].
+    fn add_lineages(
+        &mut self,
+        version: VersionId,
+        lineages: SmtForestUpdateBatch,
+    ) -> Result<Vec<(LineageId, TreeWithRoot)>>;
+
     /// Performs the provided `updates` on the forest, setting all new tree states to have the
     /// provided `new_version` and returning a vector of the mutation sets that reverse the changes
     /// to each changed tree.

--- a/miden-crypto/src/merkle/smt/large_forest/backend/persistent/keys.rs
+++ b/miden-crypto/src/merkle/smt/large_forest/backend/persistent/keys.rs
@@ -12,7 +12,7 @@ use crate::merkle::{NodeIndex, smt::LineageId};
 // ================================================================================================
 
 /// A key that uniquely identifies a leaf in the database.
-#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
 pub struct LeafKey {
     /// The lineage (and hence tree) to which the leaf belongs.
     pub lineage: LineageId,
@@ -45,7 +45,7 @@ impl Deserializable for LeafKey {
 // ================================================================================================
 
 /// A key that uniquely identifies a subtree in the database.
-#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Deserialize, Serialize)]
 pub struct SubtreeKey {
     /// The lineage (and hence tree) to which the subtree belongs.
     pub lineage: LineageId,

--- a/miden-crypto/src/merkle/smt/large_forest/backend/persistent/mod.rs
+++ b/miden-crypto/src/merkle/smt/large_forest/backend/persistent/mod.rs
@@ -142,6 +142,9 @@ const L0_FILE_COMPACTION_TRIGGER: c_int = 8;
 /// combine their batches in parallel.
 const MIN_LINEAGES_IN_BATCH_TO_PARALLELIZE: usize = 5;
 
+/// The minimum number of items per rayon chunk when parallelizing deserialization and extraction.
+const CHUNKING_UNIT: usize = 100;
+
 // PERSISTENT BACKEND
 // ================================================================================================
 
@@ -225,7 +228,7 @@ impl Backend for PersistentBackend {
 
         // We then have to load both the corresponding leaf, and the siblings for its path out of
         // storage.
-        let mut leaf_index: NodeIndex = LeafIndex::from(key).into();
+        let leaf_index: NodeIndex = LeafIndex::from(key).into();
 
         // We calculate the roots of the subtrees in order to know their keys for loading. As an
         // opening only ever needs to retrieve 8 subtrees we just do this sequentially.
@@ -246,25 +249,7 @@ impl Backend for PersistentBackend {
             subtree_cache.insert(root, maybe_tree.unwrap_or_else(|| Subtree::new(root)));
         }
 
-        // Now we can read the necessary path from the cached subtree roots.
-        let mut path = Vec::with_capacity(SMT_DEPTH as usize);
-
-        while leaf_index.depth() > 0 {
-            let is_right = leaf_index.is_position_odd();
-            leaf_index = leaf_index.parent();
-
-            let root = Subtree::find_subtree_root(leaf_index);
-            let subtree = &subtree_cache[&root]; // Known to exist by construction.
-            let InnerNode { left, right } =
-                subtree.get_inner_node(leaf_index).unwrap_or_else(|| {
-                    EmptySubtreeRoots::get_inner_node(SMT_DEPTH, leaf_index.depth())
-                });
-
-            path.push(if is_right { left } else { right });
-        }
-
-        let merkle_path =
-            SparseMerklePath::from_sized_iter(path).expect("Always succeeds by construction");
+        let merkle_path = self.compute_path(leaf_index, &subtree_cache);
 
         // This is safe to do unchecked as we ensure that the path is valid by construction.
         Ok(SmtProof::new_unchecked(merkle_path, leaf))
@@ -475,6 +460,105 @@ impl Backend for PersistentBackend {
         Ok(reversion_set)
     }
 
+    /// Adds multiple new `lineages` to the tree, creating an empty tree for each and applying the
+    /// provided modifications to it, with the result being given the specified `version`.
+    ///
+    /// If the provide batch of modifications is empty for any given lineage, then the **empty tree
+    /// will be added** as the first version in that lineage.
+    ///
+    /// # Errors
+    ///
+    /// - [`BackendError::DuplicateLineage`] if any of the provided lineages already exists in the
+    ///   backend.
+    /// - [`BackendError::Internal`] if the database cannot be accessed at any point.
+    /// - [`BackendError::Merkle`] if an error occurs with the merkle tree semantics.
+    fn add_lineages(
+        &mut self,
+        version: VersionId,
+        lineages: SmtForestUpdateBatch,
+    ) -> Result<Vec<(LineageId, TreeWithRoot)>> {
+        // We start by checking that none of the lineages already exist, as we are expected by
+        // contract to error if any is a duplicate.
+        let updates = lineages
+            .into_iter()
+            .map(|(lineage, ops)| {
+                if self.lineages.contains_key(&lineage) {
+                    return Err(BackendError::DuplicateLineage(lineage));
+                }
+                Ok((lineage, ops))
+            })
+            .collect::<Result<Vec<_>>>()?;
+        let lineage_count = updates.len();
+
+        // If we have no lineages, then we can exit early.
+        if updates.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        // Build the initial metadata and set up empty write batches for each new lineage
+        let updates_with_batch = updates
+            .into_iter()
+            .map(|(lineage, ops)| {
+                let new_meta = TreeMetadata {
+                    version,
+                    root_value: *EmptySubtreeRoots::entry(SMT_DEPTH, 0),
+                    entry_count: 0,
+                };
+                let batch = WriteBatch::default();
+                (lineage, ops, new_meta, batch)
+            })
+            .collect::<Vec<_>>();
+
+        // Process lineages in parallel, updating each tree in its own write batch
+        let lineage_data = updates_with_batch
+            .into_par_iter()
+            .map(|(lineage, ops, new_meta, batch)| {
+                let ops = ops.into_iter().map(|op| op.into()).collect();
+                let (batch, reversion, tree_data) =
+                    self.update_tree_in_write_batch(batch, lineage, new_meta, version, ops)?;
+                let batch = self.write_metadata(batch, lineage, &tree_data)?;
+                let root = tree_data.root_value;
+
+                Ok((batch, (lineage, tree_data, reversion), (lineage, root)))
+            })
+            .collect::<Result<Vec<_>>>()?;
+        let (batches, mutation_sets, roots): (Vec<_>, Vec<_>, Vec<_>) =
+            lineage_data.into_iter().fold(
+                (
+                    Vec::with_capacity(lineage_count),
+                    Vec::with_capacity(lineage_count),
+                    Vec::with_capacity(lineage_count),
+                ),
+                |(mut bs, mut ms, mut rs), (b, m, r)| {
+                    bs.push(b);
+                    ms.push(m);
+                    rs.push(r);
+                    (bs, ms, rs)
+                },
+            );
+
+        // Merge all the write batches into one atomic batch
+        let final_batch = if lineage_count > MIN_LINEAGES_IN_BATCH_TO_PARALLELIZE {
+            batches
+                .into_par_iter()
+                .fold(WriteBatch::new, |l, r| merge_batches(l, &r))
+                .reduce(WriteBatch::new, |l, r| merge_batches(l, &r))
+        } else {
+            batches.into_iter().fold(WriteBatch::new(), |l, r| merge_batches(l, &r))
+        };
+
+        // Atomically write to disk and update in-memory cache.
+        self.finalize_update(final_batch, mutation_sets.into_iter())?;
+
+        // Build the return value from the captured roots.
+        let results = roots
+            .into_iter()
+            .map(|(lineage, root)| (lineage, TreeWithRoot::new(lineage, version, root)))
+            .collect();
+
+        Ok(results)
+    }
+
     /// Performs the provided `updates` on the entire forest, returning the mutation sets that would
     /// reverse the changes to each lineage in the forest.
     ///
@@ -562,6 +646,32 @@ impl Backend for PersistentBackend {
 /// This block contains methods for internal use only that provide useful functionality for the
 /// implementation of the backend.
 impl PersistentBackend {
+    /// Computes the merkle path for the provided `lineage` beginning at the provided `leaf_index`
+    /// using the pre-loaded `subtrees`.
+    fn compute_path(
+        &self,
+        mut leaf_index: NodeIndex,
+        subtrees: &HashMap<NodeIndex, Subtree>,
+    ) -> SparseMerklePath {
+        let mut path = Vec::with_capacity(SMT_DEPTH as usize);
+
+        while leaf_index.depth() > 0 {
+            let is_right = leaf_index.is_position_odd();
+            leaf_index = leaf_index.parent();
+
+            let root = Subtree::find_subtree_root(leaf_index);
+            let subtree = &subtrees[&root]; // Known to exist by construction.
+            let InnerNode { left, right } =
+                subtree.get_inner_node(leaf_index).unwrap_or_else(|| {
+                    EmptySubtreeRoots::get_inner_node(SMT_DEPTH, leaf_index.depth())
+                });
+
+            path.push(if is_right { left } else { right });
+        }
+
+        SparseMerklePath::from_sized_iter(path).expect("Always succeeds by construction")
+    }
+
     /// Performs `updates` on the tree in the specified lineage, assigning the new tree the
     /// provided `new_version`.
     ///
@@ -585,9 +695,15 @@ impl PersistentBackend {
         // of various other operations.
         updates.sort_by_key(|(k, _)| LeafIndex::from(*k).position());
 
-        // We then have to load the leaves that correspond to these pairs from storage.
-        let leaf_map = self
-            .get_leaves_for_keys(lineage, &updates.iter().map(|(k, _)| *k).collect::<Vec<_>>())?;
+        // We then have to load the leaves that correspond to these pairs from storage. If the tree
+        // is known to be empty (entry_count == 0), we skip the disk read entirely as all leaves
+        // are guaranteed to not exist. This is primarily an optimization for the case of adding
+        // new trees.
+        let leaf_map = if tree_metadata.entry_count == 0 {
+            HashMap::new()
+        } else {
+            self.get_leaves_for_keys(lineage, &updates.iter().map(|(k, _)| *k).collect::<Vec<_>>())?
+        };
 
         // We then process the leaves in parallel to determine the mutations that we need to apply
         // to the full tree.
@@ -1086,15 +1202,43 @@ impl PersistentBackend {
     ///
     /// - [`BackendError::Internal`] if the data cannot be loaded from the database.
     fn load_leaves(&self, lineage: LineageId, indices: &[u64]) -> Result<Vec<Option<SmtLeaf>>> {
-        let col = self.cf(LEAVES_CF)?;
         let keys = indices
             .iter()
-            .map(|index| LeafKey { lineage, index: *index }.to_bytes())
-            .collect::<Vec<Vec<_>>>();
-        let leaves = self.db.multi_get_cf(keys.iter().map(|k| (col, k.as_slice())));
+            .map(|index| LeafKey { lineage, index: *index })
+            .collect::<Vec<_>>();
+
+        self.load_leaves_direct(keys.iter())
+    }
+
+    /// Loads the concrete leaves from disk corresponding to the provided `keys`.
+    ///
+    /// # Errors
+    ///
+    /// - [`BackendError::Internal`] if the data cannot be loaded from the database.
+    fn load_leaves_direct<'b>(
+        &self,
+        keys: impl Iterator<Item = &'b LeafKey>,
+    ) -> Result<Vec<Option<SmtLeaf>>> {
+        let bytes = keys.map(|k| k.to_bytes()).collect::<Vec<_>>();
+        self.load_leaves_raw(bytes.iter())
+    }
+
+    /// Loads the concrete leaves from disk corresponding to the provided `keys`.
+    ///
+    /// # Errors
+    ///
+    /// - [`BackendError::Internal`] if the data cannot be loaded from the database.
+    #[inline(always)]
+    fn load_leaves_raw<'b>(
+        &self,
+        key_bytes: impl Iterator<Item = &'b Vec<u8>>,
+    ) -> Result<Vec<Option<SmtLeaf>>> {
+        let col = self.cf(LEAVES_CF)?;
+        let leaves = self.db.multi_get_cf(key_bytes.map(|k| (col, k.as_slice())));
 
         leaves
-            .into_iter()
+            .into_par_iter()
+            .with_min_len(CHUNKING_UNIT)
             .map(|result| match result {
                 Ok(Some(bytes)) => {
                     Ok(Some(SmtLeaf::read_from_bytes_with_budget(&bytes, bytes.len())?))
@@ -1129,7 +1273,17 @@ impl PersistentBackend {
     /// - [`BackendError::Internal`] if the database cannot be accessed to get the column family.
     #[inline(always)]
     fn subtree_cf(&self, index: NodeIndex) -> Result<&db::ColumnFamily> {
-        let cf_name = subtree_cf_name(index.depth());
+        self.subtree_cf_depth(index.depth())
+    }
+
+    /// Gets the column family corresponding to the subtree with root index `index`.
+    ///
+    /// # Errors
+    ///
+    /// - [`BackendError::Internal`] if the database cannot be accessed to get the column family.
+    #[inline(always)]
+    fn subtree_cf_depth(&self, depth: u8) -> Result<&db::ColumnFamily> {
+        let cf_name = subtree_cf_name(depth);
         self.cf(cf_name)
     }
 

--- a/miden-crypto/src/merkle/smt/large_forest/backend/persistent/property_tests.rs
+++ b/miden-crypto/src/merkle/smt/large_forest/backend/persistent/property_tests.rs
@@ -54,6 +54,7 @@ proptest! {
         }
     }
 
+
     #[test]
     fn get_correct(
         lineage in arbitrary_lineage(),

--- a/miden-crypto/src/merkle/smt/large_forest/backend/persistent/tests.rs
+++ b/miden-crypto/src/merkle/smt/large_forest/backend/persistent/tests.rs
@@ -620,6 +620,130 @@ fn update_tree() -> Result<()> {
 }
 
 #[test]
+fn add_lineages() -> Result<()> {
+    let (_file, mut backend) = default_backend()?;
+    let mut rng = ContinuousRng::new([0xa1; 32]);
+
+    // An empty batch should return an empty result and leave the backend unchanged.
+    let version: VersionId = rng.value();
+    let result = backend.add_lineages(version, SmtForestUpdateBatch::empty())?;
+    assert!(result.is_empty());
+    assert_eq!(backend.lineages()?.count(), 0);
+    assert_eq!(backend.trees()?.count(), 0);
+
+    // A single lineage with two inserts should work correctly.
+    let lineage_1: LineageId = rng.value();
+    let key_1_1: Word = rng.value();
+    let value_1_1: Word = rng.value();
+    let key_1_2: Word = rng.value();
+    let value_1_2: Word = rng.value();
+
+    let mut batch = SmtForestUpdateBatch::empty();
+    batch.operations(lineage_1).add_insert(key_1_1, value_1_1);
+    batch.operations(lineage_1).add_insert(key_1_2, value_1_2);
+
+    let result = backend.add_lineages(version, batch)?;
+    assert_eq!(result.len(), 1);
+
+    let mut ref_tree_1 = Smt::new();
+    ref_tree_1.insert(key_1_1, value_1_1)?;
+    ref_tree_1.insert(key_1_2, value_1_2)?;
+
+    assert_eq!(result[0].1.root(), ref_tree_1.root());
+    assert_eq!(backend.get(lineage_1, key_1_1)?, Some(value_1_1));
+    assert_eq!(backend.get(lineage_1, key_1_2)?, Some(value_1_2));
+
+    // Multi-lineage test with a fresh backend.
+    let (_file2, mut backend) = default_backend()?;
+
+    let lineage_a: LineageId = rng.value();
+    let lineage_b: LineageId = rng.value();
+    let lineage_c: LineageId = rng.value();
+
+    let key_a_1: Word = rng.value();
+    let value_a_1: Word = rng.value();
+    let key_a_2: Word = rng.value();
+    let value_a_2: Word = rng.value();
+    let key_b_1: Word = rng.value();
+    let value_b_1: Word = rng.value();
+    let key_b_2: Word = rng.value();
+    let value_b_2: Word = rng.value();
+    let key_c_1: Word = rng.value();
+    let value_c_1: Word = rng.value();
+    let key_c_2: Word = rng.value();
+    let value_c_2: Word = rng.value();
+
+    let mut batch = SmtForestUpdateBatch::empty();
+    batch.operations(lineage_a).add_insert(key_a_1, value_a_1);
+    batch.operations(lineage_a).add_insert(key_a_2, value_a_2);
+    batch.operations(lineage_b).add_insert(key_b_1, value_b_1);
+    batch.operations(lineage_b).add_insert(key_b_2, value_b_2);
+    batch.operations(lineage_c).add_insert(key_c_1, value_c_1);
+    batch.operations(lineage_c).add_insert(key_c_2, value_c_2);
+
+    let result = backend.add_lineages(version, batch)?;
+    assert_eq!(result.len(), 3);
+
+    // Build reference trees and verify roots.
+    let mut ref_a = Smt::new();
+    ref_a.insert(key_a_1, value_a_1)?;
+    ref_a.insert(key_a_2, value_a_2)?;
+
+    let mut ref_b = Smt::new();
+    ref_b.insert(key_b_1, value_b_1)?;
+    ref_b.insert(key_b_2, value_b_2)?;
+
+    let mut ref_c = Smt::new();
+    ref_c.insert(key_c_1, value_c_1)?;
+    ref_c.insert(key_c_2, value_c_2)?;
+
+    let root_a = result.iter().find(|(l, _)| *l == lineage_a).unwrap().1.root();
+    let root_b = result.iter().find(|(l, _)| *l == lineage_b).unwrap().1.root();
+    let root_c = result.iter().find(|(l, _)| *l == lineage_c).unwrap().1.root();
+    assert_eq!(root_a, ref_a.root());
+    assert_eq!(root_b, ref_b.root());
+    assert_eq!(root_c, ref_c.root());
+    assert_eq!(backend.lineages()?.count(), 3);
+
+    // Cross-lineage gets should work correctly.
+    assert_eq!(backend.get(lineage_a, key_a_1)?, Some(value_a_1));
+    assert_eq!(backend.get(lineage_b, key_b_2)?, Some(value_b_2));
+    assert_eq!(backend.get(lineage_c, key_c_1)?, Some(value_c_1));
+
+    // Verify gets spanning all three lineages.
+    assert_eq!(backend.get(lineage_a, key_a_1)?, Some(value_a_1));
+    assert_eq!(backend.get(lineage_b, key_b_1)?, Some(value_b_1));
+    assert_eq!(backend.get(lineage_c, key_c_2)?, Some(value_c_2));
+
+    // Duplicate lineage error: pre-add one lineage, then try a batch containing it.
+    let (_file3, mut backend) = default_backend()?;
+    let existing_lineage: LineageId = rng.value();
+    let new_lineage: LineageId = rng.value();
+
+    let mut ops = SmtUpdateBatch::default();
+    ops.add_insert(rng.value(), rng.value());
+    backend.add_lineage(existing_lineage, version, ops)?;
+
+    let lineage_count_before = backend.lineages()?.count();
+
+    let mut batch = SmtForestUpdateBatch::empty();
+    batch.operations(existing_lineage).add_insert(rng.value(), rng.value());
+    batch.operations(new_lineage).add_insert(rng.value(), rng.value());
+
+    let result = backend.add_lineages(version, batch);
+    assert!(result.is_err());
+    assert_matches!(
+        result.unwrap_err(),
+        BackendError::DuplicateLineage(l) if l == existing_lineage
+    );
+
+    // Backend state should be unchanged (atomicity).
+    assert_eq!(backend.lineages()?.count(), lineage_count_before);
+
+    Ok(())
+}
+
+#[test]
 fn update_forest() -> Result<()> {
     let (_file, mut backend) = default_backend()?;
     let mut rng = ContinuousRng::new([0x51; 32]);

--- a/miden-crypto/src/merkle/smt/large_forest/mod.rs
+++ b/miden-crypto/src/merkle/smt/large_forest/mod.rs
@@ -572,7 +572,7 @@ impl<B: Backend> LargeSmtForest<B> {
     /// # Errors
     ///
     /// - [`LargeSmtForestError::Fatal`] if the backend fails to operate properly during the query.
-    /// - [`LargeSmtForestError::UnknownLineage`] If the provided `tree` specifies a lineage that is
+    /// - [`LargeSmtForestError::UnknownLineage`] if the provided `tree` specifies a lineage that is
     ///   not one known by the forest.
     /// - [`LargeSmtForestError::UnknownTree`] if the provided `tree` refers to a tree that is not a
     ///   member of the forest.
@@ -616,8 +616,8 @@ impl<B: Backend> LargeSmtForest<B> {
 
         // We compute the new leaf and new path by applying any reversions from the history on
         // top of the current state.
-        let new_leaf = self.merge_leaves(opening.leaf(), view)?;
-        let new_path = self.merge_paths(leaf_index, opening.path(), view)?;
+        let new_leaf = Self::merge_leaves(opening.leaf(), view)?;
+        let new_path = Self::merge_paths(leaf_index, opening.path(), view)?;
 
         // Finally we can compose our combined opening.
         Ok(SmtProof::new(new_path, new_leaf)?)
@@ -921,6 +921,61 @@ impl<B: Backend> LargeSmtForest<B> {
 /// Where anything more specific can be said about performance, the method documentation will
 /// contain more detail.
 impl<B: Backend> LargeSmtForest<B> {
+    /// Adds multiple new `lineages` to the tree, creating an empty tree for each and applying the
+    /// provided modifications to it, with the result being given the specified `version`.
+    ///
+    /// If the provide batch of modifications is empty for any given lineage, then the **empty tree
+    /// will be added** as the first version in that lineage.
+    ///
+    /// # Performance
+    ///
+    /// This method is intended to be a reliable choice if the caller needs to add more than one
+    /// new lineage at once. At _worst_, its performance should be no slower than repeating
+    /// [`Self::add_lineage`] in a loop, but in some cases it may be significantly more performant.
+    ///
+    /// The exact scope of any speed-up is determined by the backend in use, so it is worth reading
+    /// the documentation for the Backend's `add_lineages` method.
+    ///
+    /// # Errors
+    ///
+    /// - [`LargeSmtForestError::DuplicateLineage`] if any of the provided lineages share an ID with
+    ///   an already-known lineage.
+    /// - [`LargeSmtForestError::Fatal`] if the backend fails while being accessed.
+    /// - [`BackendError::Merkle`] if the provided `updates` cannot be applied to the empty tree.
+    pub fn add_lineages(
+        &mut self,
+        version: VersionId,
+        lineages: SmtForestUpdateBatch,
+    ) -> Result<Vec<TreeWithRoot>> {
+        // We start by performing our precondition checks: none of the lineages in the batch should
+        // already exist in the forest.
+        for lineage in lineages.lineages() {
+            if self.lineage_data.contains_key(lineage) {
+                return Err(LargeSmtForestError::DuplicateLineage(*lineage));
+            }
+        }
+
+        // With the preconditions checked we can call into the backend to perform the additions, and
+        // we forward all errors as this will be correct for conformant backend implementations.
+        let results = self.backend.add_lineages(version, lineages)?;
+
+        // Now we have to update the lineage data for each newly-added lineage. New lineages have
+        // empty histories, so we do not need to insert into `non_empty_histories`.
+        results
+            .into_iter()
+            .map(|(lineage, tree_info)| {
+                let lineage_data = LineageData {
+                    history: History::empty(self.config.max_history_versions()),
+                    latest_version: tree_info.version(),
+                    latest_root: tree_info.root(),
+                };
+                self.lineage_data.insert(lineage, lineage_data);
+
+                Ok(tree_info)
+            })
+            .collect()
+    }
+
     /// Performs the provided `updates` on the forest, adding at most one new root with version
     /// `new_version` to the forest for each target root in `updates` and returning a mapping
     /// from old root to the new root data.
@@ -1023,7 +1078,11 @@ impl<B: Backend> LargeSmtForest<B> {
 impl<B: Backend> LargeSmtForest<B> {
     /// Applies the history delta given by `history_view` on top of the provided `full_tree_leaf` to
     /// produce the correct leaf for a historical opening.
-    fn merge_leaves(&self, full_tree_leaf: &SmtLeaf, history_view: HistoryView) -> Result<SmtLeaf> {
+    ///
+    /// # Errors
+    ///
+    /// - [`LargeSmtForestError::SmtLeafError`] if the combined leaf cannot be computed correctly
+    fn merge_leaves(full_tree_leaf: &SmtLeaf, history_view: HistoryView) -> Result<SmtLeaf> {
         // We apply the historical delta on top of the existing entries to perform the reversion
         // back to the previous state.
         let mut leaf_entries = Map::new();
@@ -1051,14 +1110,21 @@ impl<B: Backend> LargeSmtForest<B> {
             "Leaf entries should not contain entries with empty values"
         );
 
-        // Any entries that are still empty at this point should be removed.
-        Ok(SmtLeaf::new(leaf_entries.into_iter().collect(), full_tree_leaf.index())?)
+        // We sort the entries to ensure a consistent ordering, as the map above is a HashMap
+        // which does not guarantee iteration order.
+        let mut entries: Vec<_> = leaf_entries.into_iter().collect();
+        entries.sort_unstable_by(|(k1, _), (k2, _)| k1.cmp(k2));
+
+        Ok(SmtLeaf::new(entries, full_tree_leaf.index())?)
     }
 
     /// Applies any historical changes contained in `history_view` on top of the merkle path
     /// obtained from the full tree to produce the correct path for a historical opening.
+    ///
+    /// # Errors
+    ///
+    /// - [`LargeSmtForestError::Merkle`] if the merkle path cannot be created properly.
     fn merge_paths(
-        &self,
         leaf_index: LeafIndex<SMT_DEPTH>,
         full_tree_path: &SparseMerklePath,
         history_view: HistoryView,

--- a/miden-crypto/src/merkle/smt/large_forest/property_tests.rs
+++ b/miden-crypto/src/merkle/smt/large_forest/property_tests.rs
@@ -22,6 +22,9 @@ use crate::{
 proptest! {
     #![proptest_config(ProptestConfig::with_cases(10))]
 
+    // ENTRIES
+    // ============================================================================================
+
     /// This test ensures that the `entries` iterator for the forest always returns the exact same
     /// values as the `entries` iterator over a basic SMT with the same state.
     #[test]
@@ -126,5 +129,64 @@ proptest! {
             .collect::<Result<Vec<_>, _>>()
             .map_err(to_fail)?;
         prop_assert!(entries.iter().all(|e| e.value != EMPTY_WORD), "EMPTY_WORD entry encountered");
+    }
+
+    // ADD LINEAGES
+    // ============================================================================================
+
+    /// This test ensures that `add_lineages` produces the same results as adding each lineage
+    /// individually via `add_lineage`.
+    #[test]
+    fn add_lineages_matches_repeated_add_lineage(
+        lineages in prop::collection::vec(arbitrary_lineage(), 0..10)
+            .prop_map(|v| v.into_iter().unique().collect::<Vec<_>>()),
+        version in arbitrary_version(),
+        entries in prop::collection::vec(arbitrary_batch(), 0..10),
+    ) {
+        // Build a forest update batch containing all lineages with their respective entries.
+        let mut batch = crate::merkle::smt::SmtForestUpdateBatch::empty();
+        for (i, lineage) in lineages.iter().enumerate() {
+            if let Some(entry_batch) = entries.get(i) {
+                *batch.operations(*lineage) = entry_batch.clone();
+            } else {
+                batch.operations(*lineage);
+            }
+        }
+
+        // Add all lineages at once via add_lineages.
+        let mut forest_batch = LargeSmtForest::new(ForestInMemoryBackend::new()).map_err(to_fail)?;
+        let batch_results = forest_batch.add_lineages(version, batch).map_err(to_fail)?;
+
+        // Add each lineage individually via add_lineage.
+        let mut forest_individual = LargeSmtForest::new(ForestInMemoryBackend::new()).map_err(to_fail)?;
+        let mut individual_results = Vec::new();
+        for (i, lineage) in lineages.iter().enumerate() {
+            let entry_batch = entries.get(i).cloned().unwrap_or_default();
+            let result = forest_individual.add_lineage(*lineage, version, entry_batch).map_err(to_fail)?;
+            individual_results.push(result);
+        }
+
+        // Both should yield the same number of results.
+        prop_assert_eq!(batch_results.len(), individual_results.len());
+
+        // For each lineage, verify the roots match and get returns the same values.
+        for (i, lineage) in lineages.iter().enumerate() {
+            let batch_root = batch_results.iter().find(|r| r.lineage() == *lineage);
+            let individual_root = &individual_results[i];
+
+            let batch_root = batch_root.unwrap();
+            prop_assert_eq!(batch_root.root(), individual_root.root());
+            prop_assert_eq!(batch_root.version(), individual_root.version());
+
+            // Verify get returns the same values for all keys in the entries.
+            let tree = TreeId::new(*lineage, version);
+            if let Some(entry_batch) = entries.get(i) {
+                for op in entry_batch.clone().into_iter() {
+                    let batch_val = forest_batch.get(tree, op.key()).map_err(to_fail)?;
+                    let individual_val = forest_individual.get(tree, op.key()).map_err(to_fail)?;
+                    prop_assert_eq!(batch_val, individual_val);
+                }
+            }
+        }
     }
 }

--- a/miden-crypto/src/merkle/smt/large_forest/test_utils.rs
+++ b/miden-crypto/src/merkle/smt/large_forest/test_utils.rs
@@ -201,6 +201,14 @@ impl Backend for FallibleEntriesBackend {
         self.inner.update_tree(lineage, new_version, updates)
     }
 
+    fn add_lineages(
+        &mut self,
+        version: VersionId,
+        lineages: SmtForestUpdateBatch,
+    ) -> BackendResult<Vec<(LineageId, TreeWithRoot)>> {
+        self.inner.add_lineages(version, lineages)
+    }
+
     fn update_forest(
         &mut self,
         new_version: VersionId,

--- a/miden-crypto/src/merkle/smt/large_forest/tests.rs
+++ b/miden-crypto/src/merkle/smt/large_forest/tests.rs
@@ -1052,6 +1052,97 @@ fn update_tree() -> Result<()> {
 // ================================================================================================
 
 #[test]
+fn add_lineages() -> Result<()> {
+    let backend = ForestInMemoryBackend::new();
+    let mut forest = Forest::new(backend)?;
+    let mut rng = ContinuousRng::new([0xa1; 32]);
+
+    // An empty batch should return an empty result and leave the forest unchanged.
+    let version: VersionId = rng.value();
+    let empty_batch = SmtForestUpdateBatch::empty();
+    let results = forest.add_lineages(version, empty_batch)?;
+    assert!(results.is_empty());
+
+    // We can add multiple distinct lineages at once, each with their own data.
+    let lineage_1: LineageId = rng.value();
+    let lineage_2: LineageId = rng.value();
+    let lineage_3: LineageId = rng.value();
+
+    let l1_key: Word = rng.value();
+    let l1_value: Word = rng.value();
+    let l2_key: Word = rng.value();
+    let l2_value: Word = rng.value();
+
+    let mut batch = SmtForestUpdateBatch::empty();
+    batch.operations(lineage_1).add_insert(l1_key, l1_value);
+    batch.operations(lineage_2).add_insert(l2_key, l2_value);
+    batch.operations(lineage_3); // empty lineage — should still be added
+
+    let results = forest.add_lineages(version, batch)?;
+    assert_eq!(results.len(), 3);
+
+    // Verify roots match reference Smt trees.
+    let mut tree_1 = Smt::new();
+    tree_1.insert(l1_key, l1_value)?;
+    let mut tree_2 = Smt::new();
+    tree_2.insert(l2_key, l2_value)?;
+    let tree_3 = Smt::new();
+
+    assert!(
+        results.iter().any(|r| r.lineage() == lineage_1
+            && r.root() == tree_1.root()
+            && r.version() == version)
+    );
+    assert!(
+        results.iter().any(|r| r.lineage() == lineage_2
+            && r.root() == tree_2.root()
+            && r.version() == version)
+    );
+    assert!(
+        results.iter().any(|r| r.lineage() == lineage_3
+            && r.root() == tree_3.root()
+            && r.version() == version)
+    );
+
+    // Verify lineage_data is populated via root_info.
+    assert_eq!(
+        forest.root_info(TreeId::new(lineage_1, version)),
+        RootInfo::LatestVersion(tree_1.root())
+    );
+    assert_eq!(
+        forest.root_info(TreeId::new(lineage_2, version)),
+        RootInfo::LatestVersion(tree_2.root())
+    );
+    assert_eq!(
+        forest.root_info(TreeId::new(lineage_3, version)),
+        RootInfo::LatestVersion(tree_3.root())
+    );
+
+    // New lineages should have empty histories.
+    assert!(!forest.get_non_empty_histories().contains(&lineage_1));
+    assert!(!forest.get_non_empty_histories().contains(&lineage_2));
+    assert!(!forest.get_non_empty_histories().contains(&lineage_3));
+
+    // Adding a batch that contains an already-known lineage should fail with DuplicateLineage.
+    let lineage_4: LineageId = rng.value();
+    let mut dup_batch = SmtForestUpdateBatch::empty();
+    dup_batch.operations(lineage_1); // already exists
+    dup_batch.operations(lineage_4); // new
+
+    let result = forest.add_lineages(version, dup_batch);
+    assert!(result.is_err());
+    assert_matches!(
+        result.unwrap_err(),
+        LargeSmtForestError::DuplicateLineage(l) if l == lineage_1
+    );
+
+    // The failed batch should not have added lineage_4.
+    assert_eq!(forest.root_info(TreeId::new(lineage_4, version)), RootInfo::Missing);
+
+    Ok(())
+}
+
+#[test]
 fn update_forest() -> Result<()> {
     let backend = ForestInMemoryBackend::new();
     let mut forest = Forest::new(backend)?;


### PR DESCRIPTION
## Describe your changes

This commit adds the `add_lineages` batch endpoint to the forest, providing a far more efficient way to add many new lineages at once than simply calling `add_lineage` in a loop.

It originally experimented with additional `open_many` and `get_many` endpoints, but these proved no more efficient than simply calling `open` and `get` in a loop and have hence been removed. They are mentioned here for posterity.

The new `add_lineages` endpoint is accompanied by comprehensive tests, as well as benchmarks to establish baseline performance. It is faster than calling `add_lineage` in a loop as soon as more than five lineages are being added when used in conjunction with the persistent backend, and when it is slower it is not by a significant amount. It is highly recommended to use this endpoint when adding multiple lineages at once.

The exact performance profile is backend-dependent.

Closes #880.

## Checklist before requesting a review

- [x] Repo forked and branch created from `next` according to naming convention.
- [x] Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- [x] Relevant issues are linked in the PR description.
- [x] Tests added for new functionality.
- [x] Documentation/comments updated according to changes.
