### PR TITLE
chore(tests): ignore debug-only tests in release mode

### DIFF
--- a/miden-crypto/src/lib.rs
+++ b/miden-crypto/src/lib.rs
@@ -249,6 +249,7 @@ mod batch_inversion {
 #[cfg(test)]
 mod tests {
 
+    #[cfg(debug_assertions)]
     #[test]
     #[should_panic]
     fn debug_assert_is_checked() {
@@ -262,6 +263,7 @@ mod tests {
         debug_assert!(false);
     }
 
+    #[cfg(debug_assertions)]
     #[test]
     #[should_panic]
     #[allow(arithmetic_overflow)]

--- a/miden-crypto/src/merkle/smt/full/concurrent/tests.rs
+++ b/miden-crypto/src/merkle/smt/full/concurrent/tests.rs
@@ -547,6 +547,7 @@ fn arb_felt() -> impl Strategy<Value = Felt> {
 }
 
 /// Test that the debug assertion panics on unsorted entries.
+#[cfg(debug_assertions)]
 #[test]
 #[should_panic = "is_sorted_by_key"]
 fn smt_with_sorted_entries_panics_on_unsorted_entries() {


### PR DESCRIPTION
## Describe your changes

It seems those 3 tests are only expected to run properly in `debug` mode, which triggers undesired noisy failures upon running `cargo test --release`, hence gating them behind a `#[cfg(debug_assertions)]`.


## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
