### PR TITLE
feat(Serde): Add ser/de for Arc<str>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Added the ability to configure the sync-to-disk behavior of the persistent backend using its config ([#912](https://github.com/0xMiden/crypto/pull/912)).
 - Adds `LargeSmtForest::add_lineages` which provides an efficient means of adding multiple new lineages at once ([#910](https://github.com/0xMiden/crypto/pull/910)).
 - [BREAKING] Removed `LexicographicWord` as `Word` itself now implements the correct comparison behavior. Any place where the former is used should be able to seamlessly swap to the latter.
+- Added `Serializable` and `Deserializable` instances for `Arc<str>`.
 
 ## 0.23.0 (2026-03-11)
 

--- a/miden-serde-utils/src/lib.rs
+++ b/miden-serde-utils/src/lib.rs
@@ -11,6 +11,7 @@ use alloc::{
     collections::{BTreeMap, BTreeSet},
     format,
     string::String,
+    sync::Arc,
     vec::Vec,
 };
 
@@ -380,12 +381,21 @@ impl Serializable for str {
 
 impl Serializable for String {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
-        target.write_usize(self.len());
-        target.write_many(self.as_bytes());
+        self.as_str().write_into(target);
     }
 
     fn get_size_hint(&self) -> usize {
-        self.len().get_size_hint() + self.len()
+        self.as_str().get_size_hint()
+    }
+}
+
+impl Serializable for Arc<str> {
+    fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        self.as_ref().write_into(target);
+    }
+
+    fn get_size_hint(&self) -> usize {
+        self.as_ref().get_size_hint()
     }
 }
 
@@ -711,6 +721,16 @@ impl Deserializable for String {
     }
 }
 
+impl Deserializable for Arc<str> {
+    fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
+        String::read_from(source).map(Arc::from)
+    }
+
+    fn min_serialized_size() -> usize {
+        1 // minimum vint length prefix
+    }
+}
+
 // GOLDILOCKS FIELD ELEMENT IMPLEMENTATIONS
 // ================================================================================================
 
@@ -736,5 +756,78 @@ impl Deserializable for p3_goldilocks::Goldilocks {
                 value
             ))
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::sync::Arc;
+
+    use super::*;
+
+    #[test]
+    fn arc_str_roundtrip() {
+        let original: Arc<str> = Arc::from("hello world");
+        let bytes = original.to_bytes();
+        let deserialized = Arc::<str>::read_from_bytes(&bytes).unwrap();
+        assert_eq!(original, deserialized);
+    }
+
+    #[test]
+    fn string_roundtrip() {
+        let original = String::from("hello world");
+        let bytes = original.to_bytes();
+        let deserialized = String::read_from_bytes(&bytes).unwrap();
+        assert_eq!(original, deserialized);
+    }
+
+    #[test]
+    fn empty_string_roundtrip() {
+        let arc: Arc<str> = Arc::from("");
+        let bytes = arc.to_bytes();
+        let deserialized = Arc::<str>::read_from_bytes(&bytes).unwrap();
+        assert_eq!(deserialized, Arc::from(""));
+
+        let string = String::from("");
+        let bytes = string.to_bytes();
+        let deserialized = String::read_from_bytes(&bytes).unwrap();
+        assert_eq!(deserialized, "");
+    }
+
+    #[test]
+    fn multibyte_utf8_roundtrip() {
+        let text = "héllo 🌍";
+
+        let arc: Arc<str> = Arc::from(text);
+        let bytes = arc.to_bytes();
+        let deserialized = Arc::<str>::read_from_bytes(&bytes).unwrap();
+        assert_eq!(&*deserialized, text);
+
+        let string = String::from(text);
+        let bytes = string.to_bytes();
+        let deserialized = String::read_from_bytes(&bytes).unwrap();
+        assert_eq!(deserialized, text);
+
+        // Cross-compat: Arc<str> bytes can be read as String and vice versa
+        let arc_bytes = Arc::<str>::from(text).to_bytes();
+        let string_bytes = String::from(text).to_bytes();
+        assert_eq!(arc_bytes, string_bytes);
+        assert_eq!(String::read_from_bytes(&arc_bytes).unwrap(), text);
+        assert_eq!(&*Arc::<str>::read_from_bytes(&string_bytes).unwrap(), text);
+    }
+
+    #[test]
+    fn arc_str_string_cross_compat() {
+        // Arc<str> -> bytes -> String
+        let arc: Arc<str> = Arc::from("cross type");
+        let bytes = arc.to_bytes();
+        let as_string = String::read_from_bytes(&bytes).unwrap();
+        assert_eq!(as_string, "cross type");
+
+        // String -> bytes -> Arc<str>
+        let string = String::from("other direction");
+        let bytes = string.to_bytes();
+        let as_arc = Arc::<str>::read_from_bytes(&bytes).unwrap();
+        assert_eq!(&*as_arc, "other direction");
     }
 }


### PR DESCRIPTION
## Describe your changes

This helps avoid the need for ser/de helpers due to the orphan rule, and is a simple change that relies on the existing `&str` ser/de machinery. It also now implements `Serializable` for `String` in terms of `str` for consistency.

Closes #885.

## Checklist before requesting a review

- [x] Repo forked and branch created from `next` according to naming convention.
- [x] Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- [x] Relevant issues are linked in the PR description.
- [x] Tests added for new functionality.
- [x] Documentation/comments updated according to changes.
