### PR TITLE
feat(LargeSmtForest): Configurable sync to disk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.24.0 (TBD)
 
 - [BREAKING] Removed `AlgebraicSponge::merge_with_int()` method ([#894](https://github.com/0xMiden/crypto/pull/894)).
+- Added the ability to configure the sync-to-disk behavior of the persistent backend using its config ([#912](https://github.com/0xMiden/crypto/pull/912)).
 
 ## 0.23.0 (2026-03-11)
 

--- a/miden-crypto/src/merkle/smt/large_forest/backend/persistent/config.rs
+++ b/miden-crypto/src/merkle/smt/large_forest/backend/persistent/config.rs
@@ -23,6 +23,11 @@ const DEFAULT_BLOOM_FILTER_BITS_PER_KEY: c_double = 10.0;
 /// The default target file size for the files that make up the database (512 MiB).
 const DEFAULT_TARGET_FILE_SIZE: u64 = 512 << 20;
 
+/// The default setting for synchronous writes (`false`).
+///
+/// When `false`, writes are buffered and not immediately flushed to disk.
+const DEFAULT_SYNC_WRITES: bool = false;
+
 // CONFIG TYPE
 // ================================================================================================
 
@@ -76,6 +81,15 @@ pub struct Config {
     ///
     /// Defaults to [`DEFAULT_TARGET_FILE_SIZE`].
     pub(super) target_file_size: u64,
+
+    /// Whether each write should be synchronously flushed to disk.
+    ///
+    /// When `true`, every write is synchronously flushed to disk, providing stronger durability
+    /// guarantees but with reduced write performance. When `false` (the default), writes are
+    /// buffered and only flushed to disk when the buffers become full.
+    ///
+    /// Defaults to [`DEFAULT_SYNC_WRITES`].
+    pub(super) sync_writes: bool,
 }
 
 impl Config {
@@ -90,6 +104,7 @@ impl Config {
     /// - `cache_size_bytes`: 2 GiB
     /// - `max_open_files`: 512
     /// - `max_wal_size`: 1 GiB
+    /// - `sync_writes`: `false`
     ///
     /// # Errors
     ///
@@ -123,6 +138,7 @@ impl Config {
             max_wal_size: DEFAULT_MAX_TOTAL_WAL_SIZE_BYTES,
             bloom_filter_bits: DEFAULT_BLOOM_FILTER_BITS_PER_KEY,
             target_file_size: DEFAULT_TARGET_FILE_SIZE,
+            sync_writes: DEFAULT_SYNC_WRITES,
         })
     }
 }
@@ -189,6 +205,18 @@ impl Config {
         self.target_file_size = target_file_size;
         self
     }
+
+    /// Sets whether writes should be synchronously flushed to disk.
+    ///
+    /// When `true`, every write is synchronously flushed to disk, providing stronger durability
+    /// guarantees but with reduced write performance. When `false` (the default), writes are
+    /// buffered only flushed to disk when the buffer becomes full.
+    ///
+    /// Defaults to `false`.
+    pub fn with_sync_writes(mut self, sync_writes: bool) -> Self {
+        self.sync_writes = sync_writes;
+        self
+    }
 }
 
 // TESTS
@@ -210,6 +238,7 @@ mod test {
         assert_eq!(config.max_wal_size, DEFAULT_MAX_TOTAL_WAL_SIZE_BYTES);
         assert_eq!(config.bloom_filter_bits, DEFAULT_BLOOM_FILTER_BITS_PER_KEY);
         assert_eq!(config.target_file_size, DEFAULT_TARGET_FILE_SIZE);
+        assert_eq!(config.sync_writes, DEFAULT_SYNC_WRITES);
 
         Ok(())
     }
@@ -265,6 +294,17 @@ mod test {
         let config = config.with_target_file_size(256 << 20);
 
         assert_eq!(config.target_file_size, 256 << 20);
+
+        Ok(())
+    }
+
+    #[test]
+    fn with_sync_writes() -> Result<()> {
+        let tempdir = tempdir()?;
+        let config = Config::new(tempdir.path())?;
+        let config = config.with_sync_writes(true);
+
+        assert!(config.sync_writes);
 
         Ok(())
     }

--- a/miden-crypto/src/merkle/smt/large_forest/backend/persistent/mod.rs
+++ b/miden-crypto/src/merkle/smt/large_forest/backend/persistent/mod.rs
@@ -171,6 +171,12 @@ pub struct PersistentBackend {
     /// Care must be taken that this is _always_ kept in sync with the on-disk copy in the
     /// [`METADATA_CF`] column.
     lineages: HashMap<LineageId, TreeMetadata>,
+
+    /// Whether writes should be synchronously flushed to disk.
+    ///
+    /// Setting this to true will result in reduced throughput but may result in higher durability
+    /// in the presence of crashes.
+    sync_writes: bool,
 }
 
 // CONSTRUCTION
@@ -189,8 +195,9 @@ impl PersistentBackend {
     pub fn load(config: Config) -> Result<Self> {
         let db = Arc::new(Self::build_db_with_options(&config)?);
         let lineages = Self::read_all_metadata(db.clone())?;
+        let sync_writes = config.sync_writes;
 
-        Ok(Self { db, lineages })
+        Ok(Self { db, lineages, sync_writes })
     }
 }
 
@@ -1145,7 +1152,7 @@ impl PersistentBackend {
     /// - [`BackendError::Internal`] if writing to the database fails for any reason.
     fn write(&self, batch: WriteBatch) -> Result<()> {
         let mut write_opts = db::WriteOptions::default();
-        write_opts.set_sync(false);
+        write_opts.set_sync(self.sync_writes);
         self.db.write_opt(batch, &write_opts)?;
 
         Ok(())


### PR DESCRIPTION
## Describe your changes

This commit makes it possible for all writes in the persistent backend of the LargeSmtForest to be flushed to disk in a manner that the user decides. The default remains `false`, providing higher write performance but less durability, and the user can set it to `true` for higher durability but lower write performance.

Closes #891

## Checklist before requesting a review
- [x] Repo forked and branch created from `next` according to naming convention.
- [x] Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- [x] Relevant issues are linked in the PR description.
- [x] Tests added for new functionality.
- [x] Documentation/comments updated according to changes.
