### PR TITLE
refactor(Word): Make `Word` constants consistent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Adds `LargeSmtForest::add_lineages` which provides an efficient means of adding multiple new lineages at once ([#910](https://github.com/0xMiden/crypto/pull/910)).
 - [BREAKING] Removed `LexicographicWord` as `Word` itself now implements the correct comparison behavior. Any place where the former is used should be able to seamlessly swap to the latter.
 - Added `Serializable` and `Deserializable` instances for `Arc<str>`.
+- [BREAKING] Removed `WORD_SIZE_FELTS` and `WORD_SIZE_BYTES` from `miden-field` in favor of `Word::NUM_FELTS` and `Word::SERIALIZED_SIZE`, respectively. The values remain the same.
+- [BREAKING] `WORD_SIZE` has been removed from `miden-crypto` in favor of `Word::NUM_FELTS`. Clients will need to update references to the constant, but `Word` will already be in scope as it is re-exported from `miden-crypto`.
 
 ## 0.23.0 (2026-03-11)
 

--- a/miden-crypto/src/lib.rs
+++ b/miden-crypto/src/lib.rs
@@ -107,11 +107,6 @@ pub mod stark {
 #[cfg(feature = "std")]
 pub type Map<K, V> = std::collections::HashMap<K, V>;
 
-#[cfg(feature = "std")]
-pub use std::collections::hash_map::Entry as MapEntry;
-#[cfg(feature = "std")]
-pub use std::collections::hash_map::IntoIter as MapIntoIter;
-
 /// An alias for a key-value map.
 ///
 /// When the `std` feature is enabled, this is an alias for [`std::collections::HashMap`].
@@ -123,6 +118,10 @@ pub type Map<K, V> = alloc::collections::BTreeMap<K, V>;
 pub use alloc::collections::btree_map::Entry as MapEntry;
 #[cfg(not(feature = "std"))]
 pub use alloc::collections::btree_map::IntoIter as MapIntoIter;
+#[cfg(feature = "std")]
+pub use std::collections::hash_map::Entry as MapEntry;
+#[cfg(feature = "std")]
+pub use std::collections::hash_map::IntoIter as MapIntoIter;
 
 /// An alias for a simple set.
 ///
@@ -141,17 +140,14 @@ pub type Set<V> = alloc::collections::BTreeSet<V>;
 // CONSTANTS
 // ================================================================================================
 
-/// Number of field elements in a word.
-pub const WORD_SIZE: usize = word::WORD_SIZE_FELTS;
-
-/// Field element representing ZERO in the Miden base filed.
+/// Field element representing ZERO in the Miden base field.
 pub const ZERO: Felt = Felt::ZERO;
 
-/// Field element representing ONE in the Miden base filed.
+/// Field element representing ONE in the Miden base field.
 pub const ONE: Felt = Felt::ONE;
 
 /// Array of field elements representing word of ZEROs in the Miden base field.
-pub const EMPTY_WORD: Word = Word::new([ZERO; WORD_SIZE]);
+pub const EMPTY_WORD: Word = Word::new([ZERO; Word::NUM_ELEMENTS]);
 
 // TRAITS
 // ================================================================================================

--- a/miden-crypto/src/merkle/merkle_tree.rs
+++ b/miden-crypto/src/merkle/merkle_tree.rs
@@ -276,11 +276,11 @@ mod tests {
 
     use super::*;
     use crate::{
-        Felt, WORD_SIZE,
+        Felt,
         merkle::{int_to_leaf, int_to_node},
     };
 
-    const LEAVES4: [Word; WORD_SIZE] =
+    const LEAVES4: [Word; Word::NUM_ELEMENTS] =
         [int_to_node(1), int_to_node(2), int_to_node(3), int_to_node(4)];
 
     const LEAVES8: [Word; 8] = [

--- a/miden-crypto/src/merkle/smt/forest/mod.rs
+++ b/miden-crypto/src/merkle/smt/forest/mod.rs
@@ -25,7 +25,7 @@ mod tests;
 ///
 /// ```rust
 /// use miden_crypto::{
-///     Felt, ONE, WORD_SIZE, Word, ZERO,
+///     Felt, ONE, Word, ZERO,
 ///     merkle::{
 ///         EmptySubtreeRoots,
 ///         smt::{MAX_LEAF_ENTRIES, SMT_DEPTH, SmtForest},
@@ -37,15 +37,15 @@ mod tests;
 ///
 /// // Insert a key-value pair into an SMT with an empty root
 /// let empty_tree_root = *EmptySubtreeRoots::entry(SMT_DEPTH, 0);
-/// let key = Word::new([ZERO; WORD_SIZE]);
-/// let value = Word::new([ONE; WORD_SIZE]);
+/// let key = Word::new([ZERO; Word::NUM_ELEMENTS]);
+/// let value = Word::new([ONE; Word::NUM_ELEMENTS]);
 /// let new_root = forest.insert(empty_tree_root, key, value).unwrap();
 ///
 /// // Insert multiple key-value pairs
 /// let mut entries = Vec::new();
 /// for i in 0..MAX_LEAF_ENTRIES {
-///     let key = Word::new([Felt::new(i as u64); WORD_SIZE]);
-///     let value = Word::new([Felt::new((i + 1) as u64); WORD_SIZE]);
+///     let key = Word::new([Felt::new(i as u64); Word::NUM_ELEMENTS]);
+///     let value = Word::new([Felt::new((i + 1) as u64); Word::NUM_ELEMENTS]);
 ///     entries.push((key, value));
 /// }
 /// let new_root = forest.batch_insert(new_root, entries.into_iter()).unwrap();

--- a/miden-crypto/src/merkle/smt/forest/tests.rs
+++ b/miden-crypto/src/merkle/smt/forest/tests.rs
@@ -3,7 +3,7 @@ use itertools::Itertools;
 
 use super::{EmptySubtreeRoots, MerkleError, SmtForest, Word};
 use crate::{
-    EMPTY_WORD, Felt, ONE, WORD_SIZE, ZERO,
+    EMPTY_WORD, Felt, ONE, ZERO,
     merkle::{
         int_to_node,
         smt::{SMT_DEPTH, SmtProofError},
@@ -16,7 +16,7 @@ use crate::{
 #[test]
 fn test_insert_root_not_in_store() -> Result<(), MerkleError> {
     let mut forest = SmtForest::new();
-    let word = Word::new([ONE; WORD_SIZE]);
+    let word = Word::new([ONE; Word::NUM_ELEMENTS]);
     assert_matches!(
         forest.insert(word, word, word),
         Err(MerkleError::RootNotInStore(_)),
@@ -30,8 +30,8 @@ fn test_insert_root_not_in_store() -> Result<(), MerkleError> {
 fn test_insert_root_empty() -> Result<(), MerkleError> {
     let mut forest = SmtForest::new();
     let empty_tree_root = *EmptySubtreeRoots::entry(SMT_DEPTH, 0);
-    let key = Word::new([ZERO; WORD_SIZE]);
-    let value = Word::new([ONE; WORD_SIZE]);
+    let key = Word::new([ZERO; Word::NUM_ELEMENTS]);
+    let value = Word::new([ONE; Word::NUM_ELEMENTS]);
     assert_eq!(
         forest.insert(empty_tree_root, key, value)?,
         Word::new([
@@ -49,8 +49,8 @@ fn test_insert_multiple_values() -> Result<(), MerkleError> {
     let mut forest = SmtForest::new();
 
     let empty_tree_root = *EmptySubtreeRoots::entry(SMT_DEPTH, 0);
-    let key = Word::new([ZERO; WORD_SIZE]);
-    let value = Word::new([ONE; WORD_SIZE]);
+    let key = Word::new([ZERO; Word::NUM_ELEMENTS]);
+    let value = Word::new([ONE; Word::NUM_ELEMENTS]);
     let new_root = forest.insert(empty_tree_root, key, value)?;
     assert_eq!(
         new_root,
@@ -99,9 +99,9 @@ fn test_batch_insert() -> Result<(), MerkleError> {
     let empty_tree_root = *EmptySubtreeRoots::entry(SMT_DEPTH, 0);
 
     let values = vec![
-        (Word::new([ZERO; WORD_SIZE]), Word::new([ONE; WORD_SIZE])),
-        (Word::new([ZERO, ONE, ZERO, ONE]), Word::new([ONE; WORD_SIZE])),
-        (Word::new([ZERO, ONE, ZERO, ZERO]), Word::new([ONE; WORD_SIZE])),
+        (Word::new([ZERO; Word::NUM_ELEMENTS]), Word::new([ONE; Word::NUM_ELEMENTS])),
+        (Word::new([ZERO, ONE, ZERO, ONE]), Word::new([ONE; Word::NUM_ELEMENTS])),
+        (Word::new([ZERO, ONE, ZERO, ZERO]), Word::new([ONE; Word::NUM_ELEMENTS])),
     ];
 
     values.into_iter().permutations(3).for_each(|values| {
@@ -130,7 +130,7 @@ fn test_batch_insert() -> Result<(), MerkleError> {
 #[test]
 fn test_open_root_not_in_store() -> Result<(), MerkleError> {
     let forest = SmtForest::new();
-    let word = Word::new([ONE; WORD_SIZE]);
+    let word = Word::new([ONE; Word::NUM_ELEMENTS]);
     assert_matches!(
         forest.open(word, word),
         Err(MerkleError::RootNotInStore(_)),
@@ -178,8 +178,8 @@ fn test_open_root_in_store() -> Result<(), MerkleError> {
 fn test_empty_word_removes_key() -> Result<(), MerkleError> {
     let mut forest = SmtForest::new();
     let empty_root = *EmptySubtreeRoots::entry(SMT_DEPTH, 0);
-    let key = Word::from([1_u32; WORD_SIZE]);
-    let value = Word::from([2_u32; WORD_SIZE]);
+    let key = Word::from([1_u32; Word::NUM_ELEMENTS]);
+    let value = Word::from([2_u32; Word::NUM_ELEMENTS]);
 
     let root_with_value = forest.insert(empty_root, key, value)?;
     let root_after_remove = forest.insert(root_with_value, key, EMPTY_WORD)?;
@@ -200,16 +200,16 @@ fn test_multiple_versions_of_same_key() -> Result<(), MerkleError> {
     let mut forest = SmtForest::new();
 
     let empty_tree_root = *EmptySubtreeRoots::entry(SMT_DEPTH, 0);
-    let key = Word::new([ZERO; WORD_SIZE]);
+    let key = Word::new([ZERO; Word::NUM_ELEMENTS]);
 
     // Insert the same key with different values, creating multiple roots
-    let value1 = Word::new([ONE; WORD_SIZE]);
+    let value1 = Word::new([ONE; Word::NUM_ELEMENTS]);
     let root1 = forest.insert(empty_tree_root, key, value1)?;
 
-    let value2 = Word::new([Felt::new(2); WORD_SIZE]);
+    let value2 = Word::new([Felt::new(2); Word::NUM_ELEMENTS]);
     let root2 = forest.insert(root1, key, value2)?;
 
-    let value3 = Word::new([Felt::new(3); WORD_SIZE]);
+    let value3 = Word::new([Felt::new(3); Word::NUM_ELEMENTS]);
     let root3 = forest.insert(root2, key, value3)?;
 
     // All three roots should be different
@@ -254,8 +254,8 @@ fn test_pop_roots() -> Result<(), MerkleError> {
     let mut forest = SmtForest::new();
 
     let empty_tree_root = *EmptySubtreeRoots::entry(SMT_DEPTH, 0);
-    let key = Word::new([ZERO; WORD_SIZE]);
-    let value = Word::new([ONE; WORD_SIZE]);
+    let key = Word::new([ZERO; Word::NUM_ELEMENTS]);
+    let value = Word::new([ONE; Word::NUM_ELEMENTS]);
     let root = forest.insert(empty_tree_root, key, value)?;
 
     assert_eq!(forest.roots.len(), 1);
@@ -274,8 +274,8 @@ fn test_pop_and_reinsert_same_tree() -> Result<(), MerkleError> {
     let mut forest = SmtForest::new();
 
     let empty_tree_root = *EmptySubtreeRoots::entry(SMT_DEPTH, 0);
-    let key = Word::new([ZERO; WORD_SIZE]);
-    let value = Word::new([ONE; WORD_SIZE]);
+    let key = Word::new([ZERO; Word::NUM_ELEMENTS]);
+    let value = Word::new([ONE; Word::NUM_ELEMENTS]);
 
     // Insert a key, then pop the tree
     let root1 = forest.insert(empty_tree_root, key, value)?;
@@ -302,7 +302,7 @@ fn test_pop_and_reinsert_same_tree() -> Result<(), MerkleError> {
 fn test_removing_empty_smt_from_forest() {
     let mut forest = SmtForest::new();
     let empty_tree_root = *EmptySubtreeRoots::entry(SMT_DEPTH, 0);
-    let non_empty_root = Word::new([ONE; WORD_SIZE]);
+    let non_empty_root = Word::new([ONE; Word::NUM_ELEMENTS]);
 
     // Popping zero SMTs from forest should be a no-op (no panic or error)
     forest.pop_smts(vec![]);
@@ -320,8 +320,8 @@ fn test_empty_root_never_removed() -> Result<(), MerkleError> {
     // popping it does not corrupt the store.
     let mut forest = SmtForest::new();
     let empty_root = *EmptySubtreeRoots::entry(SMT_DEPTH, 0);
-    let key = Word::new([ZERO; WORD_SIZE]);
-    let value = Word::new([ONE; WORD_SIZE]);
+    let key = Word::new([ZERO; Word::NUM_ELEMENTS]);
+    let value = Word::new([ONE; Word::NUM_ELEMENTS]);
 
     // batch_insert with no entries returns the empty root — it must not be registered
     let root = forest.batch_insert(empty_root, vec![])?;

--- a/miden-crypto/src/merkle/smt/full/tests.rs
+++ b/miden-crypto/src/merkle/smt/full/tests.rs
@@ -4,7 +4,7 @@ use assert_matches::assert_matches;
 
 use super::{EMPTY_WORD, LeafIndex, NodeIndex, SMT_DEPTH, Smt, SmtLeaf};
 use crate::{
-    Felt, ONE, WORD_SIZE, Word,
+    Felt, ONE, Word,
     hash::poseidon2::Poseidon2,
     merkle::{
         EmptySubtreeRoots,
@@ -36,8 +36,8 @@ fn test_smt_insert_at_same_key() {
     };
     let key_1_index: NodeIndex = LeafIndex::<SMT_DEPTH>::from(key_1).into();
 
-    let value_1 = Word::new([ONE; WORD_SIZE]);
-    let value_2 = Word::new([ONE + ONE; WORD_SIZE]);
+    let value_1 = Word::new([ONE; Word::NUM_ELEMENTS]);
+    let value_2 = Word::new([ONE + ONE; Word::NUM_ELEMENTS]);
 
     // Insert value 1 and ensure root is as expected
     {
@@ -72,7 +72,7 @@ fn test_smt_insert_at_same_key_2() {
     let key_already_present = Word::from([2_u64, 2_u64, 2_u64, key_msb].map(Felt::new));
     let key_already_present_index: NodeIndex =
         LeafIndex::<SMT_DEPTH>::from(key_already_present).into();
-    let value_already_present = Word::new([ONE + ONE + ONE; WORD_SIZE]);
+    let value_already_present = Word::new([ONE + ONE + ONE; Word::NUM_ELEMENTS]);
 
     let mut smt =
         Smt::with_entries(core::iter::once((key_already_present, value_already_present))).unwrap();
@@ -91,8 +91,8 @@ fn test_smt_insert_at_same_key_2() {
 
     assert_eq!(key_1_index, key_already_present_index);
 
-    let value_1 = Word::new([ONE; WORD_SIZE]);
-    let value_2 = Word::new([ONE + ONE; WORD_SIZE]);
+    let value_1 = Word::new([ONE; Word::NUM_ELEMENTS]);
+    let value_2 = Word::new([ONE + ONE; Word::NUM_ELEMENTS]);
 
     // Insert value 1 and ensure root is as expected
     {
@@ -170,9 +170,9 @@ fn test_smt_insert_and_remove_multiple_values() {
         Word::from([ONE, ONE, ONE, Felt::new(raw)])
     };
 
-    let value_1 = Word::new([ONE; WORD_SIZE]);
-    let value_2 = Word::new([ONE + ONE; WORD_SIZE]);
-    let value_3 = Word::new([ONE + ONE + ONE; WORD_SIZE]);
+    let value_1 = Word::new([ONE; Word::NUM_ELEMENTS]);
+    let value_2 = Word::new([ONE + ONE; Word::NUM_ELEMENTS]);
+    let value_3 = Word::new([ONE + ONE + ONE; Word::NUM_ELEMENTS]);
 
     // Insert values in the tree
     let key_values = [(key_1, value_1), (key_2, value_2), (key_3, value_3)];
@@ -241,9 +241,9 @@ fn test_smt_removal() {
         Felt::new(raw),
     ]);
 
-    let value_1 = Word::new([ONE; WORD_SIZE]);
-    let value_2 = Word::new([Felt::from_u32(2_u32); WORD_SIZE]);
-    let value_3 = Word::new([Felt::from_u32(3_u32); WORD_SIZE]);
+    let value_1 = Word::new([ONE; Word::NUM_ELEMENTS]);
+    let value_2 = Word::new([Felt::from_u32(2_u32); Word::NUM_ELEMENTS]);
+    let value_3 = Word::new([Felt::from_u32(3_u32); Word::NUM_ELEMENTS]);
 
     // insert key-value 1
     {
@@ -322,9 +322,9 @@ fn test_prospective_hash() {
         Felt::new(raw),
     ]);
 
-    let value_1 = Word::new([ONE; WORD_SIZE]);
-    let value_2 = Word::new([Felt::from_u32(2_u32); WORD_SIZE]);
-    let value_3 = Word::new([Felt::from_u32(3_u32); WORD_SIZE]);
+    let value_1 = Word::new([ONE; Word::NUM_ELEMENTS]);
+    let value_2 = Word::new([Felt::from_u32(2_u32); Word::NUM_ELEMENTS]);
+    let value_3 = Word::new([Felt::from_u32(3_u32); Word::NUM_ELEMENTS]);
 
     // insert key-value 1
     {
@@ -445,9 +445,9 @@ fn test_prospective_insertion() {
         Felt::new(raw),
     ]);
 
-    let value_1 = Word::new([ONE; WORD_SIZE]);
-    let value_2 = Word::new([Felt::from_u32(2_u32); WORD_SIZE]);
-    let value_3 = Word::new([Felt::from_u32(3_u32); WORD_SIZE]);
+    let value_1 = Word::new([ONE; Word::NUM_ELEMENTS]);
+    let value_2 = Word::new([Felt::from_u32(2_u32); Word::NUM_ELEMENTS]);
+    let value_3 = Word::new([Felt::from_u32(3_u32); Word::NUM_ELEMENTS]);
 
     let root_empty = smt.root();
 
@@ -530,7 +530,7 @@ fn test_prospective_insertion() {
 #[test]
 fn test_mutations_no_mutations() {
     let key = Word::from([ONE, ONE, ONE, ONE]);
-    let value = Word::new([ONE; WORD_SIZE]);
+    let value = Word::new([ONE; Word::NUM_ELEMENTS]);
     let entries = [(key, value)];
 
     let tree = Smt::with_entries(entries).unwrap();
@@ -554,9 +554,9 @@ fn test_mutations_revert() {
         Felt::new(3),
     ]);
 
-    let value_1 = Word::new([ONE; WORD_SIZE]);
-    let value_2 = Word::new([Felt::from_u32(2_u32); WORD_SIZE]);
-    let value_3 = Word::new([Felt::from_u32(3_u32); WORD_SIZE]);
+    let value_1 = Word::new([ONE; Word::NUM_ELEMENTS]);
+    let value_2 = Word::new([Felt::from_u32(2_u32); Word::NUM_ELEMENTS]);
+    let value_3 = Word::new([Felt::from_u32(3_u32); Word::NUM_ELEMENTS]);
 
     smt.insert(key_1, value_1).unwrap();
     smt.insert(key_2, value_2).unwrap();
@@ -589,9 +589,9 @@ fn test_mutation_set_serialization() {
         Felt::new(3),
     ]);
 
-    let value_1 = Word::new([ONE; WORD_SIZE]);
-    let value_2 = Word::new([Felt::from_u32(2_u32); WORD_SIZE]);
-    let value_3 = Word::new([Felt::from_u32(3_u32); WORD_SIZE]);
+    let value_1 = Word::new([ONE; Word::NUM_ELEMENTS]);
+    let value_2 = Word::new([Felt::from_u32(2_u32); Word::NUM_ELEMENTS]);
+    let value_3 = Word::new([Felt::from_u32(3_u32); Word::NUM_ELEMENTS]);
 
     smt.insert(key_1, value_1).unwrap();
     smt.insert(key_2, value_2).unwrap();
@@ -621,8 +621,8 @@ fn test_smt_path_to_keys_in_same_leaf_are_equal() {
     let key_1: Word = Word::from([ONE, ONE, ONE, Felt::new(raw)]);
     let key_2: Word = Word::from([Felt::new(2), Felt::new(2), Felt::new(2), Felt::new(raw)]);
 
-    let value_1 = Word::new([ONE; WORD_SIZE]);
-    let value_2 = Word::new([Felt::from_u32(2_u32); WORD_SIZE]);
+    let value_1 = Word::new([ONE; Word::NUM_ELEMENTS]);
+    let value_2 = Word::new([Felt::from_u32(2_u32); Word::NUM_ELEMENTS]);
 
     let smt = Smt::with_entries([(key_1, value_1), (key_2, value_2)]).unwrap();
 
@@ -644,8 +644,8 @@ fn test_smt_get_value() {
     let key_1: Word = Word::from([ONE, ONE, ONE, ONE]);
     let key_2: Word = Word::from([2_u32, 2_u32, 2_u32, 2_u32]);
 
-    let value_1 = Word::new([ONE; WORD_SIZE]);
-    let value_2 = Word::new([Felt::from_u32(2_u32); WORD_SIZE]);
+    let value_1 = Word::new([ONE; Word::NUM_ELEMENTS]);
+    let value_2 = Word::new([Felt::from_u32(2_u32); Word::NUM_ELEMENTS]);
 
     let smt = Smt::with_entries([(key_1, value_1), (key_2, value_2)]).unwrap();
 
@@ -667,8 +667,8 @@ fn test_smt_entries() {
     let key_1 = Word::from([ONE, ONE, ONE, ONE]);
     let key_2 = Word::from([2_u32, 2_u32, 2_u32, 2_u32]);
 
-    let value_1 = Word::new([ONE; WORD_SIZE]);
-    let value_2 = Word::new([Felt::from_u32(2_u32); WORD_SIZE]);
+    let value_1 = Word::new([ONE; Word::NUM_ELEMENTS]);
+    let value_2 = Word::new([Felt::from_u32(2_u32); Word::NUM_ELEMENTS]);
     let entries = [(key_1, value_1), (key_2, value_2)];
 
     let smt = Smt::with_entries(entries).unwrap();
@@ -809,7 +809,7 @@ fn test_max_leaf_entries_validation() {
 #[test]
 fn test_smt_proof_error_invalid_key_for_proof() {
     let key = Word::from([ONE, ONE, ONE, Felt::new(42)]);
-    let value = Word::new([ONE; WORD_SIZE]);
+    let value = Word::new([ONE; Word::NUM_ELEMENTS]);
 
     let smt = Smt::with_entries([(key, value)]).unwrap();
     let proof = smt.open(&key);
@@ -828,14 +828,14 @@ fn test_smt_proof_error_invalid_key_for_proof() {
 #[test]
 fn test_smt_proof_error_value_mismatch() {
     let key = Word::from([ONE, ONE, ONE, Felt::new(42)]);
-    let value = Word::new([ONE; WORD_SIZE]);
+    let value = Word::new([ONE; Word::NUM_ELEMENTS]);
 
     let smt = Smt::with_entries([(key, value)]).unwrap();
     let proof = smt.open(&key);
     let root = smt.root();
 
     // Use the correct key but wrong value
-    let wrong_value = Word::new([Felt::new(999); WORD_SIZE]);
+    let wrong_value = Word::new([Felt::new(999); Word::NUM_ELEMENTS]);
 
     assert_matches!(
         proof.verify_presence(&key, &wrong_value, &root),
@@ -848,14 +848,14 @@ fn test_smt_proof_error_value_mismatch() {
 #[test]
 fn test_smt_proof_error_conflicting_roots() {
     let key = Word::from([ONE, ONE, ONE, Felt::new(42)]);
-    let value = Word::new([ONE; WORD_SIZE]);
+    let value = Word::new([ONE; Word::NUM_ELEMENTS]);
 
     let smt = Smt::with_entries([(key, value)]).unwrap();
     let proof = smt.open(&key);
     let actual_root = smt.root();
 
     // Use a completely wrong root
-    let wrong_root = Word::new([Felt::new(999); WORD_SIZE]);
+    let wrong_root = Word::new([Felt::new(999); Word::NUM_ELEMENTS]);
 
     assert_matches!(
         proof.verify_presence(&key, &value, &wrong_root),
@@ -881,7 +881,7 @@ fn test_smt_proof_verify_unset_success() {
 #[test]
 fn test_smt_proof_verify_unset_fails_when_value_exists() {
     let key = Word::from([ONE, ONE, ONE, Felt::new(42)]);
-    let value = Word::new([ONE; WORD_SIZE]);
+    let value = Word::new([ONE; Word::NUM_ELEMENTS]);
 
     let smt = Smt::with_entries([(key, value)]).unwrap();
     let proof = smt.open(&key);
@@ -895,14 +895,14 @@ fn test_smt_proof_verify_unset_fails_when_value_exists() {
 #[test]
 fn test_smt_proof_verify_absence_success_different_value() {
     let key = Word::from([ONE, ONE, ONE, Felt::new(42)]);
-    let actual_value = Word::new([ONE; WORD_SIZE]);
+    let actual_value = Word::new([ONE; Word::NUM_ELEMENTS]);
 
     let smt = Smt::with_entries([(key, actual_value)]).unwrap();
     let proof = smt.open(&key);
     let root = smt.root();
 
     // The key has a different value, so this pair is absent
-    let absent_value = Word::new([Felt::new(999); WORD_SIZE]);
+    let absent_value = Word::new([Felt::new(999); Word::NUM_ELEMENTS]);
     proof.verify_absence(&key, &absent_value, &root).unwrap();
 }
 
@@ -916,7 +916,7 @@ fn test_smt_proof_verify_absence_success_key_unset() {
     let root = smt.root();
 
     // Any non-empty value should be absent since key is unset
-    let value = Word::new([ONE; WORD_SIZE]);
+    let value = Word::new([ONE; Word::NUM_ELEMENTS]);
     proof.verify_absence(&key, &value, &root).unwrap();
 }
 
@@ -924,7 +924,7 @@ fn test_smt_proof_verify_absence_success_key_unset() {
 #[test]
 fn test_smt_proof_error_value_present() {
     let key = Word::from([ONE, ONE, ONE, Felt::new(42)]);
-    let value = Word::new([ONE; WORD_SIZE]);
+    let value = Word::new([ONE; Word::NUM_ELEMENTS]);
 
     let smt = Smt::with_entries([(key, value)]).unwrap();
     let proof = smt.open(&key);
@@ -941,7 +941,7 @@ fn test_smt_proof_error_value_present() {
 #[test]
 fn test_smt_proof_verify_absence_invalid_key() {
     let key = Word::from([ONE, ONE, ONE, Felt::new(42)]);
-    let value = Word::new([ONE; WORD_SIZE]);
+    let value = Word::new([ONE; Word::NUM_ELEMENTS]);
 
     let smt = Smt::with_entries([(key, value)]).unwrap();
     let proof = smt.open(&key);
@@ -960,7 +960,7 @@ fn test_smt_proof_verify_absence_invalid_key() {
 #[test]
 fn test_smt_proof_get_returns_none_for_different_leaf() {
     let key = Word::from([ONE, ONE, ONE, Felt::new(42)]);
-    let value = Word::new([ONE; WORD_SIZE]);
+    let value = Word::new([ONE; Word::NUM_ELEMENTS]);
 
     let smt = Smt::with_entries([(key, value)]).unwrap();
     let proof = smt.open(&key);
@@ -978,7 +978,7 @@ fn test_smt_proof_get_returns_none_for_different_leaf() {
 #[test]
 fn test_smt_proof_get_returns_empty_for_absent_key_same_leaf() {
     let key = Word::from([ONE, ONE, ONE, Felt::new(42)]);
-    let value = Word::new([ONE; WORD_SIZE]);
+    let value = Word::new([ONE; Word::NUM_ELEMENTS]);
 
     let smt = Smt::with_entries([(key, value)]).unwrap();
     let proof = smt.open(&key);
@@ -1057,7 +1057,7 @@ fn test_compute_mutations_rejects_duplicate_keys() {
 
     let smt = Smt::default();
     let key = Word::from([ONE, ONE, ONE, Felt::new(42)]);
-    let value = Word::new([ONE; WORD_SIZE]);
+    let value = Word::new([ONE; Word::NUM_ELEMENTS]);
 
     let result = smt.compute_mutations(vec![(key, value), (key, value)]);
 
@@ -1072,8 +1072,8 @@ fn test_compute_mutations_rejects_duplicate_keys_different_values() {
 
     let smt = Smt::default();
     let key = Word::from([ONE, ONE, ONE, Felt::new(42)]);
-    let value_1 = Word::new([ONE; WORD_SIZE]);
-    let value_2 = Word::new([Felt::from_u32(2_u32); WORD_SIZE]);
+    let value_1 = Word::new([ONE; Word::NUM_ELEMENTS]);
+    let value_2 = Word::new([Felt::from_u32(2_u32); Word::NUM_ELEMENTS]);
 
     let result = smt.compute_mutations(vec![(key, value_1), (key, value_2)]);
 
@@ -1093,9 +1093,9 @@ fn test_compute_mutations_rejects_interleaved_duplicate_keys() {
     let key_1 = Word::from([ONE, ONE, ONE, Felt::new(42)]);
     let key_2 = Word::from([Felt::new(2), Felt::new(2), Felt::new(2), Felt::new(42)]);
 
-    let value_1 = Word::new([ONE; WORD_SIZE]);
-    let value_2 = Word::new([Felt::from_u32(2_u32); WORD_SIZE]);
-    let value_3 = Word::new([Felt::from_u32(3_u32); WORD_SIZE]);
+    let value_1 = Word::new([ONE; Word::NUM_ELEMENTS]);
+    let value_2 = Word::new([Felt::from_u32(2_u32); Word::NUM_ELEMENTS]);
+    let value_3 = Word::new([Felt::from_u32(3_u32); Word::NUM_ELEMENTS]);
 
     // k1 appears at positions 0 and 2, interleaved with k2
     let result = smt.compute_mutations(vec![(key_1, value_1), (key_2, value_2), (key_1, value_3)]);
@@ -1113,8 +1113,8 @@ fn test_compute_mutations_no_false_positives() {
     let key_1 = Word::from([ONE, ONE, ONE, Felt::new(42)]);
     let key_2 = Word::from([Felt::new(2), Felt::new(2), Felt::new(2), Felt::new(42)]);
 
-    let value_1 = Word::new([ONE; WORD_SIZE]);
-    let value_2 = Word::new([Felt::from_u32(2_u32); WORD_SIZE]);
+    let value_1 = Word::new([ONE; Word::NUM_ELEMENTS]);
+    let value_2 = Word::new([Felt::from_u32(2_u32); Word::NUM_ELEMENTS]);
 
     // These are different keys (despite sharing a leaf index), so this should succeed.
     let result = smt.compute_mutations(vec![(key_1, value_1), (key_2, value_2)]);
@@ -1128,8 +1128,8 @@ fn test_with_entries_rejects_duplicate_keys() {
     use crate::merkle::MerkleError;
 
     let key = Word::from([ONE, ONE, ONE, Felt::new(42)]);
-    let value_1 = Word::new([ONE; WORD_SIZE]);
-    let value_2 = Word::new([Felt::from_u32(2_u32); WORD_SIZE]);
+    let value_1 = Word::new([ONE; Word::NUM_ELEMENTS]);
+    let value_2 = Word::new([Felt::from_u32(2_u32); Word::NUM_ELEMENTS]);
 
     let result = Smt::with_entries(vec![(key, value_1), (key, value_2)]);
 
@@ -1146,9 +1146,9 @@ fn test_with_entries_rejects_interleaved_duplicate_keys() {
     let key_1 = Word::from([ONE, ONE, ONE, Felt::new(42)]);
     let key_2 = Word::from([Felt::new(2), Felt::new(2), Felt::new(2), Felt::new(42)]);
 
-    let value_1 = Word::new([ONE; WORD_SIZE]);
-    let value_2 = Word::new([Felt::from_u32(2_u32); WORD_SIZE]);
-    let value_3 = Word::new([Felt::from_u32(3_u32); WORD_SIZE]);
+    let value_1 = Word::new([ONE; Word::NUM_ELEMENTS]);
+    let value_2 = Word::new([Felt::from_u32(2_u32); Word::NUM_ELEMENTS]);
+    let value_3 = Word::new([Felt::from_u32(3_u32); Word::NUM_ELEMENTS]);
 
     // k1 appears at positions 0 and 2, interleaved with k2
     let result = Smt::with_entries(vec![(key_1, value_1), (key_2, value_2), (key_1, value_3)]);

--- a/miden-crypto/src/merkle/smt/large/tests.rs
+++ b/miden-crypto/src/merkle/smt/large/tests.rs
@@ -4,7 +4,7 @@ use rand::{Rng, prelude::IteratorRandom, rng};
 
 use super::MemoryStorage;
 use crate::{
-    EMPTY_WORD, Felt, ONE, WORD_SIZE, Word,
+    EMPTY_WORD, Felt, ONE, Word,
     merkle::{
         InnerNodeInfo,
         smt::{
@@ -64,8 +64,8 @@ fn test_smt_get_value() {
     let key_1: Word = Word::from([ONE, ONE, ONE, ONE]);
     let key_2: Word = Word::from([2_u32, 2_u32, 2_u32, 2_u32]);
 
-    let value_1 = Word::new([ONE; WORD_SIZE]);
-    let value_2 = Word::new([Felt::from_u32(2_u32); WORD_SIZE]);
+    let value_1 = Word::new([ONE; Word::NUM_ELEMENTS]);
+    let value_2 = Word::new([Felt::from_u32(2_u32); Word::NUM_ELEMENTS]);
     let smt = LargeSmt::<_>::with_entries(storage, [(key_1, value_1), (key_2, value_2)]).unwrap();
 
     let returned_value_1 = smt.get_value(&key_1);
@@ -197,7 +197,7 @@ fn test_empty_smt() {
 fn test_single_entry_smt() {
     let storage = MemoryStorage::new();
     let key = Word::new([ONE, ONE, ONE, ONE]);
-    let value = Word::new([ONE; WORD_SIZE]);
+    let value = Word::new([ONE; Word::NUM_ELEMENTS]);
 
     let mut smt = LargeSmt::<_>::with_entries(storage, [(key, value)]).unwrap();
 
@@ -213,7 +213,7 @@ fn test_single_entry_smt() {
     assert_eq!(entries.len(), 1, "Single entry SMT should have one entry");
     assert_eq!(entries[0], (key, value), "Single entry SMT entry mismatch");
 
-    let new_value = Word::new([Felt::from_u32(2_u32); WORD_SIZE]);
+    let new_value = Word::new([Felt::from_u32(2_u32); Word::NUM_ELEMENTS]);
     let mutations = smt.compute_mutations(vec![(key, new_value)]).unwrap();
 
     assert_eq!(
@@ -247,8 +247,8 @@ fn test_single_entry_smt() {
 fn test_duplicate_key_insertion() {
     let storage = MemoryStorage::new();
     let key = Word::from([ONE, ONE, ONE, ONE]);
-    let value1 = Word::new([ONE; WORD_SIZE]);
-    let value2 = Word::new([Felt::from_u32(2_u32); WORD_SIZE]);
+    let value1 = Word::new([ONE; Word::NUM_ELEMENTS]);
+    let value2 = Word::new([Felt::from_u32(2_u32); Word::NUM_ELEMENTS]);
 
     let entries = vec![(key, value1), (key, value2)];
 
@@ -262,7 +262,7 @@ fn test_compute_mutations_rejects_duplicate_keys() {
     let smt = LargeSmt::<_>::with_entries(storage, vec![]).unwrap();
 
     let key = Word::from([ONE, ONE, ONE, ONE]);
-    let value = Word::new([ONE; WORD_SIZE]);
+    let value = Word::new([ONE; Word::NUM_ELEMENTS]);
 
     let entries = vec![(key, value), (key, value)];
     let result = smt.compute_mutations(entries);
@@ -281,9 +281,9 @@ fn test_compute_mutations_rejects_interleaved_duplicate_keys() {
     let key_1 = Word::from([ONE, ONE, ONE, Felt::new(42)]);
     let key_2 = Word::from([Felt::new(2), Felt::new(2), Felt::new(2), Felt::new(42)]);
 
-    let value_1 = Word::new([ONE; WORD_SIZE]);
-    let value_2 = Word::new([Felt::from_u32(2_u32); WORD_SIZE]);
-    let value_3 = Word::new([Felt::from_u32(3_u32); WORD_SIZE]);
+    let value_1 = Word::new([ONE; Word::NUM_ELEMENTS]);
+    let value_2 = Word::new([Felt::from_u32(2_u32); Word::NUM_ELEMENTS]);
+    let value_3 = Word::new([Felt::from_u32(3_u32); Word::NUM_ELEMENTS]);
 
     // k1 appears at positions 0 and 2, interleaved with k2
     let entries = vec![(key_1, value_1), (key_2, value_2), (key_1, value_3)];
@@ -300,8 +300,8 @@ fn test_insert_batch_rejects_duplicate_keys() {
     let mut smt = LargeSmt::<_>::with_entries(storage, vec![]).unwrap();
 
     let key = Word::from([ONE, ONE, ONE, ONE]);
-    let value1 = Word::new([ONE; WORD_SIZE]);
-    let value2 = Word::new([Felt::from_u32(2_u32); WORD_SIZE]);
+    let value1 = Word::new([ONE; Word::NUM_ELEMENTS]);
+    let value2 = Word::new([Felt::from_u32(2_u32); Word::NUM_ELEMENTS]);
 
     let entries = vec![(key, value1), (key, value2)];
     let result = smt.insert_batch(entries);
@@ -312,11 +312,11 @@ fn test_insert_batch_rejects_duplicate_keys() {
 fn test_delete_entry() {
     let storage = MemoryStorage::new();
     let key1 = Word::new([ONE, ONE, ONE, ONE]);
-    let value1 = Word::new([ONE; WORD_SIZE]);
+    let value1 = Word::new([ONE; Word::NUM_ELEMENTS]);
     let key2 = Word::from([2_u32, 2_u32, 2_u32, 2_u32]);
-    let value2 = Word::new([Felt::from_u32(2_u32); WORD_SIZE]);
+    let value2 = Word::new([Felt::from_u32(2_u32); Word::NUM_ELEMENTS]);
     let key3 = Word::from([3_u32, 3_u32, 3_u32, 3_u32]);
-    let value3 = Word::new([Felt::from_u32(3_u32); WORD_SIZE]);
+    let value3 = Word::new([Felt::from_u32(3_u32); Word::NUM_ELEMENTS]);
 
     let initial_entries = vec![(key1, value1), (key2, value2), (key3, value3)];
 
@@ -358,7 +358,7 @@ fn test_insert_entry() {
     assert_eq!(large_smt.num_leaves(), control_smt.num_leaves(), "Number of leaves mismatch");
 
     let new_key = Word::from([100_u32, 100_u32, 100_u32, 100_u32]);
-    let new_value = Word::new([Felt::from_u32(100_u32); WORD_SIZE]);
+    let new_value = Word::new([Felt::from_u32(100_u32); Word::NUM_ELEMENTS]);
 
     let old_value = large_smt.insert(new_key, new_value).unwrap();
     let control_old_value = control_smt.insert(new_key, new_value).unwrap();
@@ -393,9 +393,9 @@ fn test_mutations_revert() {
     let key_2: Word = Word::new([Felt::new(2), Felt::new(2), Felt::new(2), Felt::new(2)]);
     let key_3: Word = Word::new([Felt::new(0), Felt::new(0), Felt::new(0), Felt::new(3)]);
 
-    let value_1 = Word::new([ONE; WORD_SIZE]);
-    let value_2 = Word::new([Felt::from_u32(2_u32); WORD_SIZE]);
-    let value_3 = Word::new([Felt::from_u32(3_u32); WORD_SIZE]);
+    let value_1 = Word::new([ONE; Word::NUM_ELEMENTS]);
+    let value_2 = Word::new([Felt::from_u32(2_u32); Word::NUM_ELEMENTS]);
+    let value_3 = Word::new([Felt::from_u32(3_u32); Word::NUM_ELEMENTS]);
 
     smt.insert(key_1, value_1).unwrap();
     smt.insert(key_2, value_2).unwrap();
@@ -495,9 +495,9 @@ fn test_insert_batch_with_deletions() {
     let key_2 = crate::Word::new([Felt::new(2), Felt::new(2), Felt::new(2), Felt::new(2)]);
     let key_3 = crate::Word::new([Felt::new(0), Felt::new(0), Felt::new(0), Felt::new(3)]);
 
-    let value_1 = crate::Word::new([ONE; WORD_SIZE]);
-    let value_2 = crate::Word::new([Felt::new(2); WORD_SIZE]);
-    let value_3 = crate::Word::new([Felt::new(3); WORD_SIZE]);
+    let value_1 = crate::Word::new([ONE; Word::NUM_ELEMENTS]);
+    let value_2 = crate::Word::new([Felt::new(2); Word::NUM_ELEMENTS]);
+    let value_3 = crate::Word::new([Felt::new(3); Word::NUM_ELEMENTS]);
 
     smt.insert(key_1, value_1).unwrap();
     smt.insert(key_2, value_2).unwrap();
@@ -522,7 +522,7 @@ fn test_insert_batch_no_mutations() {
     let mut smt = LargeSmt::new(storage).unwrap();
 
     let key_1 = crate::Word::new([ONE, ONE, ONE, Felt::new(1)]);
-    let value_1 = crate::Word::new([ONE; WORD_SIZE]);
+    let value_1 = crate::Word::new([ONE; Word::NUM_ELEMENTS]);
 
     smt.insert(key_1, value_1).unwrap();
     let root_before = smt.root();

--- a/miden-crypto/src/merkle/store/tests.rs
+++ b/miden-crypto/src/merkle/store/tests.rs
@@ -14,7 +14,7 @@ use super::{
     Poseidon2, Word,
 };
 use crate::{
-    Felt, ONE, WORD_SIZE, ZERO,
+    Felt, ONE, ZERO,
     merkle::{
         MerkleTree, int_to_leaf, int_to_node,
         smt::{LeafIndex, SMT_MAX_DEPTH, SimpleSmt},
@@ -687,7 +687,7 @@ fn node_path_should_be_truncated_by_midtier_insert() {
 
     // insert first node - works as expected
     let depth = 64;
-    let node = Word::from([Felt::new(key); WORD_SIZE]);
+    let node = Word::from([Felt::new(key); Word::NUM_ELEMENTS]);
     let index = NodeIndex::new(depth, key).unwrap();
     let root = store.set_node(root, index, node).unwrap().root;
     let result = store.get_node(root, index).unwrap();
@@ -701,7 +701,7 @@ fn node_path_should_be_truncated_by_midtier_insert() {
     let key = key ^ (1 << 63);
     let key = key >> 8;
     let depth = 56;
-    let node = Word::from([Felt::new(key); WORD_SIZE]);
+    let node = Word::from([Felt::new(key); Word::NUM_ELEMENTS]);
     let index = NodeIndex::new(depth, key).unwrap();
     let root = store.set_node(root, index, node).unwrap().root;
     let result = store.get_node(root, index).unwrap();
@@ -730,7 +730,7 @@ fn get_leaf_depth_works_depth_64() {
     // this will create a rainbow tree and test all opening to depth 64
     for d in 0..64 {
         let k = key & (u64::MAX >> d);
-        let node = Word::from([Felt::new(k); WORD_SIZE]);
+        let node = Word::from([Felt::new(k); Word::NUM_ELEMENTS]);
         let index = NodeIndex::new(64, k).unwrap();
 
         // assert the leaf doesn't exist before the insert. the returned depth should always
@@ -754,7 +754,7 @@ fn get_leaf_depth_works_with_incremental_depth() {
     assert_eq!(0, store.get_leaf_depth(root, 64, key).unwrap());
     let depth = 64;
     let index = NodeIndex::new(depth, key).unwrap();
-    let node = Word::from([Felt::new(key); WORD_SIZE]);
+    let node = Word::from([Felt::new(key); Word::NUM_ELEMENTS]);
     root = store.set_node(root, index, node).unwrap().root;
     assert_eq!(depth, store.get_leaf_depth(root, 64, key).unwrap());
 
@@ -763,7 +763,7 @@ fn get_leaf_depth_works_with_incremental_depth() {
     assert_eq!(1, store.get_leaf_depth(root, 64, key).unwrap());
     let depth = 16;
     let index = NodeIndex::new(depth, key >> (64 - depth)).unwrap();
-    let node = Word::from([Felt::new(key); WORD_SIZE]);
+    let node = Word::from([Felt::new(key); Word::NUM_ELEMENTS]);
     root = store.set_node(root, index, node).unwrap().root;
     assert_eq!(depth, store.get_leaf_depth(root, 64, key).unwrap());
 
@@ -771,7 +771,7 @@ fn get_leaf_depth_works_with_incremental_depth() {
     let key = 0b11001011_10110111_00000000_00000000_00000000_00000000_00000000_00000000_u64;
     assert_eq!(16, store.get_leaf_depth(root, 64, key).unwrap());
     let index = NodeIndex::new(depth, key >> (64 - depth)).unwrap();
-    let node = Word::from([Felt::new(key); WORD_SIZE]);
+    let node = Word::from([Felt::new(key); Word::NUM_ELEMENTS]);
     root = store.set_node(root, index, node).unwrap().root;
     assert_eq!(depth, store.get_leaf_depth(root, 64, key).unwrap());
 
@@ -780,7 +780,7 @@ fn get_leaf_depth_works_with_incremental_depth() {
     assert_eq!(15, store.get_leaf_depth(root, 64, key).unwrap());
     let depth = 17;
     let index = NodeIndex::new(depth, key >> (64 - depth)).unwrap();
-    let node = Word::from([Felt::new(key); WORD_SIZE]);
+    let node = Word::from([Felt::new(key); Word::NUM_ELEMENTS]);
     root = store.set_node(root, index, node).unwrap().root;
     assert_eq!(depth, store.get_leaf_depth(root, 64, key).unwrap());
 }
@@ -798,7 +798,7 @@ fn get_leaf_depth_works_with_depth_8() {
 
     for k in [a, b, c, d] {
         let index = NodeIndex::new(8, k).unwrap();
-        let node = Word::from([Felt::new(k); WORD_SIZE]);
+        let node = Word::from([Felt::new(k); Word::NUM_ELEMENTS]);
         root = store.set_node(root, index, node).unwrap().root;
     }
 

--- a/miden-crypto/src/rand/mod.rs
+++ b/miden-crypto/src/rand/mod.rs
@@ -1,6 +1,5 @@
 //! Pseudo-random element generation.
 
-use miden_field::word::WORD_SIZE_BYTES;
 use rand::RngCore;
 
 use crate::{Felt, Word};
@@ -102,7 +101,7 @@ impl Randomizable for Felt {
 }
 
 impl Randomizable for Word {
-    const VALUE_SIZE: usize = WORD_SIZE_BYTES;
+    const VALUE_SIZE: usize = Word::SERIALIZED_SIZE;
 
     fn from_random_bytes(bytes: &[u8]) -> Option<Self> {
         let bytes_array: Option<[u8; 32]> = bytes.try_into().ok();

--- a/miden-crypto/tests/rocksdb_large_smt.rs
+++ b/miden-crypto/tests/rocksdb_large_smt.rs
@@ -1,5 +1,5 @@
 use miden_crypto::{
-    EMPTY_WORD, Felt, ONE, WORD_SIZE, Word, ZERO,
+    EMPTY_WORD, Felt, ONE, Word, ZERO,
     merkle::{
         InnerNodeInfo,
         smt::{LargeSmt, LargeSmtError, RocksDbConfig, RocksDbStorage},
@@ -36,7 +36,7 @@ fn rocksdb_sanity_insert_and_get() {
     let mut smt = LargeSmt::<RocksDbStorage>::new(storage).unwrap();
 
     let key = Word::new([ONE, ONE, ONE, ONE]);
-    let val = Word::new([ONE; WORD_SIZE]);
+    let val = Word::new([ONE; Word::NUM_ELEMENTS]);
 
     let prev = smt.insert(key, val).unwrap();
     assert_eq!(prev, EMPTY_WORD);

--- a/miden-field/src/word/mod.rs
+++ b/miden-field/src/word/mod.rs
@@ -14,13 +14,9 @@ use core::{
 use miden_serde_utils::{
     ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable,
 };
-use thiserror::Error;
-
-pub const WORD_SIZE_FELTS: usize = 4;
-pub const WORD_SIZE_BYTES: usize = 32;
-
 #[cfg(not(all(target_family = "wasm", miden)))]
 use p3_field::integers::QuotientMap;
+use thiserror::Error;
 
 use super::Felt;
 use crate::utils::bytes_to_hex_string;
@@ -66,9 +62,9 @@ pub struct Word {
 // Compile-time assertions to ensure `Word` has the same layout as `[Felt; 4]`. This is relied upon
 // in `as_elements_array`/`as_elements_array_mut`.
 const _: () = {
-    assert!(WORD_SIZE_FELTS == 4, "WORD_SIZE_FELTS is assumed to be 4");
-    assert!(WORD_SIZE_BYTES == 32, "WORD_SIZE_BYTES is assumed to be 32");
-    assert!(core::mem::size_of::<Word>() == WORD_SIZE_FELTS * core::mem::size_of::<Felt>());
+    assert!(Word::NUM_ELEMENTS == 4, "Word::NUM_ELEMENTS is assumed to be 4");
+    assert!(Word::SERIALIZED_SIZE == 32, "Word::SERIALIZED_SIZE is assumed to be 32");
+    assert!(core::mem::size_of::<Word>() == Word::NUM_ELEMENTS * core::mem::size_of::<Felt>());
     assert!(core::mem::offset_of!(Word, a) == 0);
     assert!(core::mem::offset_of!(Word, b) == core::mem::size_of::<Felt>());
     assert!(core::mem::offset_of!(Word, c) == 2 * core::mem::size_of::<Felt>());
@@ -82,17 +78,20 @@ impl core::fmt::Debug for Word {
 }
 
 impl Word {
+    /// The number of field elements in the word.
+    pub const NUM_ELEMENTS: usize = 4;
+
     /// The serialized size of the word in bytes.
-    pub const SERIALIZED_SIZE: usize = WORD_SIZE_BYTES;
+    pub const SERIALIZED_SIZE: usize = 32;
 
     /// Creates a new [`Word`] from the given field elements.
-    pub const fn new(value: [Felt; WORD_SIZE_FELTS]) -> Self {
+    pub const fn new(value: [Felt; Self::NUM_ELEMENTS]) -> Self {
         let [a, b, c, d] = value;
         Self { a, b, c, d }
     }
 
     /// Returns the elements of this word as an array.
-    pub const fn into_elements(self) -> [Felt; WORD_SIZE_FELTS] {
+    pub const fn into_elements(self) -> [Felt; Self::NUM_ELEMENTS] {
         [self.a, self.b, self.c, self.d]
     }
 
@@ -101,8 +100,8 @@ impl Word {
     /// # Safety
     /// This assumes the four fields of [`Word`] are laid out contiguously with no padding, in
     /// the same order as `[Felt; 4]`.
-    fn as_elements_array(&self) -> &[Felt; WORD_SIZE_FELTS] {
-        unsafe { &*(&self.a as *const Felt as *const [Felt; WORD_SIZE_FELTS]) }
+    fn as_elements_array(&self) -> &[Felt; Self::NUM_ELEMENTS] {
+        unsafe { &*(&self.a as *const Felt as *const [Felt; Self::NUM_ELEMENTS]) }
     }
 
     /// Returns the elements of this word as a mutable array reference.
@@ -110,8 +109,8 @@ impl Word {
     /// # Safety
     /// This assumes the four fields of [`Word`] are laid out contiguously with no padding, in
     /// the same order as `[Felt; 4]`.
-    fn as_elements_array_mut(&mut self) -> &mut [Felt; WORD_SIZE_FELTS] {
-        unsafe { &mut *(&mut self.a as *mut Felt as *mut [Felt; WORD_SIZE_FELTS]) }
+    fn as_elements_array_mut(&mut self) -> &mut [Felt; Self::NUM_ELEMENTS] {
+        unsafe { &mut *(&mut self.a as *mut Felt as *mut [Felt; Self::NUM_ELEMENTS]) }
     }
 
     /// Parses a hex string into a new [`Word`].
@@ -193,7 +192,7 @@ impl Word {
 
     /// Returns a new [Word] consisting of four ZERO elements.
     pub const fn empty() -> Self {
-        Self::new([Felt::ZERO; WORD_SIZE_FELTS])
+        Self::new([Felt::ZERO; Self::NUM_ELEMENTS])
     }
 
     /// Returns true if the word consists of four ZERO elements.
@@ -211,8 +210,8 @@ impl Word {
     }
 
     /// Returns the word as a byte array.
-    pub fn as_bytes(&self) -> [u8; WORD_SIZE_BYTES] {
-        let mut result = [0; WORD_SIZE_BYTES];
+    pub fn as_bytes(&self) -> [u8; Self::SERIALIZED_SIZE] {
+        let mut result = [0; Self::SERIALIZED_SIZE];
 
         let elements = self.as_elements_array();
         result[..8].copy_from_slice(&elements[0].as_canonical_u64().to_le_bytes());
@@ -233,7 +232,7 @@ impl Word {
 
     /// Returns all elements of multiple words as a slice.
     pub fn words_as_elements(words: &[Self]) -> &[Felt] {
-        let len = words.len() * WORD_SIZE_FELTS;
+        let len = words.len() * Self::NUM_ELEMENTS;
         unsafe { slice::from_raw_parts(words.as_ptr() as *const Felt, len) }
     }
 
@@ -265,7 +264,7 @@ impl Hash for Word {
 }
 
 impl Deref for Word {
-    type Target = [Felt; WORD_SIZE_FELTS];
+    type Target = [Felt; Word::NUM_ELEMENTS];
 
     fn deref(&self) -> &Self::Target {
         self.as_elements_array()
@@ -370,7 +369,7 @@ pub enum WordError {
     TypeConversion(&'static str),
 }
 
-impl TryFrom<&Word> for [bool; WORD_SIZE_FELTS] {
+impl TryFrom<&Word> for [bool; Word::NUM_ELEMENTS] {
     type Error = WordError;
 
     fn try_from(value: &Word) -> Result<Self, Self::Error> {
@@ -378,7 +377,7 @@ impl TryFrom<&Word> for [bool; WORD_SIZE_FELTS] {
     }
 }
 
-impl TryFrom<Word> for [bool; WORD_SIZE_FELTS] {
+impl TryFrom<Word> for [bool; Word::NUM_ELEMENTS] {
     type Error = WordError;
 
     fn try_from(value: Word) -> Result<Self, Self::Error> {
@@ -396,7 +395,7 @@ impl TryFrom<Word> for [bool; WORD_SIZE_FELTS] {
     }
 }
 
-impl TryFrom<&Word> for [u8; WORD_SIZE_FELTS] {
+impl TryFrom<&Word> for [u8; Word::NUM_ELEMENTS] {
     type Error = WordError;
 
     fn try_from(value: &Word) -> Result<Self, Self::Error> {
@@ -404,7 +403,7 @@ impl TryFrom<&Word> for [u8; WORD_SIZE_FELTS] {
     }
 }
 
-impl TryFrom<Word> for [u8; WORD_SIZE_FELTS] {
+impl TryFrom<Word> for [u8; Word::NUM_ELEMENTS] {
     type Error = WordError;
 
     fn try_from(value: Word) -> Result<Self, Self::Error> {
@@ -418,7 +417,7 @@ impl TryFrom<Word> for [u8; WORD_SIZE_FELTS] {
     }
 }
 
-impl TryFrom<&Word> for [u16; WORD_SIZE_FELTS] {
+impl TryFrom<&Word> for [u16; Word::NUM_ELEMENTS] {
     type Error = WordError;
 
     fn try_from(value: &Word) -> Result<Self, Self::Error> {
@@ -426,7 +425,7 @@ impl TryFrom<&Word> for [u16; WORD_SIZE_FELTS] {
     }
 }
 
-impl TryFrom<Word> for [u16; WORD_SIZE_FELTS] {
+impl TryFrom<Word> for [u16; Word::NUM_ELEMENTS] {
     type Error = WordError;
 
     fn try_from(value: Word) -> Result<Self, Self::Error> {
@@ -440,7 +439,7 @@ impl TryFrom<Word> for [u16; WORD_SIZE_FELTS] {
     }
 }
 
-impl TryFrom<&Word> for [u32; WORD_SIZE_FELTS] {
+impl TryFrom<&Word> for [u32; Word::NUM_ELEMENTS] {
     type Error = WordError;
 
     fn try_from(value: &Word) -> Result<Self, Self::Error> {
@@ -448,7 +447,7 @@ impl TryFrom<&Word> for [u32; WORD_SIZE_FELTS] {
     }
 }
 
-impl TryFrom<Word> for [u32; WORD_SIZE_FELTS] {
+impl TryFrom<Word> for [u32; Word::NUM_ELEMENTS] {
     type Error = WordError;
 
     fn try_from(value: Word) -> Result<Self, Self::Error> {
@@ -462,37 +461,37 @@ impl TryFrom<Word> for [u32; WORD_SIZE_FELTS] {
     }
 }
 
-impl From<&Word> for [u64; WORD_SIZE_FELTS] {
+impl From<&Word> for [u64; Word::NUM_ELEMENTS] {
     fn from(value: &Word) -> Self {
         (*value).into()
     }
 }
 
-impl From<Word> for [u64; WORD_SIZE_FELTS] {
+impl From<Word> for [u64; Word::NUM_ELEMENTS] {
     fn from(value: Word) -> Self {
         value.into_elements().map(|felt| felt.as_canonical_u64())
     }
 }
 
-impl From<&Word> for [Felt; WORD_SIZE_FELTS] {
+impl From<&Word> for [Felt; Word::NUM_ELEMENTS] {
     fn from(value: &Word) -> Self {
         (*value).into()
     }
 }
 
-impl From<Word> for [Felt; WORD_SIZE_FELTS] {
+impl From<Word> for [Felt; Word::NUM_ELEMENTS] {
     fn from(value: Word) -> Self {
         value.into_elements()
     }
 }
 
-impl From<&Word> for [u8; WORD_SIZE_BYTES] {
+impl From<&Word> for [u8; Word::SERIALIZED_SIZE] {
     fn from(value: &Word) -> Self {
         (*value).into()
     }
 }
 
-impl From<Word> for [u8; WORD_SIZE_BYTES] {
+impl From<Word> for [u8; Word::SERIALIZED_SIZE] {
     fn from(value: Word) -> Self {
         value.as_bytes()
     }
@@ -517,26 +516,26 @@ impl From<Word> for String {
 // CONVERSIONS: TO WORD
 // ================================================================================================
 
-impl From<&[bool; WORD_SIZE_FELTS]> for Word {
-    fn from(value: &[bool; WORD_SIZE_FELTS]) -> Self {
+impl From<&[bool; Word::NUM_ELEMENTS]> for Word {
+    fn from(value: &[bool; Word::NUM_ELEMENTS]) -> Self {
         (*value).into()
     }
 }
 
-impl From<[bool; WORD_SIZE_FELTS]> for Word {
-    fn from(value: [bool; WORD_SIZE_FELTS]) -> Self {
+impl From<[bool; Word::NUM_ELEMENTS]> for Word {
+    fn from(value: [bool; Word::NUM_ELEMENTS]) -> Self {
         [value[0] as u32, value[1] as u32, value[2] as u32, value[3] as u32].into()
     }
 }
 
-impl From<&[u8; WORD_SIZE_FELTS]> for Word {
-    fn from(value: &[u8; WORD_SIZE_FELTS]) -> Self {
+impl From<&[u8; Word::NUM_ELEMENTS]> for Word {
+    fn from(value: &[u8; Word::NUM_ELEMENTS]) -> Self {
         (*value).into()
     }
 }
 
-impl From<[u8; WORD_SIZE_FELTS]> for Word {
-    fn from(value: [u8; WORD_SIZE_FELTS]) -> Self {
+impl From<[u8; Word::NUM_ELEMENTS]> for Word {
+    fn from(value: [u8; Word::NUM_ELEMENTS]) -> Self {
         Self::new([
             Felt::from_u8(value[0]),
             Felt::from_u8(value[1]),
@@ -546,14 +545,14 @@ impl From<[u8; WORD_SIZE_FELTS]> for Word {
     }
 }
 
-impl From<&[u16; WORD_SIZE_FELTS]> for Word {
-    fn from(value: &[u16; WORD_SIZE_FELTS]) -> Self {
+impl From<&[u16; Word::NUM_ELEMENTS]> for Word {
+    fn from(value: &[u16; Word::NUM_ELEMENTS]) -> Self {
         (*value).into()
     }
 }
 
-impl From<[u16; WORD_SIZE_FELTS]> for Word {
-    fn from(value: [u16; WORD_SIZE_FELTS]) -> Self {
+impl From<[u16; Word::NUM_ELEMENTS]> for Word {
+    fn from(value: [u16; Word::NUM_ELEMENTS]) -> Self {
         Self::new([
             Felt::from_u16(value[0]),
             Felt::from_u16(value[1]),
@@ -563,14 +562,14 @@ impl From<[u16; WORD_SIZE_FELTS]> for Word {
     }
 }
 
-impl From<&[u32; WORD_SIZE_FELTS]> for Word {
-    fn from(value: &[u32; WORD_SIZE_FELTS]) -> Self {
+impl From<&[u32; Word::NUM_ELEMENTS]> for Word {
+    fn from(value: &[u32; Word::NUM_ELEMENTS]) -> Self {
         (*value).into()
     }
 }
 
-impl From<[u32; WORD_SIZE_FELTS]> for Word {
-    fn from(value: [u32; WORD_SIZE_FELTS]) -> Self {
+impl From<[u32; Word::NUM_ELEMENTS]> for Word {
+    fn from(value: [u32; Word::NUM_ELEMENTS]) -> Self {
         Self::new([
             Felt::from_u32(value[0]),
             Felt::from_u32(value[1]),
@@ -580,18 +579,18 @@ impl From<[u32; WORD_SIZE_FELTS]> for Word {
     }
 }
 
-impl TryFrom<&[u64; WORD_SIZE_FELTS]> for Word {
+impl TryFrom<&[u64; Word::NUM_ELEMENTS]> for Word {
     type Error = WordError;
 
-    fn try_from(value: &[u64; WORD_SIZE_FELTS]) -> Result<Self, WordError> {
+    fn try_from(value: &[u64; Word::NUM_ELEMENTS]) -> Result<Self, WordError> {
         (*value).try_into()
     }
 }
 
-impl TryFrom<[u64; WORD_SIZE_FELTS]> for Word {
+impl TryFrom<[u64; Word::NUM_ELEMENTS]> for Word {
     type Error = WordError;
 
-    fn try_from(value: [u64; WORD_SIZE_FELTS]) -> Result<Self, WordError> {
+    fn try_from(value: [u64; Word::NUM_ELEMENTS]) -> Result<Self, WordError> {
         let err = || WordError::InvalidFieldElement("value >= field modulus".into());
         Ok(Self::new([
             Felt::from_canonical_checked(value[0]).ok_or_else(err)?,
@@ -602,30 +601,30 @@ impl TryFrom<[u64; WORD_SIZE_FELTS]> for Word {
     }
 }
 
-impl From<&[Felt; WORD_SIZE_FELTS]> for Word {
-    fn from(value: &[Felt; WORD_SIZE_FELTS]) -> Self {
+impl From<&[Felt; Word::NUM_ELEMENTS]> for Word {
+    fn from(value: &[Felt; Word::NUM_ELEMENTS]) -> Self {
         Self::new(*value)
     }
 }
 
-impl From<[Felt; WORD_SIZE_FELTS]> for Word {
-    fn from(value: [Felt; WORD_SIZE_FELTS]) -> Self {
+impl From<[Felt; Word::NUM_ELEMENTS]> for Word {
+    fn from(value: [Felt; Word::NUM_ELEMENTS]) -> Self {
         Self::new(value)
     }
 }
 
-impl TryFrom<&[u8; WORD_SIZE_BYTES]> for Word {
+impl TryFrom<&[u8; Word::SERIALIZED_SIZE]> for Word {
     type Error = WordError;
 
-    fn try_from(value: &[u8; WORD_SIZE_BYTES]) -> Result<Self, Self::Error> {
+    fn try_from(value: &[u8; Word::SERIALIZED_SIZE]) -> Result<Self, Self::Error> {
         (*value).try_into()
     }
 }
 
-impl TryFrom<[u8; WORD_SIZE_BYTES]> for Word {
+impl TryFrom<[u8; Word::SERIALIZED_SIZE]> for Word {
     type Error = WordError;
 
-    fn try_from(value: [u8; WORD_SIZE_BYTES]) -> Result<Self, Self::Error> {
+    fn try_from(value: [u8; Word::SERIALIZED_SIZE]) -> Result<Self, Self::Error> {
         // Note: the input length is known, the conversion from slice to array must succeed so the
         // `unwrap`s below are safe
         let a = u64::from_le_bytes(value[0..8].try_into().unwrap());
@@ -647,9 +646,9 @@ impl TryFrom<&[u8]> for Word {
     type Error = WordError;
 
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        let value: [u8; WORD_SIZE_BYTES] = value
-            .try_into()
-            .map_err(|_| WordError::InvalidInputLength("bytes", WORD_SIZE_BYTES, value.len()))?;
+        let value: [u8; Word::SERIALIZED_SIZE] = value.try_into().map_err(|_| {
+            WordError::InvalidInputLength("bytes", Word::SERIALIZED_SIZE, value.len())
+        })?;
         value.try_into()
     }
 }
@@ -658,9 +657,9 @@ impl TryFrom<&[Felt]> for Word {
     type Error = WordError;
 
     fn try_from(value: &[Felt]) -> Result<Self, Self::Error> {
-        let value: [Felt; WORD_SIZE_FELTS] = value
-            .try_into()
-            .map_err(|_| WordError::InvalidInputLength("elements", WORD_SIZE_FELTS, value.len()))?;
+        let value: [Felt; Word::NUM_ELEMENTS] = value.try_into().map_err(|_| {
+            WordError::InvalidInputLength("elements", Word::NUM_ELEMENTS, value.len())
+        })?;
         Ok(value.into())
     }
 }
@@ -671,7 +670,7 @@ impl TryFrom<&str> for Word {
 
     /// Expects the string to start with `0x`.
     fn try_from(value: &str) -> Result<Self, Self::Error> {
-        crate::utils::hex_to_bytes::<WORD_SIZE_BYTES>(value)
+        crate::utils::hex_to_bytes::<{ Word::SERIALIZED_SIZE }>(value)
             .map_err(WordError::HexParse)
             .and_then(Word::try_from)
     }
@@ -714,7 +713,7 @@ impl Serializable for Word {
 #[cfg(not(all(target_family = "wasm", miden)))]
 impl Deserializable for Word {
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
-        let mut inner: [Felt; WORD_SIZE_FELTS] = [Felt::ZERO; WORD_SIZE_FELTS];
+        let mut inner: [Felt; Word::NUM_ELEMENTS] = [Felt::ZERO; Word::NUM_ELEMENTS];
         for inner in inner.iter_mut() {
             let e = source.read_u64()?;
             if e >= Felt::ORDER {

--- a/miden-field/src/word/tests.rs
+++ b/miden-field/src/word/tests.rs
@@ -4,14 +4,14 @@ use core::cmp::Ordering;
 use miden_serde_utils::SliceReader;
 use proptest::prelude::*;
 
-use super::{Deserializable, Felt, Serializable, WORD_SIZE_BYTES, WORD_SIZE_FELTS, Word};
+use super::{Deserializable, Felt, Serializable, Word};
 use crate::word;
 
 // TESTS
 // ================================================================================================
 
 /// Returns a strategy which generates a `[u64; 4]` where all values are canonical field elements.
-fn any_word_elements_u64_canonical() -> BoxedStrategy<[u64; WORD_SIZE_FELTS]> {
+fn any_word_elements_u64_canonical() -> BoxedStrategy<[u64; Word::NUM_ELEMENTS]> {
     prop::array::uniform4(0u64..Felt::ORDER).no_shrink().boxed()
 }
 
@@ -29,7 +29,7 @@ proptest! {
     fn word_serialization_roundtrip(word in any::<Word>()) {
         let mut bytes = Vec::new();
         word.write_into(&mut bytes);
-        prop_assert_eq!(WORD_SIZE_BYTES, bytes.len());
+        prop_assert_eq!(Word::SERIALIZED_SIZE, bytes.len());
         prop_assert_eq!(bytes.len(), word.get_size_hint());
 
         let mut reader = SliceReader::new(&bytes);
@@ -46,49 +46,49 @@ proptest! {
     }
 
     #[test]
-    fn word_bool_conversion_roundtrip(v in any::<[bool; WORD_SIZE_FELTS]>()) {
+    fn word_bool_conversion_roundtrip(v in any::<[bool; Word::NUM_ELEMENTS]>()) {
         let word: Word = v.into();
-        prop_assert_eq!(v, <[bool; WORD_SIZE_FELTS]>::try_from(word).unwrap());
+        prop_assert_eq!(v, <[bool; Word::NUM_ELEMENTS]>::try_from(word).unwrap());
 
         let word: Word = (&v).into();
-        prop_assert_eq!(v, <[bool; WORD_SIZE_FELTS]>::try_from(&word).unwrap());
+        prop_assert_eq!(v, <[bool; Word::NUM_ELEMENTS]>::try_from(&word).unwrap());
     }
 
     #[test]
-    fn word_u8_conversion_roundtrip(v in any::<[u8; WORD_SIZE_FELTS]>()) {
+    fn word_u8_conversion_roundtrip(v in any::<[u8; Word::NUM_ELEMENTS]>()) {
         let word: Word = v.into();
-        prop_assert_eq!(v, <[u8; WORD_SIZE_FELTS]>::try_from(word).unwrap());
+        prop_assert_eq!(v, <[u8; Word::NUM_ELEMENTS]>::try_from(word).unwrap());
 
         let word: Word = (&v).into();
-        prop_assert_eq!(v, <[u8; WORD_SIZE_FELTS]>::try_from(&word).unwrap());
+        prop_assert_eq!(v, <[u8; Word::NUM_ELEMENTS]>::try_from(&word).unwrap());
     }
 
     #[test]
-    fn word_u16_conversion_roundtrip(v in any::<[u16; WORD_SIZE_FELTS]>()) {
+    fn word_u16_conversion_roundtrip(v in any::<[u16; Word::NUM_ELEMENTS]>()) {
         let word: Word = v.into();
-        prop_assert_eq!(v, <[u16; WORD_SIZE_FELTS]>::try_from(word).unwrap());
+        prop_assert_eq!(v, <[u16; Word::NUM_ELEMENTS]>::try_from(word).unwrap());
 
         let word: Word = (&v).into();
-        prop_assert_eq!(v, <[u16; WORD_SIZE_FELTS]>::try_from(&word).unwrap());
+        prop_assert_eq!(v, <[u16; Word::NUM_ELEMENTS]>::try_from(&word).unwrap());
     }
 
     #[test]
-    fn word_u32_conversion_roundtrip(v in any::<[u32; WORD_SIZE_FELTS]>()) {
+    fn word_u32_conversion_roundtrip(v in any::<[u32; Word::NUM_ELEMENTS]>()) {
         let word: Word = v.into();
-        prop_assert_eq!(v, <[u32; WORD_SIZE_FELTS]>::try_from(word).unwrap());
+        prop_assert_eq!(v, <[u32; Word::NUM_ELEMENTS]>::try_from(word).unwrap());
 
         let word: Word = (&v).into();
-        prop_assert_eq!(v, <[u32; WORD_SIZE_FELTS]>::try_from(&word).unwrap());
+        prop_assert_eq!(v, <[u32; Word::NUM_ELEMENTS]>::try_from(&word).unwrap());
     }
 
     #[test]
     fn word_u64_conversion_roundtrip(v in any_word_elements_u64_canonical()) {
         let word: Word = v.try_into().unwrap();
-        let round_trip: [u64; WORD_SIZE_FELTS] = word.into();
+        let round_trip: [u64; Word::NUM_ELEMENTS] = word.into();
         prop_assert_eq!(v, round_trip);
 
         let word: Word = (&v).try_into().unwrap();
-        let round_trip: [u64; WORD_SIZE_FELTS] = (&word).into();
+        let round_trip: [u64; Word::NUM_ELEMENTS] = (&word).into();
         prop_assert_eq!(v, round_trip);
     }
 
@@ -97,21 +97,21 @@ proptest! {
         let elements = elements.map(Felt::new);
 
         let word: Word = elements.into();
-        let round_trip: [Felt; WORD_SIZE_FELTS] = word.into();
+        let round_trip: [Felt; Word::NUM_ELEMENTS] = word.into();
         prop_assert_eq!(elements, round_trip);
 
         let word: Word = (&elements).into();
-        let round_trip: [Felt; WORD_SIZE_FELTS] = (&word).into();
+        let round_trip: [Felt; Word::NUM_ELEMENTS] = (&word).into();
         prop_assert_eq!(elements, round_trip);
     }
 
     #[test]
     fn word_bytes_conversion_roundtrip(word in any::<Word>()) {
-        let bytes: [u8; WORD_SIZE_BYTES] = word.into();
+        let bytes: [u8; Word::SERIALIZED_SIZE] = word.into();
         let round_trip: Word = bytes.try_into().unwrap();
         prop_assert_eq!(word, round_trip);
 
-        let bytes: [u8; WORD_SIZE_BYTES] = (&word).into();
+        let bytes: [u8; Word::SERIALIZED_SIZE] = (&word).into();
         let round_trip: Word = (&bytes).try_into().unwrap();
         prop_assert_eq!(word, round_trip);
     }
@@ -155,17 +155,17 @@ proptest! {
     #[test]
     fn word_index_matches_into_elements(word in any::<Word>()) {
         let elements = word.into_elements();
-        for idx in 0..WORD_SIZE_FELTS {
+        for idx in 0..Word::NUM_ELEMENTS {
             prop_assert_eq!(word[idx], elements[idx]);
         }
     }
 
     #[test]
-    fn word_index_mut_updates_all_elements(word in any::<Word>(), values in any::<[u64; WORD_SIZE_FELTS]>()) {
+    fn word_index_mut_updates_all_elements(word in any::<Word>(), values in any::<[u64; Word::NUM_ELEMENTS]>()) {
         let mut word = word;
 
         let mut expected = word.into_elements();
-        for idx in 0..WORD_SIZE_FELTS {
+        for idx in 0..Word::NUM_ELEMENTS {
             let value = values[idx];
             expected[idx] = Felt::new(value);
             word[idx] = Felt::new(value);
@@ -248,7 +248,7 @@ proptest! {
         map.insert(word, 1);
 
         // Round-trip via bytes to create an equivalent key.
-        let bytes: [u8; WORD_SIZE_BYTES] = word.into();
+        let bytes: [u8; Word::SERIALIZED_SIZE] = word.into();
         let key2: Word = bytes.try_into().unwrap();
         prop_assert_eq!(word, key2);
 


### PR DESCRIPTION
## Describe your changes

This commit removes the `WORD_SIZE_FELTS` and `WORD_SIZE_BYTES` module-level constants in favor of the associated constants `Word::NUM_FELTS` and `Word::SERIALIZED_SIZE` respectively. This makes the API more consistent while incurring no functional or performance regressions.

It also removes `WORD_SIZE` from `miden-crypto` to help harmonize usage as the constant's name was potentially misleading. If we are making a breaking API change anyway, we might as well harmonize usages wholesale.

CLoses #915.

## Checklist before requesting a review

- [x] Repo forked and branch created from `next` according to naming convention.
- [x] Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- [x] Relevant issues are linked in the PR description.
- [x] Tests added for new functionality.
- [x] Documentation/comments updated according to changes.
