### PR TITLE
feat(SmtForest): Improve `entry_count` performance

### DIFF
--- a/miden-crypto/src/merkle/smt/large_forest/backend/mod.rs
+++ b/miden-crypto/src/merkle/smt/large_forest/backend/mod.rs
@@ -111,6 +111,14 @@ where
     ///
     /// It is the responsibility of the forest to ensure lineage existence before querying the
     /// backend. The backend must return an error if the lineage does not exist.
+    ///
+    /// # Expected Behavior
+    ///
+    /// Implementations must guarantee the following behavior in addition to the global invariants:
+    ///
+    /// - This method must be **cheap** to call, not requiring network or disk I/O to service the
+    ///   result. This usually implies in-memory caching of the data.
+    /// - This method must not return errors other than if the lineage does not exist.
     fn entry_count(&self, lineage: LineageId) -> Result<usize>;
 
     /// Returns an iterator that yields the populated (key-value) entries for the specified

--- a/miden-crypto/src/merkle/smt/large_forest/history/mod.rs
+++ b/miden-crypto/src/merkle/smt/large_forest/history/mod.rs
@@ -131,7 +131,8 @@ impl History {
     }
 
     /// Adds a version to the history with the provided `root` and represented by the changes from
-    /// the current tree given in `nodes` and `leaves`.
+    /// the current tree given in `nodes` and `changed_keys`, with `entry_count` as the total
+    /// number of entries for the tree that corresponds to this version.
     ///
     /// If adding this version would result in exceeding `self.max_count` historical versions, then
     /// the oldest of the versions is automatically removed.
@@ -157,6 +158,7 @@ impl History {
         version_id: VersionId,
         nodes: NodeChanges,
         changed_keys: ChangedKeys,
+        entry_count: usize,
     ) -> Result<()> {
         // We need to fail early if the provided new version is not monotonic with respect to the
         // latest version in the history.
@@ -185,13 +187,15 @@ impl History {
             }
         }
 
-        self.deltas.push_back(Delta::new(root, version_id, nodes, changed_keys));
+        self.deltas
+            .push_back(Delta::new(root, version_id, nodes, changed_keys, entry_count));
 
         Ok(())
     }
 
-    /// Adds a version to the history and represented by the changes from the current tree given
-    /// `mutations`.
+    /// Adds a version to the history, represented by the changes from the current tree given
+    /// `mutations`, with `entry_count` corresponding to the number of entries in the full tree
+    /// corresponding to this version.
     ///
     /// If adding this version would result in exceeding `self.max_count` historical versions, then
     /// the oldest of the versions is automatically removed.
