### PR TITLE
refactor(Felt): Remove `Deref` for `Felt`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Added `Serializable` and `Deserializable` instances for `Arc<str>`.
 - [BREAKING] Removed `WORD_SIZE_FELTS` and `WORD_SIZE_BYTES` from `miden-field` in favor of `Word::NUM_FELTS` and `Word::SERIALIZED_SIZE`, respectively. The values remain the same.
 - [BREAKING] `WORD_SIZE` has been removed from `miden-crypto` in favor of `Word::NUM_FELTS`. Clients will need to update references to the constant, but `Word` will already be in scope as it is re-exported from `miden-crypto`.
+- [BREAKING] Removed implementations of `Deref` and `DerefMut` for `Felt`.
 
 ## 0.23.0 (2026-03-11)
 

--- a/miden-field/src/native/mod.rs
+++ b/miden-field/src/native/mod.rs
@@ -5,7 +5,7 @@ use core::{
     array, fmt,
     hash::{Hash, Hasher},
     iter::{Product, Sum},
-    ops::{Add, AddAssign, Deref, DerefMut, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign},
+    ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign},
 };
 
 use miden_serde_utils::{
@@ -415,22 +415,6 @@ impl FeltFromIntError {
     /// Returns the integer for which the conversion failed.
     pub fn as_u64(&self) -> u64 {
         self.0
-    }
-}
-
-impl Deref for Felt {
-    type Target = Goldilocks;
-
-    #[inline]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl DerefMut for Felt {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
     }
 }
 


### PR DESCRIPTION
## Describe your changes

The trait implementation was both unused and caused type inference issues, so removing it is the simplest choice.

Closes #908.

## Checklist before requesting a review

- [x] Repo forked and branch created from `next` according to naming convention.
- [x] Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- [x] Relevant issues are linked in the PR description.
- [x] Tests added for new functionality.
- [x] Documentation/comments updated according to changes.
