### PR TITLE
perf: make field operations for `Goldilocks` faster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Adds `LargeSmtForest::add_lineages` which provides an efficient means of adding multiple new lineages at once ([#910](https://github.com/0xMiden/crypto/pull/910)).
 - [BREAKING] Removed `LexicographicWord` as `Word` itself now implements the correct comparison behavior. Any place where the former is used should be able to seamlessly swap to the latter.
 - Added `Serializable` and `Deserializable` instances for `Arc<str>`.
-- [BREAKING] Removed `WORD_SIZE_FELTS` and `WORD_SIZE_BYTES` from `miden-field` in favor of `Word::NUM_FELTS` and `Word::SERIALIZED_SIZE`, respectively. The values remain the same.
+- [BREAKING] Removed `WORD_SIZE_FELTS` and `WORD_SIZE_BYTES` from `miden-field` in favor of `Word::NUM_ELEMENTS` and `Word::SERIALIZED_SIZE`, respectively. The values remain the same.
 - [BREAKING] `WORD_SIZE` has been removed from `miden-crypto` in favor of `Word::NUM_ELEMENTS`. Clients will need to update references to the constant, but `Word` will already be in scope as it is re-exported from `miden-crypto`.
 - [BREAKING] Removed implementations of `Deref` and `DerefMut` for `Felt`.
 - [BREAKING] Update `Poseidon2` instance to match Plonky3 one ([#905](https://github.com/0xMiden/crypto/pull/905)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,12 @@
 - [BREAKING] Removed `LexicographicWord` as `Word` itself now implements the correct comparison behavior. Any place where the former is used should be able to seamlessly swap to the latter.
 - Added `Serializable` and `Deserializable` instances for `Arc<str>`.
 - [BREAKING] Removed `WORD_SIZE_FELTS` and `WORD_SIZE_BYTES` from `miden-field` in favor of `Word::NUM_FELTS` and `Word::SERIALIZED_SIZE`, respectively. The values remain the same.
-- [BREAKING] `WORD_SIZE` has been removed from `miden-crypto` in favor of `Word::NUM_FELTS`. Clients will need to update references to the constant, but `Word` will already be in scope as it is re-exported from `miden-crypto`.
+- [BREAKING] `WORD_SIZE` has been removed from `miden-crypto` in favor of `Word::NUM_ELEMENTS`. Clients will need to update references to the constant, but `Word` will already be in scope as it is re-exported from `miden-crypto`.
 - [BREAKING] Removed implementations of `Deref` and `DerefMut` for `Felt`.
 - [BREAKING] Update `Poseidon2` instance to match Plonky3 one ([#905](https://github.com/0xMiden/crypto/pull/905)).
 - Use per-chunk scratch space for batch inversion ([#933](https://github.com/0xMiden/crypto/pull/933)).
 - [BREAKING] Changed the signature of `Felt::new` to perform reduction, and raise an error if the input is invalid. Retained the old behavior as `Felt::new_unchecked`, as its usage may lead to incorrect results.
+- Optimize field operations for `Goldilocks` ([#926](https://github.com/0xMiden/crypto/pull/926)).
 
 ## 0.23.0 (2026-03-11)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1156,6 +1156,7 @@ dependencies = [
  "p3-challenger",
  "p3-field",
  "p3-goldilocks",
+ "p3-util",
  "paste",
  "proptest",
  "rand 0.10.1",

--- a/miden-field/Cargo.toml
+++ b/miden-field/Cargo.toml
@@ -26,7 +26,7 @@ num-bigint              = { default-features = false, version = "0.4" }
 p3-challenger.workspace = true
 p3-field.workspace      = true
 p3-goldilocks.workspace = true
-p3-util.workspace      = true
+p3-util.workspace       = true
 paste                   = { version = "1.0.15" }
 proptest                = { default-features = false, features = ["alloc", "std"], optional = true, version = "1.7" }
 rand                    = { default-features = false, version = "0.10" }

--- a/miden-field/Cargo.toml
+++ b/miden-field/Cargo.toml
@@ -26,6 +26,7 @@ num-bigint              = { default-features = false, version = "0.4" }
 p3-challenger.workspace = true
 p3-field.workspace      = true
 p3-goldilocks.workspace = true
+p3-util.workspace      = true
 paste                   = { version = "1.0.15" }
 proptest                = { default-features = false, features = ["alloc", "std"], optional = true, version = "1.7" }
 rand                    = { default-features = false, version = "0.10" }

--- a/miden-field/src/native/mod.rs
+++ b/miden-field/src/native/mod.rs
@@ -144,7 +144,7 @@ fn raw_felt_u64(value: &Felt) -> u64 {
 ///
 /// `Felt` is `#[repr(transparent)]` over `Goldilocks`, so the element layout matches.
 #[inline]
-fn felt_as_goldilock_slice(s: &[Felt]) -> &[Goldilocks] {
+fn felts_as_goldilocks_slice(s: &[Felt]) -> &[Goldilocks] {
     // SAFETY: `Felt` is `#[repr(transparent)]` over `Goldilocks`, so the element layout matches.
     unsafe { core::slice::from_raw_parts(s.as_ptr().cast::<Goldilocks>(), s.len()) }
 }
@@ -155,8 +155,8 @@ fn felt_as_goldilock_slice(s: &[Felt]) -> &[Goldilocks] {
 ///
 /// `Felt` is `#[repr(transparent)]` over `Goldilocks`, so `[Felt; N]` matches `[Goldilocks; N]`.
 #[inline]
-fn felt_as_goldilocks_array<const N: usize>(a: &[Felt; N]) -> &[Goldilocks; N] {
-    // SAFETY: same layout as `felt_as_goldilock_slice`, for a fixed `N`.
+fn felts_as_goldilocks_array<const N: usize>(a: &[Felt; N]) -> &[Goldilocks; N] {
+    // SAFETY: same layout as `felts_as_goldilocks_slice`, for a fixed `N`.
     unsafe { &*(a as *const [Felt; N] as *const [Goldilocks; N]) }
 }
 
@@ -250,14 +250,14 @@ impl PrimeCharacteristicRing for Felt {
     #[inline]
     fn sum_array<const N: usize>(input: &[Self]) -> Self {
         assert_eq!(N, input.len());
-        let g = felt_as_goldilock_slice(input);
+        let g = felts_as_goldilocks_slice(input);
         Self(Goldilocks::sum_array::<N>(g))
     }
 
     #[inline]
     fn dot_product<const N: usize>(lhs: &[Self; N], rhs: &[Self; N]) -> Self {
-        let lhs_g = felt_as_goldilocks_array(lhs);
-        let rhs_g = felt_as_goldilocks_array(rhs);
+        let lhs_g = felts_as_goldilocks_array(lhs);
+        let rhs_g = felts_as_goldilocks_array(rhs);
         Self(Goldilocks::dot_product(lhs_g, rhs_g))
     }
 

--- a/miden-field/src/native/mod.rs
+++ b/miden-field/src/native/mod.rs
@@ -1,6 +1,6 @@
 //! Off-chain implementation of [`crate::Felt`].
 
-use alloc::format;
+use alloc::{format, vec, vec::Vec};
 use core::{
     array, fmt,
     hash::{Hash, Hasher},
@@ -22,6 +22,7 @@ use p3_field::{
     quotient_map_large_iint, quotient_map_large_uint, quotient_map_small_int,
 };
 use p3_goldilocks::Goldilocks;
+use p3_util::flatten_to_base;
 use rand::{
     Rng,
     distr::{Distribution, StandardUniform},
@@ -137,6 +138,17 @@ fn raw_felt_u64(value: &Felt) -> u64 {
     unsafe { core::mem::transmute_copy(value) }
 }
 
+/// Reinterprets a `Felt` slice as `Goldilocks`.
+///
+/// # Safety
+///
+/// `Felt` is `#[repr(transparent)]` over `Goldilocks`, so the element layout matches.
+#[inline]
+fn felt_as_goldilock_slice(s: &[Felt]) -> &[Goldilocks] {
+    // SAFETY: `Felt` is `#[repr(transparent)]` over `Goldilocks`, so the element layout matches.
+    unsafe { core::slice::from_raw_parts(s.as_ptr().cast::<Goldilocks>(), s.len()) }
+}
+
 impl fmt::Display for Felt {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -162,6 +174,8 @@ impl Hash for Felt {
 // ================================================================================================
 
 impl Field for Felt {
+    // TODO: This should only be the case for WASM targets.
+    // Native targets should be able to leverage AVX2 / NEON optimizations from Plonky3.
     type Packing = Self;
 
     const GENERATOR: Self = Self(Goldilocks::GENERATOR);
@@ -220,6 +234,29 @@ impl PrimeCharacteristicRing for Felt {
     #[inline]
     fn exp_u64(&self, power: u64) -> Self {
         self.0.exp_u64(power).into()
+    }
+
+    #[inline]
+    fn sum_array<const N: usize>(input: &[Self]) -> Self {
+        assert_eq!(N, input.len());
+        let g = felt_as_goldilock_slice(input);
+        Self(Goldilocks::sum_array::<N>(g))
+    }
+
+    #[inline]
+    fn dot_product<const N: usize>(lhs: &[Self; N], rhs: &[Self; N]) -> Self {
+        let lhs_g: [Goldilocks; N] = core::array::from_fn(|i| lhs[i].0);
+        let rhs_g: [Goldilocks; N] = core::array::from_fn(|i| rhs[i].0);
+        Self(Goldilocks::dot_product(&lhs_g, &rhs_g))
+    }
+
+    #[inline]
+    fn zero_vec(len: usize) -> Vec<Self> {
+        // SAFETY:
+        // Due to `#[repr(transparent)]`, Felt, Goldilocks and u64 have the same size,
+        // alignment and memory layout making `flatten_to_base` safe.
+        // This will create a vector of Felt elements with value set to 0.
+        unsafe { flatten_to_base(vec![0u64; len]) }
     }
 }
 

--- a/miden-field/src/native/mod.rs
+++ b/miden-field/src/native/mod.rs
@@ -149,6 +149,17 @@ fn felt_as_goldilock_slice(s: &[Felt]) -> &[Goldilocks] {
     unsafe { core::slice::from_raw_parts(s.as_ptr().cast::<Goldilocks>(), s.len()) }
 }
 
+/// Reinterprets a `Felt` array as `Goldilocks`.
+///
+/// # Safety
+///
+/// `Felt` is `#[repr(transparent)]` over `Goldilocks`, so `[Felt; N]` matches `[Goldilocks; N]`.
+#[inline]
+fn felt_as_goldilocks_array<const N: usize>(a: &[Felt; N]) -> &[Goldilocks; N] {
+    // SAFETY: same layout as `felt_as_goldilock_slice`, for a fixed `N`.
+    unsafe { &*(a as *const [Felt; N] as *const [Goldilocks; N]) }
+}
+
 impl fmt::Display for Felt {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -245,9 +256,9 @@ impl PrimeCharacteristicRing for Felt {
 
     #[inline]
     fn dot_product<const N: usize>(lhs: &[Self; N], rhs: &[Self; N]) -> Self {
-        let lhs_g: [Goldilocks; N] = core::array::from_fn(|i| lhs[i].0);
-        let rhs_g: [Goldilocks; N] = core::array::from_fn(|i| rhs[i].0);
-        Self(Goldilocks::dot_product(&lhs_g, &rhs_g))
+        let lhs_g = felt_as_goldilocks_array(lhs);
+        let rhs_g = felt_as_goldilocks_array(rhs);
+        Self(Goldilocks::dot_product(lhs_g, rhs_g))
     }
 
     #[inline]


### PR DESCRIPTION
## Describe your changes

We were not overriding the default impl. for some trait methods of our Goldilocks wrapper, which resulted to not leverage the tailored implementations for Goldilocks in Plonky3.

See related https://github.com/0xMiden/p3-miden/issues/65.

## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