@@ -214,6 +218,7 @@ impl History {
         &mut self,
         version_id: VersionId,
         mutations: MutationSet,
+        entry_count: usize,
     ) -> Result<()> {
         let mut changed_keys = ChangedKeys::default();
         mutations.new_pairs.into_iter().for_each(|(k, v)| {
@@ -232,7 +237,7 @@ impl History {
             .collect();
 
         // Now we can simply delegate to the standard function.
-        self.add_version(mutations.new_root, version_id, node_changes, changed_keys)
+        self.add_version(mutations.new_root, version_id, node_changes, changed_keys, entry_count)
     }
 
     /// Returns the index in the sequence of deltas of the version that corresponds to the provided
@@ -396,6 +401,12 @@ impl<'history> HistoryView<'history> {
     pub fn changed_keys(&self) -> impl Iterator<Item = (Word, Word)> + 'history {
         self.delta.changed_keys.iter().map(|(k, v)| (*k, *v))
     }
+
+    /// Returns the total number of entries in the tree at this historical version.
+    #[must_use]
+    pub fn entry_count(&self) -> usize {
+        self.delta.entry_count
+    }
 }
 
 // DELTA
@@ -436,19 +447,30 @@ struct Delta {
     /// represented by the delta. This includes pairs that either add or mutate a value under a
     /// key, and pairs where the value is the `EMPTY_WORD` and hence represent removals.
     changed_keys: ChangedKeys,
+
+    /// The total number of entries that existed in the tree at the version represented by this
+    /// delta, stored eagerly to avoid recomputation.
+    entry_count: usize,
 }
 
 impl Delta {
     /// Creates a new delta with the provided `root`, representing the provided changes to the
-    /// `nodes` in the merkle tree, and using `added_keys` and `removed_keys` to represent the
-    /// changes to entries in the tree.
+    /// `nodes` in the merkle tree, using `changed_keys` to represent the changes to entries in
+    /// the tree, and storing `entry_count` as the total number of entries at this version.
     #[must_use]
     fn new(
         root: RootValue,
         version_id: VersionId,
         nodes: NodeChanges,
         changed_keys: ChangedKeys,
+        entry_count: usize,
     ) -> Self {
-        Self { root, version_id, nodes, changed_keys }
+        Self {
+            root,
+            version_id,
+            nodes,
+            changed_keys,
+            entry_count,
+        }
     }
 }

--- a/miden-crypto/src/merkle/smt/large_forest/history/tests.rs
+++ b/miden-crypto/src/merkle/smt/large_forest/history/tests.rs
@@ -3,7 +3,9 @@
 
 use alloc::vec::Vec;
 
-use super::{ChangedKeys, History, NodeChanges, error::Result};
+use super::{
+    super::test_utils::UNUSED_ENTRY_COUNT, ChangedKeys, History, NodeChanges, error::Result,
+};
 use crate::{
     EMPTY_WORD, Felt, Word,
     field::PrimeCharacteristicRing,
@@ -34,8 +36,8 @@ fn roots() -> Result<()> {
     let mut history = History::empty(2);
     let root_1: Word = rng.value();
     let root_2: Word = rng.value();
-    history.add_version(root_1, 0, nodes.clone(), changed_keys.clone())?;
-    history.add_version(root_2, 1, nodes.clone(), changed_keys.clone())?;
+    history.add_version(root_1, 0, nodes.clone(), changed_keys.clone(), UNUSED_ENTRY_COUNT)?;
+    history.add_version(root_2, 1, nodes.clone(), changed_keys.clone(), UNUSED_ENTRY_COUNT)?;
 
     // We should be able to get all the roots.
     let roots = history.roots().collect::<Vec<_>>();
@@ -61,11 +63,41 @@ fn find_latest_corresponding_version() -> Result<()> {
     let v4 = 31;
     let v5 = 45;
 
-    history.add_version(rng.value(), v1, nodes.clone(), changed_keys.clone())?;
-    history.add_version(rng.value(), v2, nodes.clone(), changed_keys.clone())?;
-    history.add_version(rng.value(), v3, nodes.clone(), changed_keys.clone())?;
-    history.add_version(rng.value(), v4, nodes.clone(), changed_keys.clone())?;
-    history.add_version(rng.value(), v5, nodes.clone(), changed_keys.clone())?;
+    history.add_version(
+        rng.value(),
+        v1,
+        nodes.clone(),
+        changed_keys.clone(),
+        UNUSED_ENTRY_COUNT,
+    )?;
+    history.add_version(
+        rng.value(),
+        v2,
+        nodes.clone(),
+        changed_keys.clone(),
+        UNUSED_ENTRY_COUNT,
+    )?;
+    history.add_version(
+        rng.value(),
+        v3,
+        nodes.clone(),
+        changed_keys.clone(),
+        UNUSED_ENTRY_COUNT,
+    )?;
+    history.add_version(
+        rng.value(),
+        v4,
+        nodes.clone(),
+        changed_keys.clone(),
+        UNUSED_ENTRY_COUNT,
+    )?;
+    history.add_version(
+        rng.value(),
+        v5,
+        nodes.clone(),
+        changed_keys.clone(),
+        UNUSED_ENTRY_COUNT,
+    )?;
 
     // When we query for a version that is older than the oldest in the history we should get an
     // error.
@@ -107,18 +139,18 @@ fn add_version() -> Result<()> {
 
     let root_1: Word = rng.value();
     let id_1 = 0;
-    history.add_version(root_1, id_1, nodes.clone(), changed_keys.clone())?;
+    history.add_version(root_1, id_1, nodes.clone(), changed_keys.clone(), UNUSED_ENTRY_COUNT)?;
     assert_eq!(history.num_versions(), 1);
 
     let root_2: Word = rng.value();
     let id_2 = 1;
-    history.add_version(root_2, id_2, nodes.clone(), changed_keys.clone())?;
+    history.add_version(root_2, id_2, nodes.clone(), changed_keys.clone(), UNUSED_ENTRY_COUNT)?;
     assert_eq!(history.num_versions(), 2);
 
     // At this point, adding any version should remove the oldest.
     let root_3: Word = rng.value();
     let id_3 = 2;
-    history.add_version(root_3, id_3, nodes.clone(), changed_keys.clone())?;
+    history.add_version(root_3, id_3, nodes.clone(), changed_keys.clone(), UNUSED_ENTRY_COUNT)?;
     assert_eq!(history.num_versions(), 2);
 
     // If we then query for that first version it won't be there anymore, but the other two
@@ -128,7 +160,11 @@ fn add_version() -> Result<()> {
     assert!(history.get_view_at(id_3).is_ok());
 
     // If we try and add a version with a non-monotonic version number, we should see an error.
-    assert!(history.add_version(root_3, id_1, nodes, changed_keys.clone()).is_err());
+    assert!(
+        history
+            .add_version(root_3, id_1, nodes, changed_keys.clone(), UNUSED_ENTRY_COUNT)
+            .is_err()
+    );
 
     Ok(())
 }
@@ -163,7 +199,7 @@ fn add_version_from_mutation_set() -> Result<()> {
     let mut history = History::empty(2);
     let version: VersionId = rng.value();
 
-    history.add_version_from_mutation_set(version, mutations)?;
+    history.add_version_from_mutation_set(version, mutations, UNUSED_ENTRY_COUNT)?;
 
     // Now we can check that it did things correctly.
     let view = history.get_view_at(version)?;
@@ -187,19 +223,19 @@ fn truncate() -> Result<()> {
 
     let root_1: Word = rng.value();
     let id_1 = 5;
-    history.add_version(root_1, id_1, nodes.clone(), changed_keys.clone())?;
+    history.add_version(root_1, id_1, nodes.clone(), changed_keys.clone(), UNUSED_ENTRY_COUNT)?;
 
     let root_2: Word = rng.value();
     let id_2 = 10;
-    history.add_version(root_2, id_2, nodes.clone(), changed_keys.clone())?;
+    history.add_version(root_2, id_2, nodes.clone(), changed_keys.clone(), UNUSED_ENTRY_COUNT)?;
 
     let root_3: Word = rng.value();
     let id_3 = 15;
-    history.add_version(root_3, id_3, nodes.clone(), changed_keys.clone())?;
+    history.add_version(root_3, id_3, nodes.clone(), changed_keys.clone(), UNUSED_ENTRY_COUNT)?;
 
     let root_4: Word = rng.value();
     let id_4 = 20;
-    history.add_version(root_4, id_4, nodes.clone(), changed_keys.clone())?;
+    history.add_version(root_4, id_4, nodes.clone(), changed_keys.clone(), UNUSED_ENTRY_COUNT)?;
 
     assert_eq!(history.num_versions(), 4);
 
@@ -239,11 +275,11 @@ fn clear() -> Result<()> {
 
     let root_1: Word = rng.value();
     let id_1 = 0;
-    history.add_version(root_1, id_1, nodes.clone(), changed_keys.clone())?;
+    history.add_version(root_1, id_1, nodes.clone(), changed_keys.clone(), UNUSED_ENTRY_COUNT)?;
 
     let root_2: Word = rng.value();
     let id_2 = 1;
-    history.add_version(root_2, id_2, nodes.clone(), changed_keys.clone())?;
+    history.add_version(root_2, id_2, nodes.clone(), changed_keys.clone(), UNUSED_ENTRY_COUNT)?;
 
     assert_eq!(history.num_versions(), 2);
 
@@ -286,7 +322,7 @@ fn view_at() -> Result<()> {
     changed_1.insert(l2_e1_key, l2_e1_value);
     changed_1.insert(l2_e2_key, l2_e2_value);
 
-    history.add_version(root_1, id_1, nodes_1.clone(), changed_1.clone())?;
+    history.add_version(root_1, id_1, nodes_1.clone(), changed_1.clone(), 3)?;
     assert_eq!(history.num_versions(), 1);
 
     // We then add another version that overlaps with the older version.
@@ -306,7 +342,7 @@ fn view_at() -> Result<()> {
     l3_e1_key[3] = Felt::from_u64(leaf_3_ix.position());
     let l3_e1_value: Word = rng.value();
     changed_2.insert(l3_e1_key, l3_e1_value);
-    history.add_version(root_2, id_2, nodes_2.clone(), changed_2.clone())?;
+    history.add_version(root_2, id_2, nodes_2.clone(), changed_2.clone(), 7)?;
     assert_eq!(history.num_versions(), 2);
 
     // And another version for the sake of the test.
@@ -327,7 +363,7 @@ fn view_at() -> Result<()> {
     let l1n_e1_value: Word = rng.value();
     changed_3.insert(l1n_e1_key, l1n_e1_value);
 
-    history.add_version(root_3, id_3, nodes_3.clone(), changed_3.clone())?;
+    history.add_version(root_3, id_3, nodes_3.clone(), changed_3.clone(), 15)?;
     assert_eq!(history.num_versions(), 3);
 
     // At this point, we can grab a view into the history. If we grab something older than the
@@ -337,6 +373,7 @@ fn view_at() -> Result<()> {
     // If we grab something valid, then we should get the right results. Let's grab the oldest
     // possible version to test the overlay logic.
     let view = history.get_view_at(id_1)?;
+    assert_eq!(view.entry_count(), 3);
 
     // Getting a node in the targeted version should just return it.
     assert_eq!(view.node_value(&NodeIndex::new(2, 1).unwrap()), Some(&n1_value));
@@ -387,6 +424,7 @@ fn view_at() -> Result<()> {
     let view = history.get_view_at(7)?;
     assert_eq!(view.node_value(&NodeIndex::new_unchecked(30, 1)), Some(&n5_value));
     assert!(view.node_value(&NodeIndex::new_unchecked(30, 2)).is_none());
+    assert_eq!(view.entry_count(), 15);
 
     Ok(())
 }
@@ -420,14 +458,16 @@ fn history_from_smt_non_overlapping() -> Result<()> {
     let mutations_v0 = smt.compute_mutations(vec![(key_1, value_1)]).unwrap();
     let reversion_set = smt.apply_mutations_with_reversion(mutations_v0).unwrap();
     let root_v0 = smt.root();
-    history.add_version_from_mutation_set(0, reversion_set)?;
+    // Before this mutation the tree was empty, so the entry count for version 0 is 0.
+    history.add_version_from_mutation_set(0, reversion_set, 0)?;
     assert_eq!(history.num_versions(), 1);
 
     // Version 1: Insert second key-value pair
     let mutations_v1 = smt.compute_mutations(vec![(key_2, value_2)]).unwrap();
     let reversion_set = smt.apply_mutations_with_reversion(mutations_v1).unwrap();
     let root_v1 = smt.root();
-    history.add_version_from_mutation_set(1, reversion_set)?;
+    // Before this mutation the tree had 1 entry (key_1), so the entry count for version 1 is 1.
+    history.add_version_from_mutation_set(1, reversion_set, 1)?;
 
     // Verify the roots for older states are tracked correctly in the history.
     assert!(history.is_known_root(initial_root));
@@ -441,10 +481,12 @@ fn history_from_smt_non_overlapping() -> Result<()> {
     let view_v0 = history.get_view_at(0)?;
     assert_eq!(view_v0.value(&key_1), Some(EMPTY_WORD));
     assert_eq!(view_v0.value(&key_2), Some(EMPTY_WORD));
+    assert_eq!(view_v0.entry_count(), 0);
 
     // When we query version 1 it should only make revert one change on top of the current tree.
     let view_v1 = history.get_view_at(1)?;
     assert_eq!(view_v1.value(&key_2), Some(EMPTY_WORD));
+    assert_eq!(view_v1.entry_count(), 1);
 
     // Verify querying a non-existent key returns None
     let nonexistent_key: Word = rng.value();
@@ -468,20 +510,116 @@ fn history_from_smt_overlapping() -> Result<()> {
     // Version 0: Insert initial value
     let mutations_v0 = smt.compute_mutations(vec![(key, value_v0)]).unwrap();
     let reversion_set = smt.apply_mutations_with_reversion(mutations_v0).unwrap();
-    history.add_version_from_mutation_set(0, reversion_set)?;
+    // Before this mutation the tree was empty, so the entry count for version 0 is 0.
+    history.add_version_from_mutation_set(0, reversion_set, 0)?;
 
     // Version 1: Update to new value
     let mutations_v1 = smt.compute_mutations(vec![(key, value_v1)]).unwrap();
     let reversion_set = smt.apply_mutations_with_reversion(mutations_v1).unwrap();
-    history.add_version_from_mutation_set(1, reversion_set)?;
+    // Before this mutation the tree had 1 entry (key), so the entry count for version 1 is 1.
+    history.add_version_from_mutation_set(1, reversion_set, 1)?;
 
     // In version 0 we should have the correct (empty) value when reverted.
     let view_v0 = history.get_view_at(0)?;
     assert_eq!(view_v0.value(&key), Some(EMPTY_WORD));
+    assert_eq!(view_v0.entry_count(), 0);
 
     // In version 1 we should have the value set in the transition to version 0.
     let view_v1 = history.get_view_at(1)?;
     assert_eq!(view_v1.value(&key), Some(value_v0));
+    assert_eq!(view_v1.entry_count(), 1);
+
+    Ok(())
+}
+
+#[test]
+fn entry_count_single_version() -> Result<()> {
+    let mut rng = ContinuousRng::new([0x1c; 32]);
+    let mut history = History::empty(3);
+
+    let root: Word = rng.value();
+    history.add_version(root, 0, NodeChanges::default(), ChangedKeys::default(), 42)?;
+
+    let view = history.get_view_at(0)?;
+    assert_eq!(view.entry_count(), 42);
+
+    Ok(())
+}
+
+#[test]
+fn entry_count_multiple_versions() -> Result<()> {
+    let mut rng = ContinuousRng::new([0x1d; 32]);
+    let mut history = History::empty(5);
+
+    // Add versions with different entry counts.
+    history.add_version(rng.value(), 0, NodeChanges::default(), ChangedKeys::default(), 0)?;
+    history.add_version(rng.value(), 1, NodeChanges::default(), ChangedKeys::default(), 5)?;
+    history.add_version(rng.value(), 2, NodeChanges::default(), ChangedKeys::default(), 3)?;
+    history.add_version(rng.value(), 3, NodeChanges::default(), ChangedKeys::default(), 10)?;
+
+    assert_eq!(history.get_view_at(0)?.entry_count(), 0);
+    assert_eq!(history.get_view_at(1)?.entry_count(), 5);
+    assert_eq!(history.get_view_at(2)?.entry_count(), 3);
+    assert_eq!(history.get_view_at(3)?.entry_count(), 10);
+
+    Ok(())
+}
+
+#[test]
+fn entry_count_after_eviction() -> Result<()> {
+    let mut rng = ContinuousRng::new([0x1e; 32]);
+    let mut history = History::empty(2);
+
+    // Add 3 versions to a history that can hold only 2, causing eviction of the oldest.
+    history.add_version(rng.value(), 0, NodeChanges::default(), ChangedKeys::default(), 1)?;
+    history.add_version(rng.value(), 1, NodeChanges::default(), ChangedKeys::default(), 5)?;
+    history.add_version(rng.value(), 2, NodeChanges::default(), ChangedKeys::default(), 10)?;
+
+    // Version 0 should have been evicted.
+    assert!(history.get_view_at(0).is_err());
+
+    // The remaining versions should still have the correct entry counts.
+    assert_eq!(history.get_view_at(1)?.entry_count(), 5);
+    assert_eq!(history.get_view_at(2)?.entry_count(), 10);
+
+    Ok(())
+}
+
+#[test]
+fn entry_count_after_truncation() -> Result<()> {
+    let mut rng = ContinuousRng::new([0x1f; 32]);
+    let mut history = History::empty(4);
+
+    history.add_version(rng.value(), 5, NodeChanges::default(), ChangedKeys::default(), 2)?;
+    history.add_version(rng.value(), 10, NodeChanges::default(), ChangedKeys::default(), 7)?;
+    history.add_version(rng.value(), 15, NodeChanges::default(), ChangedKeys::default(), 12)?;
+
+    // Truncate to version 10, removing version 5.
+    history.truncate(10);
+    assert_eq!(history.num_versions(), 2);
+
+    // The surviving versions should retain their entry counts.
+    assert_eq!(history.get_view_at(10)?.entry_count(), 7);
+    assert_eq!(history.get_view_at(15)?.entry_count(), 12);
+
+    Ok(())
+}
+
+#[test]
+fn entry_count_reaches_zero_through_removals() -> Result<()> {
+    let mut rng = ContinuousRng::new([0x20; 32]);
+    let mut history = History::empty(4);
+
+    // Simulate a tree that gains entries and then has them all removed.
+    history.add_version(rng.value(), 0, NodeChanges::default(), ChangedKeys::default(), 0)?;
+    history.add_version(rng.value(), 1, NodeChanges::default(), ChangedKeys::default(), 3)?;
+    history.add_version(rng.value(), 2, NodeChanges::default(), ChangedKeys::default(), 1)?;
+    history.add_version(rng.value(), 3, NodeChanges::default(), ChangedKeys::default(), 0)?;
+
+    assert_eq!(history.get_view_at(0)?.entry_count(), 0);
+    assert_eq!(history.get_view_at(1)?.entry_count(), 3);
+    assert_eq!(history.get_view_at(2)?.entry_count(), 1);
+    assert_eq!(history.get_view_at(3)?.entry_count(), 0);
 
     Ok(())
 }

--- a/miden-crypto/src/merkle/smt/large_forest/mod.rs
+++ b/miden-crypto/src/merkle/smt/large_forest/mod.rs
@@ -678,14 +678,9 @@ impl<B: Backend> LargeSmtForest<B> {
     ///
     /// # Performance
     ///
-    /// Due to the way that tree data is stored, this method exhibits a split performance profile.
-    ///
-    /// - If querying for a `tree` that is the latest in its lineage, the time to return a result
-    ///   should be constant.
-    /// - If querying for a `tree` that is a historical version, the time to return a result will be
-    ///   linear in the number of entries in the tree. This is because an overlaid iterator has to
-    ///   be created to yield the correct entries for the historical version, and then queried for
-    ///   its length.
+    /// This method should always return its result in constant time. The exact performance profile
+    /// to do this is dependent on the backend for the most recent tree, but for historical trees
+    /// will be the same regardless of the backend in use.
     ///
     /// # Errors
     ///
@@ -715,19 +710,7 @@ impl<B: Backend> LargeSmtForest<B> {
             return Err(LargeSmtForestError::UnknownTree(tree));
         };
 
-        // In the general case there is no faster path than doing the iteration to merge the
-        // history with the full tree, so we just count the iterator.
-        //
-        // We have to do it this way to avoid silently swallowing errors during iteration.
-        let iterator =
-            EntriesIterator::new_with_history(self.backend.entries(tree.lineage())?, view);
-        let mut count = 0;
-        for entry in iterator {
-            entry?;
-            count += 1;
-        }
-
-        Ok(count)
+        Ok(view.entry_count())
     }
 
     /// Returns an iterator that yields the entries in the specified `tree`.
@@ -865,6 +848,16 @@ impl<B: Backend> LargeSmtForest<B> {
             return Err(LargeSmtForestError::UnknownLineage(lineage));
         };
 
+        // We capture the entry count before the backend update, as this is the count for the
+        // version being pushed into history. This must precede `update_tree` because the backend
+        // entry count changes after that call.
+        //
+        // By the contract of the `Backend` trait, `entry_count` is expected to be extremely cheap,
+        // and only fail if the lineage in question is missing. Versions of this method that are
+        // expensive to call, or that can fail due to I/O or other such reasons, are considered
+        // non-conformant.
+        let old_entry_count = self.backend.entry_count(lineage)?;
+
         // We now know that we have a valid lineage and a valid version, so we perform the update in
         // the backend.
         let reversion_set = self.backend.update_tree(lineage, new_version, updates)?;
@@ -888,7 +881,11 @@ impl<B: Backend> LargeSmtForest<B> {
         // hence should only ever fail due to a programmer bug so we panic if it does fail.
         lineage_data
             .history
-            .add_version_from_mutation_set(lineage_data.latest_version, reversion_set)
+            .add_version_from_mutation_set(
+                lineage_data.latest_version,
+                reversion_set,
+                old_entry_count,
+            )
             .unwrap_or_else(|_| {
                 panic!("Unable to add valid version {} to history", lineage_data.latest_version)
             });
@@ -1018,6 +1015,22 @@ impl<B: Backend> LargeSmtForest<B> {
             })
             .collect::<Result<Vec<_>>>()?;
 
+        // We capture the entry counts before the backend update, as these are the counts for the
+        // versions being pushed into history. This must precede `update_forest` because the
+        // backend entry counts change after that call. We capture for all lineages eagerly
+        // (including those that may produce no-op updates) to keep the logic simple and consistent
+        // with `update_tree`, and use a map to eliminate any accidental dependencies on iteration
+        // order.
+        //
+        // By the contract of the `Backend` trait, `entry_count` is expected to be extremely cheap,
+        // and only fail if the lineage in question is missing. Versions of this method that are
+        // expensive to call, or that can fail due to I/O or other such reasons, are considered
+        // non-conformant.
+        let old_entry_counts: Map<LineageId, usize> = updates
+            .lineages()
+            .map(|lineage| Ok((*lineage, self.backend.entry_count(*lineage)?)))
+            .collect::<Result<_>>()?;
+
         // With the preconditions checked we can call into the backend to perform the updates, and
         // we forward all errors as this will be correct for conformant backend implementations.
         let reversion_sets = self.backend.update_forest(new_version, updates)?;
@@ -1027,6 +1040,8 @@ impl<B: Backend> LargeSmtForest<B> {
         reversion_sets
             .into_iter()
             .map(|(lineage, reversion)| {
+                // Known to exist by construction, so the bare index is safe.
+                let old_entry_count = old_entry_counts[&lineage];
                 let lineage_data = self
                     .lineage_data
                     .get_mut(&lineage)
@@ -1049,7 +1064,11 @@ impl<B: Backend> LargeSmtForest<B> {
                 // hence should only ever fail due to a programmer bug so we panic if it does fail.
                 lineage_data
                     .history
-                    .add_version_from_mutation_set(lineage_data.latest_version, reversion)
+                    .add_version_from_mutation_set(
+                        lineage_data.latest_version,
+                        reversion,
+                        old_entry_count,
+                    )
                     .unwrap_or_else(|_| {
                         panic!(
                             "Unable to add valid version {} to history",

--- a/miden-crypto/src/merkle/smt/large_forest/test_utils.rs
+++ b/miden-crypto/src/merkle/smt/large_forest/test_utils.rs
@@ -1,6 +1,9 @@
 #![cfg(test)]
 //! This module contains utility functions for testing the large forest.
 
+/// Placeholder entry count for tests that do not exercise or assert entry count behavior.
+pub const UNUSED_ENTRY_COUNT: usize = 0;
+
 use alloc::{string::ToString, vec::Vec};
 use core::error::Error;
 

--- a/miden-crypto/src/merkle/smt/large_forest/tests.rs
+++ b/miden-crypto/src/merkle/smt/large_forest/tests.rs
@@ -12,7 +12,7 @@ use alloc::vec::Vec;
 
 use assert_matches::assert_matches;
 
-use super::{Config, Result};
+use super::{Config, Result, test_utils::UNUSED_ENTRY_COUNT};
 use crate::{
     EMPTY_WORD, Map, Set, Word,
     merkle::{
@@ -626,6 +626,118 @@ fn entry_count() -> Result<()> {
     // current tree or a historical tree.
     assert_eq!(forest.entry_count(TreeId::new(lineage_1, version_1))?, 3);
     assert_eq!(forest.entry_count(TreeId::new(lineage_1, version_2))?, 3);
+
+    Ok(())
+}
+
+#[test]
+fn entry_count_historical_across_versions() -> Result<()> {
+    let backend = ForestInMemoryBackend::new();
+    let mut forest = Forest::new(backend)?;
+    let mut rng = ContinuousRng::new([0x23; 32]);
+
+    let lineage: LineageId = rng.value();
+    let version_1: VersionId = rng.value();
+
+    // Version 1: Insert 2 entries.
+    let key_1: Word = rng.value();
+    let value_1: Word = rng.value();
+    let key_2: Word = rng.value();
+    let value_2: Word = rng.value();
+
+    let mut ops = SmtUpdateBatch::empty();
+    ops.add_insert(key_1, value_1);
+    ops.add_insert(key_2, value_2);
+    forest.add_lineage(lineage, version_1, ops)?;
+
+    // Version 2: Insert 1 more entry (total 3).
+    let version_2 = version_1 + 1;
+    let key_3: Word = rng.value();
+    let value_3: Word = rng.value();
+
+    let mut ops = SmtUpdateBatch::empty();
+    ops.add_insert(key_3, value_3);
+    forest.update_tree(lineage, version_2, ops)?;
+
+    // Version 3: Remove 1 entry (total 2).
+    let version_3 = version_2 + 1;
+    let mut ops = SmtUpdateBatch::empty();
+    ops.add_remove(key_1);
+    forest.update_tree(lineage, version_3, ops)?;
+
+    // Verify entry counts for all versions.
+    assert_eq!(forest.entry_count(TreeId::new(lineage, version_1))?, 2);
+    assert_eq!(forest.entry_count(TreeId::new(lineage, version_2))?, 3);
+    assert_eq!(forest.entry_count(TreeId::new(lineage, version_3))?, 2);
+
+    Ok(())
+}
+
+#[test]
+fn entry_count_historical_across_versions_via_update_forest() -> Result<()> {
+    let backend = ForestInMemoryBackend::new();
+    let mut forest = Forest::new(backend)?;
+    let mut rng = ContinuousRng::new([0x24; 32]);
+
+    // Set up two lineages so we exercise the update_forest path (which updates multiple lineages
+    // in a single batch).
+    let lineage_a: LineageId = rng.value();
+    let lineage_b: LineageId = rng.value();
+    let version_1: VersionId = rng.value();
+
+    // Version 1: lineage_a gets 2 entries, lineage_b gets 1 entry.
+    let a_key_1: Word = rng.value();
+    let a_value_1: Word = rng.value();
+    let a_key_2: Word = rng.value();
+    let a_value_2: Word = rng.value();
+    let b_key_1: Word = rng.value();
+    let b_value_1: Word = rng.value();
+
+    let mut ops_a = SmtUpdateBatch::empty();
+    ops_a.add_insert(a_key_1, a_value_1);
+    ops_a.add_insert(a_key_2, a_value_2);
+    forest.add_lineage(lineage_a, version_1, ops_a)?;
+
+    let mut ops_b = SmtUpdateBatch::empty();
+    ops_b.add_insert(b_key_1, b_value_1);
+    forest.add_lineage(lineage_b, version_1, ops_b)?;
+
+    // Version 2 via update_forest: add 1 entry to lineage_a (total 3), add 2 entries to
+    // lineage_b (total 3).
+    let version_2 = version_1 + 1;
+    let a_key_3: Word = rng.value();
+    let a_value_3: Word = rng.value();
+    let b_key_2: Word = rng.value();
+    let b_value_2: Word = rng.value();
+    let b_key_3: Word = rng.value();
+    let b_value_3: Word = rng.value();
+
+    let mut batch = SmtForestUpdateBatch::empty();
+    batch.operations(lineage_a).add_insert(a_key_3, a_value_3);
+    batch.operations(lineage_b).add_insert(b_key_2, b_value_2);
+    batch.operations(lineage_b).add_insert(b_key_3, b_value_3);
+    forest.update_forest(version_2, batch)?;
+
+    // Version 3 via update_forest: remove 1 entry from lineage_a (total 2), add 1 entry to
+    // lineage_b (total 4).
+    let version_3 = version_2 + 1;
+    let b_key_4: Word = rng.value();
+    let b_value_4: Word = rng.value();
+
+    let mut batch = SmtForestUpdateBatch::empty();
+    batch.operations(lineage_a).add_remove(a_key_1);
+    batch.operations(lineage_b).add_insert(b_key_4, b_value_4);
+    forest.update_forest(version_3, batch)?;
+
+    // Verify historical entry counts for lineage_a.
+    assert_eq!(forest.entry_count(TreeId::new(lineage_a, version_1))?, 2);
+    assert_eq!(forest.entry_count(TreeId::new(lineage_a, version_2))?, 3);
+    assert_eq!(forest.entry_count(TreeId::new(lineage_a, version_3))?, 2);
+
+    // Verify historical entry counts for lineage_b.
+    assert_eq!(forest.entry_count(TreeId::new(lineage_b, version_1))?, 1);
+    assert_eq!(forest.entry_count(TreeId::new(lineage_b, version_2))?, 3);
+    assert_eq!(forest.entry_count(TreeId::new(lineage_b, version_3))?, 4);
 
     Ok(())
 }
@@ -1311,7 +1423,9 @@ fn truncate_removes_emptied_lineages_from_non_empty_histories() {
     let mut history = History::empty(4);
     let nodes = NodeChanges::default();
     let changed_keys = ChangedKeys::default();
-    history.add_version(rand_value(), 5, nodes, changed_keys).unwrap();
+    history
+        .add_version(rand_value(), 5, nodes, changed_keys, UNUSED_ENTRY_COUNT)
+        .unwrap();
     assert_eq!(history.num_versions(), 1);
 
     let lineage_data = LineageData {
@@ -1356,10 +1470,10 @@ fn truncate_retains_non_empty_lineages_in_non_empty_histories() {
     let nodes = NodeChanges::default();
     let changed_keys = ChangedKeys::default();
     history
-        .add_version(rand_value(), 5, nodes.clone(), changed_keys.clone())
+        .add_version(rand_value(), 5, nodes.clone(), changed_keys.clone(), UNUSED_ENTRY_COUNT)
         .unwrap();
     history
-        .add_version(rand_value(), 8, nodes.clone(), changed_keys.clone())
+        .add_version(rand_value(), 8, nodes.clone(), changed_keys.clone(), UNUSED_ENTRY_COUNT)
         .unwrap();
     assert_eq!(history.num_versions(), 2);
 
@@ -1449,13 +1563,12 @@ fn entries_with_fallible_backend() -> Result<()> {
 }
 
 #[test]
-fn entry_count_with_fallible_backend() -> Result<()> {
+fn entry_count_historical_bypasses_fallible_entries_iterator() -> Result<()> {
     let backend = FallibleEntriesBackend::new();
     let mut forest = LargeSmtForest::new(backend)?;
     let mut rng = ContinuousRng::new([0xfb; 32]);
 
-    // Add a lineage with more than 3 entries at version V1 so we can verify that the iteration
-    // stops at the failure point and does not silently count additional entries.
+    // Add a lineage with 5 entries at version V1.
     let lineage: LineageId = rng.value();
     let version_1: VersionId = rng.value();
     let key_1: Word = rng.value();
@@ -1487,9 +1600,10 @@ fn entry_count_with_fallible_backend() -> Result<()> {
     forest.update_tree(lineage, version_2, operations)?;
 
     // Query entry_count for the historical version V1.
-    // This takes the WithHistory iteration path, which will hit our fallible iterator.
+    // With the stored entry count optimization, this no longer iterates through entries,
+    // so it succeeds even with a fallible backend.
     let result = forest.entry_count(TreeId::new(lineage, version_1));
-    assert_matches!(result, Err(LargeSmtForestError::Unspecified(msg)) if msg == "simulated read failure");
+    assert_eq!(result?, 5);
 
     Ok(())
 }


### PR DESCRIPTION
## Describe your changes

This commit eagerly computes historical entry counts when creating the history deltas, making it possible to provide the true historical entry counts without traversing the historical entries of the tree. This drastically improves the performance of `entry_count`, while avoiding any regressions in other code paths.

Closes #889. Marked as 'no changelog' as all changes are internal to the forest and should not break clients.

## Checklist before requesting a review

- [x] Repo forked and branch created from `next` according to naming convention.
- [x] Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- [x] Relevant issues are linked in the PR description.
- [x] Tests added for new functionality.
- [x] Documentation/comments updated according to changes.
