### PR TITLE
Update miden-crypto to rand 0.10 and remove winter-rand-utils

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,7 +154,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "constant_time_eq",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -223,7 +223,18 @@ checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.0",
 ]
 
 [[package]]
@@ -233,7 +244,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
 dependencies = [
  "aead",
- "chacha20",
+ "chacha20 0.9.1",
  "cipher",
  "poly1305",
  "zeroize",
@@ -356,6 +367,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "criterion"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -455,7 +475,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest",
  "fiat-crypto",
@@ -716,6 +736,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.0",
  "wasip2",
  "wasip3",
 ]
@@ -890,7 +911,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -1018,9 +1039,9 @@ dependencies = [
  "p3-symmetric",
  "p3-util",
  "proptest",
- "rand 0.9.2",
- "rand_chacha",
- "rand_core 0.9.5",
+ "rand 0.10.0",
+ "rand_chacha 0.10.0",
+ "rand_core 0.10.0",
  "rand_hc",
  "rayon",
  "rocksdb",
@@ -1032,7 +1053,6 @@ dependencies = [
  "subtle",
  "tempfile",
  "thiserror",
- "winter-rand-utils",
  "x25519-dalek",
 ]
 
@@ -1574,7 +1594,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -1631,7 +1651,7 @@ dependencies = [
  "bitflags",
  "num-traits",
  "rand 0.9.2",
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
  "unarray",
@@ -1664,7 +1684,7 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rand_core 0.9.5",
 ]
 
@@ -1674,6 +1694,8 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
 dependencies = [
+ "chacha20 0.10.0",
+ "getrandom 0.4.2",
  "rand_core 0.10.0",
 ]
 
@@ -1685,6 +1707,16 @@ checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e6af7f3e25ded52c41df4e0b1af2d047e45896c2f3281792ed68a1c243daedb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.10.0",
 ]
 
 [[package]]
@@ -1958,7 +1990,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -2378,22 +2410,6 @@ checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
 ]
-
-[[package]]
-name = "winter-rand-utils"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4ff3b651754a7bd216f959764d0a5ab6f4b551c9a3a08fb9ccecbed594b614a"
-dependencies = [
- "rand 0.9.2",
- "winter-utils",
-]
-
-[[package]]
-name = "winter-utils"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9951263ef5317740cd0f49e618db00c72fabb70b75756ea26c4d5efe462c04dd"
 
 [[package]]
 name = "wit-bindgen"

--- a/deny.toml
+++ b/deny.toml
@@ -39,8 +39,8 @@ skip = [
   { name = "spin" },
 ]
 skip-tree = [
-  # miden-crypto uses rand 0.9 while Plonky3 0.5 uses rand 0.10,
-  # causing duplicate rand / rand_core / getrandom trees
+  # proptest still pulls rand 0.9 while miden-crypto and Plonky3 use rand 0.10,
+  # and crypto deps like k256/chacha20poly1305/rand_hc still pull rand_core/getrandom 0.6/0.2
   { name = "getrandom", version = "=0.2.17" },
   { name = "rand", version = "=0.9.2" },
   { name = "rand_core", version = "=0.6.4" },

--- a/deny.toml
+++ b/deny.toml
@@ -39,10 +39,13 @@ skip = [
   { name = "spin" },
 ]
 skip-tree = [
-  # proptest still pulls rand 0.9 while miden-crypto and Plonky3 use rand 0.10,
-  # and crypto deps like k256/chacha20poly1305/rand_hc still pull rand_core/getrandom 0.6/0.2
+  # proptest still pulls rand/rand_chacha 0.9 while miden-crypto and Plonky3 use 0.10,
+  # and older crypto deps still pull rand_core/getrandom/chacha20/cpufeatures from the 0.6/0.2/0.9 lines
+  { name = "chacha20", version = "=0.9.1" },
+  { name = "cpufeatures", version = "=0.2.17" },
   { name = "getrandom", version = "=0.2.17" },
   { name = "rand", version = "=0.9.2" },
+  { name = "rand_chacha", version = "=0.9.0" },
   { name = "rand_core", version = "=0.6.4" },
 ]
 wildcards = "allow"

--- a/miden-crypto-fuzz/Cargo.lock
+++ b/miden-crypto-fuzz/Cargo.lock
@@ -13,6 +13,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
 name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -47,6 +53,12 @@ name = "base64ct"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e050f626429857a27ddccb31e0aca21356bfa709c04041aefddac081a8f068a"
+
+[[package]]
+name = "bitflags"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "blake3"
@@ -102,7 +114,18 @@ checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.0",
 ]
 
 [[package]]
@@ -112,7 +135,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
 dependencies = [
  "aead",
- "chacha20",
+ "chacha20 0.9.1",
  "cipher",
  "poly1305",
  "zeroize",
@@ -149,6 +172,21 @@ checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam-deque"
@@ -211,7 +249,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest",
  "fiat-crypto",
@@ -318,6 +356,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "ff"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -350,6 +394,12 @@ dependencies = [
  "nanorand",
  "spin 0.9.8",
 ]
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "futures-core"
@@ -395,8 +445,22 @@ checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "rand_core 0.10.0",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -417,6 +481,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hkdf"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -432,6 +517,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest",
+]
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "indexmap"
+version = "2.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -451,6 +554,12 @@ checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jobserver"
@@ -492,8 +601,14 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -527,8 +642,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "memchr"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
 name = "miden-crypto"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "blake3",
  "cc",
@@ -544,25 +671,20 @@ dependencies = [
  "miden-serde-utils",
  "num",
  "num-complex",
- "p3-air",
+ "once_cell",
  "p3-blake3",
  "p3-challenger",
- "p3-commit",
  "p3-dft",
- "p3-field",
  "p3-goldilocks",
  "p3-keccak",
  "p3-matrix",
  "p3-maybe-rayon",
- "p3-merkle-tree",
- "p3-miden-air",
- "p3-miden-fri",
- "p3-miden-prover",
+ "p3-miden-lifted-stark",
  "p3-symmetric",
  "p3-util",
  "rand",
  "rand_chacha",
- "rand_core 0.9.3",
+ "rand_core 0.10.0",
  "rand_hc",
  "rayon",
  "serde",
@@ -575,7 +697,7 @@ dependencies = [
 
 [[package]]
 name = "miden-crypto-derive"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "quote",
  "syn",
@@ -587,12 +709,11 @@ version = "0.0.0"
 dependencies = [
  "libfuzzer-sys",
  "miden-crypto",
- "rand",
 ]
 
 [[package]]
 name = "miden-field"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "miden-serde-utils",
  "num-bigint",
@@ -608,7 +729,7 @@ dependencies = [
 
 [[package]]
 name = "miden-serde-utils"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "p3-field",
  "p3-goldilocks",
@@ -702,6 +823,10 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+dependencies = [
+ "critical-section",
+ "portable-atomic",
+]
 
 [[package]]
 name = "opaque-debug"
@@ -711,19 +836,20 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "p3-air"
-version = "0.4.2"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0141a56ed9924ce0265e7e91cd29bbcd230262744b7a7f0c448bfbf212f73182"
+checksum = "9f2ec9cbfc642fc5173817287c3f8b789d07743b5f7e812d058b7a03e344f9ab"
 dependencies = [
  "p3-field",
  "p3-matrix",
+ "tracing",
 ]
 
 [[package]]
 name = "p3-blake3"
-version = "0.4.2"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "006330bae15fdda0d460e73e03e7ebf06e8848dfda8355f9d568a7fed7c37719"
+checksum = "b667f43b19499dd939c9e2553aa95688936a88360d50117dae3c8848d07dbc70"
 dependencies = [
  "blake3",
  "p3-symmetric",
@@ -732,9 +858,9 @@ dependencies = [
 
 [[package]]
 name = "p3-challenger"
-version = "0.4.2"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20e42ba74a49c08c6e99f74cd9b343bfa31aa5721fea55079b18e3fd65f1dcbc"
+checksum = "4a0b490c745a7d2adeeafff06411814c8078c432740162332b3cd71be0158a76"
 dependencies = [
  "p3-field",
  "p3-maybe-rayon",
@@ -746,13 +872,11 @@ dependencies = [
 
 [[package]]
 name = "p3-commit"
-version = "0.4.2"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "498211e7b9a0f8366b410b4a9283ae82ff2fc91f473b1c5816aa6e90e74b125d"
+checksum = "916ae7989d5c3b49f887f5c55b2f9826bdbb81aaebf834503c4145d8b267c829"
 dependencies = [
  "itertools",
- "p3-challenger",
- "p3-dft",
  "p3-field",
  "p3-matrix",
  "p3-util",
@@ -761,9 +885,9 @@ dependencies = [
 
 [[package]]
 name = "p3-dft"
-version = "0.4.2"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e63fa5eb1bd12a240089e72ae3fe10350944d9c166d00a3bfd2a1794db65cf5c"
+checksum = "55301e91544440254977108b85c32c09d7ea05f2f0dd61092a2825339906a4a7"
 dependencies = [
  "itertools",
  "p3-field",
@@ -776,9 +900,9 @@ dependencies = [
 
 [[package]]
 name = "p3-field"
-version = "0.4.2"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ebfdb6ef992ae64e9e8f449ac46516ffa584f11afbdf9ee244288c2a633cdf4"
+checksum = "85affca7fc983889f260655c4cf74163eebb94605f702e4b6809ead707cba54f"
 dependencies = [
  "itertools",
  "num-bigint",
@@ -792,15 +916,16 @@ dependencies = [
 
 [[package]]
 name = "p3-goldilocks"
-version = "0.4.2"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64716244b5612622d4e78a4f48b74f6d3bb7b4085b7b6b25364b1dfca7198c66"
+checksum = "0ca1081f5c47b940f2d75a11c04f62ea1cc58a5d480dd465fef3861c045c63cd"
 dependencies = [
  "num-bigint",
  "p3-challenger",
  "p3-dft",
  "p3-field",
  "p3-mds",
+ "p3-poseidon1",
  "p3-poseidon2",
  "p3-symmetric",
  "p3-util",
@@ -810,24 +935,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "p3-interpolation"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d877565a94a527c89459fc8ccb0eb58769d8c86456575d1315a1651bd24616d"
-dependencies = [
- "p3-field",
- "p3-matrix",
- "p3-maybe-rayon",
- "p3-util",
-]
-
-[[package]]
 name = "p3-keccak"
-version = "0.4.2"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d57334537d10316e0f1cda622f0a5b3239f219a5dcd2a95ea87e41e00df6a92"
+checksum = "ebcf27615ece1995e4fcf4c69740f1cf515d1481367a20b4b3ce7f4f1b8d70f7"
 dependencies = [
- "p3-field",
  "p3-symmetric",
  "p3-util",
  "tiny-keccak",
@@ -835,9 +947,9 @@ dependencies = [
 
 [[package]]
 name = "p3-matrix"
-version = "0.4.2"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5542f96504dae8100c91398fb1e3f5ec669eb9c73d9e0b018a93b5fe32bad230"
+checksum = "53428126b009071563d1d07305a9de8be0d21de00b57d2475289ee32ffca6577"
 dependencies = [
  "itertools",
  "p3-field",
@@ -846,23 +958,22 @@ dependencies = [
  "rand",
  "serde",
  "tracing",
- "transpose",
 ]
 
 [[package]]
 name = "p3-maybe-rayon"
-version = "0.4.2"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e5669ca75645f99cd001e9d0289a4eeff2bc2cd9dc3c6c3aaf22643966e83df"
+checksum = "082bf467011c06c768c579ec6eb9accb5e1e62108891634cc770396e917f978a"
 dependencies = [
  "rayon",
 ]
 
 [[package]]
 name = "p3-mds"
-version = "0.4.2"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "038763af23df9da653065867fd85b38626079031576c86fd537097e5be6a0da0"
+checksum = "35209e6214102ea6ec6b8cb1b9c15a9b8e597a39f9173597c957f123bced81b3"
 dependencies = [
  "p3-dft",
  "p3-field",
@@ -872,16 +983,71 @@ dependencies = [
 ]
 
 [[package]]
-name = "p3-merkle-tree"
-version = "0.4.2"
+name = "p3-miden-lifted-air"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d93625a3041effddc72ee2511c919f710b7f91fd0f9931ab8a70aeba586fd6e"
+checksum = "c5c31c65fdc88952d7b301546add9670676e5b878aa0066dd929f107c203b006"
 dependencies = [
- "itertools",
+ "p3-air",
+ "p3-field",
+ "p3-matrix",
+ "p3-util",
+ "thiserror",
+]
+
+[[package]]
+name = "p3-miden-lifted-fri"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab9932f1b0a16609a45cd4ee10a4d35412728bc4b38837c7979d7c85d8dcc9fc"
+dependencies = [
+ "p3-challenger",
+ "p3-commit",
+ "p3-dft",
+ "p3-field",
+ "p3-matrix",
+ "p3-maybe-rayon",
+ "p3-miden-lmcs",
+ "p3-miden-transcript",
+ "p3-util",
+ "rand",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "p3-miden-lifted-stark"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c3956ab7270c3cdd53ca9796d39ae1821984eb977415b0672110f9666bff5d8"
+dependencies = [
+ "p3-challenger",
+ "p3-dft",
+ "p3-field",
+ "p3-matrix",
+ "p3-maybe-rayon",
+ "p3-miden-lifted-air",
+ "p3-miden-lifted-fri",
+ "p3-miden-lmcs",
+ "p3-miden-stateful-hasher",
+ "p3-miden-transcript",
+ "p3-util",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "p3-miden-lmcs"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c46791c983e772136db3d48f102431457451447abb9087deb6c8ce3c1efc86"
+dependencies = [
  "p3-commit",
  "p3-field",
  "p3-matrix",
  "p3-maybe-rayon",
+ "p3-miden-stateful-hasher",
+ "p3-miden-transcript",
  "p3-symmetric",
  "p3-util",
  "rand",
@@ -891,83 +1057,32 @@ dependencies = [
 ]
 
 [[package]]
-name = "p3-miden-air"
-version = "0.4.2"
+name = "p3-miden-stateful-hasher"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a88e6ee9c92ff6c0b64f1ec0d61eda72fb432bda45337d876c46bd43748508"
+checksum = "ec47a9d9615eb3d9d2a59b00d19751d9ad85384b55886827913d680d912eac6a"
 dependencies = [
- "p3-air",
  "p3-field",
- "p3-matrix",
+ "p3-symmetric",
 ]
 
 [[package]]
-name = "p3-miden-fri"
-version = "0.4.2"
+name = "p3-miden-transcript"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e282998bc1d12dceaa0ed8979fa507b8369d663fa377da695d578f5f3a035935"
+checksum = "40c565647487e4a949f67e6f115b0391d6cb82ac8e561165789939bab23d0ae7"
 dependencies = [
- "itertools",
  "p3-challenger",
- "p3-commit",
- "p3-dft",
  "p3-field",
- "p3-interpolation",
- "p3-matrix",
- "p3-maybe-rayon",
- "p3-util",
- "rand",
- "serde",
- "tracing",
-]
-
-[[package]]
-name = "p3-miden-prover"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f05a61c10cc2d6a73e192ac34a9884e4f26bd877f3eaea441d7b7ebfdffdf6c7"
-dependencies = [
- "itertools",
- "p3-challenger",
- "p3-commit",
- "p3-dft",
- "p3-field",
- "p3-interpolation",
- "p3-matrix",
- "p3-maybe-rayon",
- "p3-miden-air",
- "p3-miden-uni-stark",
- "p3-util",
- "serde",
- "tracing",
-]
-
-[[package]]
-name = "p3-miden-uni-stark"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a78b6a5b5f6bdc55439d343d2a0a2a8e7cb6544b03296f54d2214a84e91e130"
-dependencies = [
- "itertools",
- "p3-air",
- "p3-challenger",
- "p3-commit",
- "p3-dft",
- "p3-field",
- "p3-matrix",
- "p3-maybe-rayon",
- "p3-uni-stark",
- "p3-util",
  "serde",
  "thiserror",
- "tracing",
 ]
 
 [[package]]
 name = "p3-monty-31"
-version = "0.4.2"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57a981d60da3d8cbf8561014e2c186068578405fd69098fa75b43d4afb364a47"
+checksum = "ffa8c99ec50c035020bbf5457c6a729ba6a975719c1a8dd3f16421081e4f650c"
 dependencies = [
  "itertools",
  "num-bigint",
@@ -976,6 +1091,7 @@ dependencies = [
  "p3-matrix",
  "p3-maybe-rayon",
  "p3-mds",
+ "p3-poseidon1",
  "p3-poseidon2",
  "p3-symmetric",
  "p3-util",
@@ -984,14 +1100,24 @@ dependencies = [
  "serde",
  "spin 0.10.0",
  "tracing",
- "transpose",
+]
+
+[[package]]
+name = "p3-poseidon1"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a018b618e3fa0aec8be933b1d8e404edd23f46991f6bf3f5c2f3f95e9413fe9"
+dependencies = [
+ "p3-field",
+ "p3-symmetric",
+ "rand",
 ]
 
 [[package]]
 name = "p3-poseidon2"
-version = "0.4.2"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "903b73e4f9a7781a18561c74dc169cf03333497b57a8dd02aaeb130c0f386599"
+checksum = "256a668a9ba916f8767552f13d0ba50d18968bc74a623bfdafa41e2970c944d0"
 dependencies = [
  "p3-field",
  "p3-mds",
@@ -1002,43 +1128,25 @@ dependencies = [
 
 [[package]]
 name = "p3-symmetric"
-version = "0.4.2"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cd788f04e86dd5c35dd87cad29eefdb6371d2fd5f7664451382eeacae3c3ed0"
+checksum = "6c60a71a1507c13611b0f2b0b6e83669fd5b76f8e3115bcbced5ccfdf3ca7807"
 dependencies = [
  "itertools",
  "p3-field",
- "serde",
-]
-
-[[package]]
-name = "p3-uni-stark"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68d409704a8cbdb6c77f6b83a05c6b16a3c8a2c00d880146fa34181977a0d3ac"
-dependencies = [
- "itertools",
- "p3-air",
- "p3-challenger",
- "p3-commit",
- "p3-dft",
- "p3-field",
- "p3-matrix",
- "p3-maybe-rayon",
  "p3-util",
  "serde",
- "thiserror",
- "tracing",
 ]
 
 [[package]]
 name = "p3-util"
-version = "0.4.2"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "663b16021930bc600ecada915c6c3965730a3b9d6a6c23434ccf70bfc29d6881"
+checksum = "f8b766b9e9254bf3fa98d76e42cf8a5b30628c182dfd5272d270076ee12f0fc0"
 dependencies = [
  "rayon",
  "serde",
+ "transpose",
 ]
 
 [[package]]
@@ -1069,10 +1177,16 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "ppv-lite86"
@@ -1081,6 +1195,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
 ]
 
 [[package]]
@@ -1108,23 +1232,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
-name = "rand"
-version = "0.9.2"
+name = "r-efi"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
 dependencies = [
- "rand_chacha",
- "rand_core 0.9.3",
+ "chacha20 0.10.0",
+ "getrandom 0.4.2",
+ "rand_core 0.10.0",
 ]
 
 [[package]]
 name = "rand_chacha"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+checksum = "3e6af7f3e25ded52c41df4e0b1af2d047e45896c2f3281792ed68a1c243daedb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.3",
+ "rand_core 0.10.0",
 ]
 
 [[package]]
@@ -1138,12 +1269,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.9.3"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
-dependencies = [
- "getrandom 0.3.4",
-]
+checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
 
 [[package]]
 name = "rand_hc"
@@ -1256,13 +1384,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -1423,6 +1564,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "universal-hash"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1450,7 +1597,16 @@ version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.46.0",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -1499,10 +1655,132 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "x25519-dalek"
@@ -1539,3 +1817,9 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/miden-crypto-fuzz/Cargo.toml
+++ b/miden-crypto-fuzz/Cargo.toml
@@ -10,7 +10,6 @@ cargo-fuzz = true
 [dependencies]
 libfuzzer-sys = "0.4"
 miden-crypto  = { features = ["concurrent", "fuzzing"], path = "../miden-crypto" }
-rand          = { default-features = false, version = "0.9" }
 
 # Existing SMT fuzz target (for sequential vs parallel consistency)
 [[bin]]

--- a/miden-crypto-fuzz/fuzz_targets/smt.rs
+++ b/miden-crypto-fuzz/fuzz_targets/smt.rs
@@ -2,7 +2,6 @@
 
 use libfuzzer_sys::fuzz_target;
 use miden_crypto::{Felt, ONE, Word, merkle::smt::Smt};
-use rand::Rng; // Needed for randomizing the split percentage
 
 struct FuzzInput {
     entries: Vec<(Word, Word)>,
@@ -11,8 +10,7 @@ struct FuzzInput {
 
 impl FuzzInput {
     fn from_bytes(data: &[u8]) -> Self {
-        let mut rng = rand::rng();
-        let split_percentage = rng.random_range(20..80); // Randomly choose between 20% and 80%
+        let split_percentage = Self::split_percentage(data);
 
         let split_index = (data.len() * split_percentage) / 100;
         let (construction_data, update_data) = data.split_at(split_index);
@@ -21,6 +19,10 @@ impl FuzzInput {
         let updates = Self::parse_entries(update_data);
 
         Self { entries, updates }
+    }
+
+    fn split_percentage(data: &[u8]) -> usize {
+        20 + usize::from(data.first().copied().unwrap_or(0)) % 60
     }
 
     fn parse_entries(data: &[u8]) -> Vec<(Word, Word)> {

--- a/miden-crypto/Cargo.toml
+++ b/miden-crypto/Cargo.toml
@@ -82,7 +82,7 @@ required-features = ["std"]
 [features]
 concurrent        = ["dep:rayon", "p3-maybe-rayon/parallel", "p3-miden-lifted-stark/parallel", "p3-util/parallel", "std"]
 default           = ["concurrent", "std"]
-executable        = ["concurrent", "dep:clap", "dep:rand-utils"]
+executable        = ["concurrent", "dep:clap"]
 fuzzing           = []
 internal          = ["concurrent"]
 persistent-forest = ["rocksdb", "serde"]
@@ -110,10 +110,9 @@ num              = { default-features = false, features = ["alloc", "libm"], ver
 num-complex      = { default-features = false, version = "0.4" }
 once_cell        = { default-features = false, features = ["alloc", "critical-section"], version = "1.21" }
 proptest         = { default-features = false, features = ["alloc"], optional = true, version = "1.7" }
-rand             = { default-features = false, version = "0.9" }
-rand-utils       = { optional = true, package = "winter-rand-utils", version = "0.13" }
-rand_chacha      = { default-features = false, version = "0.9" }
-rand_core        = { default-features = false, version = "0.9" }
+rand             = { default-features = false, version = "0.10" }
+rand_chacha      = { default-features = false, version = "0.10" }
+rand_core        = { default-features = false, version = "0.10" }
 rand_hc          = { version = "0.3" }
 rayon            = { optional = true, version = "1.10" }
 rocksdb          = { default-features = false, features = ["bindgen-runtime", "lz4"], optional = true, version = "0.24" }
@@ -145,7 +144,6 @@ hex            = { default-features = false, features = ["alloc"], version = "0.
 itertools      = { version = "0.14" }
 miden-field    = { features = ["testing"], workspace = true }
 proptest       = { default-features = false, features = ["alloc"], version = "1.7" }
-rand-utils     = { package = "winter-rand-utils", version = "0.13" }
 rstest         = { version = "0.26" }
 seq-macro      = { version = "0.3" }
 tempfile       = { version = "3.20" }
@@ -158,7 +156,7 @@ glob = "0.3"
 workspace = true
 
 [package.metadata.cargo-machete]
-ignored = ["getrandom", "rand-utils"]
+ignored = ["getrandom"]
 
 [[test]]
 name              = "rocksdb_large_smt"

--- a/miden-crypto/Cargo.toml
+++ b/miden-crypto/Cargo.toml
@@ -144,6 +144,7 @@ hex            = { default-features = false, features = ["alloc"], version = "0.
 itertools      = { version = "0.14" }
 miden-field    = { features = ["testing"], workspace = true }
 proptest       = { default-features = false, features = ["alloc"], version = "1.7" }
+rand           = { default-features = false, features = ["std", "thread_rng"], version = "0.10" }
 rstest         = { version = "0.26" }
 seq-macro      = { version = "0.3" }
 tempfile       = { version = "3.20" }

--- a/miden-crypto/src/aead/aead_poseidon2/mod.rs
+++ b/miden-crypto/src/aead/aead_poseidon2/mod.rs
@@ -13,7 +13,7 @@ use core::ops::Range;
 use miden_crypto_derive::{SilentDebug, SilentDisplay};
 use num::Integer;
 use rand::{
-    Rng,
+    Rng, RngExt,
     distr::{Distribution, StandardUniform, Uniform},
 };
 use subtle::ConstantTimeEq;
@@ -772,7 +772,7 @@ impl AeadScheme for AeadPoseidon2 {
             .map_err(|_| EncryptionError::FailedOperation)
     }
 
-    fn encrypt_bytes<R: rand::CryptoRng + rand::RngCore>(
+    fn encrypt_bytes<R: rand::CryptoRng + rand::Rng>(
         key: &Self::Key,
         rng: &mut R,
         plaintext: &[u8],
@@ -801,7 +801,7 @@ impl AeadScheme for AeadPoseidon2 {
     // OPTIMIZED FELT METHODS
     // --------------------------------------------------------------------------------------------
 
-    fn encrypt_elements<R: rand::CryptoRng + rand::RngCore>(
+    fn encrypt_elements<R: rand::CryptoRng + rand::Rng>(
         key: &Self::Key,
         rng: &mut R,
         plaintext: &[Felt],

--- a/miden-crypto/src/aead/aead_poseidon2/test.rs
+++ b/miden-crypto/src/aead/aead_poseidon2/test.rs
@@ -2,7 +2,7 @@ use proptest::{
     prelude::{any, prop},
     prop_assert_eq, prop_assert_ne, prop_assume, proptest,
 };
-use rand::{RngCore, SeedableRng};
+use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha20Rng;
 
 use super::*;

--- a/miden-crypto/src/aead/mod.rs
+++ b/miden-crypto/src/aead/mod.rs
@@ -52,7 +52,7 @@ pub(crate) trait AeadScheme {
     // BYTE METHODS
     // ================================================================================================
 
-    fn encrypt_bytes<R: rand::CryptoRng + rand::RngCore>(
+    fn encrypt_bytes<R: rand::CryptoRng + rand::Rng>(
         key: &Self::Key,
         rng: &mut R,
         plaintext: &[u8],
@@ -69,7 +69,7 @@ pub(crate) trait AeadScheme {
     // ================================================================================================
 
     /// Encrypts field elements with associated data. Default implementation converts to bytes.
-    fn encrypt_elements<R: rand::CryptoRng + rand::RngCore>(
+    fn encrypt_elements<R: rand::CryptoRng + rand::Rng>(
         key: &Self::Key,
         rng: &mut R,
         plaintext: &[Felt],

--- a/miden-crypto/src/aead/xchacha/mod.rs
+++ b/miden-crypto/src/aead/xchacha/mod.rs
@@ -16,7 +16,7 @@ use chacha20poly1305::{
     XChaCha20Poly1305,
     aead::{Aead, AeadCore, KeyInit},
 };
-use rand::{CryptoRng, RngCore};
+use rand::{CryptoRng, Rng};
 #[cfg(any(test, feature = "testing"))]
 use subtle::ConstantTimeEq;
 
@@ -65,7 +65,7 @@ pub struct Nonce {
 
 impl Nonce {
     /// Creates a new random nonce using the provided random number generator
-    pub fn with_rng<R: RngCore + CryptoRng>(rng: &mut R) -> Self {
+    pub fn with_rng<R: Rng + CryptoRng>(rng: &mut R) -> Self {
         // we use a seedable CSPRNG and seed it with `rng`
         // this is a work around the fact that the version of the `rand` dependency in our crate
         // is different than the one used in the `chacha20poly1305`. This solution will
@@ -73,7 +73,7 @@ impl Nonce {
         // the `rand` dependency matching ours
         use chacha20poly1305::aead::rand_core::SeedableRng;
         let mut seed = [0_u8; 32];
-        rand::RngCore::fill_bytes(rng, &mut seed);
+        Rng::fill_bytes(rng, &mut seed);
         let rng = rand_hc::Hc128Rng::from_seed(seed);
 
         Nonce {
@@ -115,7 +115,7 @@ impl SecretKey {
     }
 
     /// Creates a new random secret key using the provided random number generator
-    pub fn with_rng<R: RngCore + CryptoRng>(rng: &mut R) -> Self {
+    pub fn with_rng<R: Rng + CryptoRng>(rng: &mut R) -> Self {
         // we use a seedable CSPRNG and seed it with `rng`
         // this is a work around the fact that the version of the `rand` dependency in our crate
         // is different than the one used in the `chacha20poly1305`. This solution will
@@ -123,7 +123,7 @@ impl SecretKey {
         // the `rand` dependency matching ours
         use chacha20poly1305::aead::rand_core::SeedableRng;
         let mut seed = [0_u8; 32];
-        rand::RngCore::fill_bytes(rng, &mut seed);
+        Rng::fill_bytes(rng, &mut seed);
         let rng = rand_hc::Hc128Rng::from_seed(seed);
 
         let key = XChaCha20Poly1305::generate_key(rng);
@@ -348,7 +348,7 @@ impl AeadScheme for XChaCha {
             .map_err(|_| EncryptionError::FailedOperation)
     }
 
-    fn encrypt_bytes<R: rand::CryptoRng + rand::RngCore>(
+    fn encrypt_bytes<R: rand::CryptoRng + rand::Rng>(
         key: &Self::Key,
         rng: &mut R,
         plaintext: &[u8],

--- a/miden-crypto/src/aead/xchacha/test.rs
+++ b/miden-crypto/src/aead/xchacha/test.rs
@@ -2,7 +2,7 @@ use proptest::{
     prelude::{any, prop},
     prop_assert_eq, prop_assert_ne, proptest,
 };
-use rand::{Rng, SeedableRng};
+use rand::{Rng, RngExt, SeedableRng};
 use rand_chacha::ChaCha20Rng;
 
 use super::*;
@@ -67,7 +67,7 @@ proptest! {
 
         // Generate random bytes
         let mut data = vec![0_u8; data_len];
-        rng.fill(&mut data[..]);
+        rng.fill_bytes(&mut data[..]);
 
         let encrypted = key.encrypt_bytes_with_nonce(&data, &[], nonce).unwrap();
         let decrypted = key.decrypt_bytes(&encrypted).unwrap();
@@ -87,10 +87,10 @@ proptest! {
 
         // Generate random bytes
         let mut associated_data = vec![0_u8; associated_data_len];
-        rng.fill(&mut associated_data[..]);
+        rng.fill_bytes(&mut associated_data[..]);
 
         let mut data = vec![0_u8; data_len];
-        rng.fill(&mut data[..]);
+        rng.fill_bytes(&mut data[..]);
 
 
         let encrypted = key.encrypt_bytes_with_nonce(&data, &associated_data, nonce).unwrap();
@@ -112,7 +112,7 @@ proptest! {
         let key1 = SecretKey::with_rng(&mut rng1);
         let key2 = SecretKey::with_rng(&mut rng2);
         let mut nonce_bytes = [0_u8; 24];
-        rng2.fill(&mut nonce_bytes[..]);
+        rng2.fill_bytes(&mut nonce_bytes[..]);
         let nonce1 = Nonce::from_slice(&nonce_bytes);
         let nonce2 = Nonce::from_slice(&nonce_bytes);
 
@@ -134,9 +134,9 @@ proptest! {
         let mut rng = ChaCha20Rng::seed_from_u64(seed);
         let key = SecretKey::with_rng(&mut rng);
         let mut nonce_bytes = [0_u8; 24];
-        rng.fill(&mut nonce_bytes[..]);
+        rng.fill_bytes(&mut nonce_bytes[..]);
         let nonce1 = Nonce::from_slice(&nonce_bytes);
-        rng.fill(&mut nonce_bytes[..]);
+        rng.fill_bytes(&mut nonce_bytes[..]);
         let nonce2 = Nonce::from_slice(&nonce_bytes);
 
         let encrypted1 = key.encrypt_bytes_with_nonce(&data, &associated_data, nonce1).unwrap();

--- a/miden-crypto/src/dsa/ecdsa_k256_keccak/mod.rs
+++ b/miden-crypto/src/dsa/ecdsa_k256_keccak/mod.rs
@@ -9,7 +9,7 @@ use k256::{
     pkcs8::DecodePublicKey,
 };
 use miden_crypto_derive::{SilentDebug, SilentDisplay};
-use rand::{CryptoRng, RngCore};
+use rand::{CryptoRng, Rng};
 use thiserror::Error;
 
 use crate::{
@@ -59,14 +59,14 @@ impl SecretKey {
     }
 
     /// Generates a new secret key using the provided random number generator.
-    pub fn with_rng<R: CryptoRng + RngCore>(rng: &mut R) -> Self {
+    pub fn with_rng<R: CryptoRng + Rng>(rng: &mut R) -> Self {
         // we use a seedable CSPRNG and seed it with `rng`
         // this is a work around the fact that the version of the `rand` dependency in our crate
         // is different than the one used in the `k256` one. This solution will no longer be needed
         // once `k256` gets a new release with a version of the `rand` dependency matching ours
         use k256::elliptic_curve::rand_core::SeedableRng;
         let mut seed = [0_u8; 32];
-        rand::RngCore::fill_bytes(rng, &mut seed);
+        Rng::fill_bytes(rng, &mut seed);
         let mut rng = rand_hc::Hc128Rng::from_seed(seed);
 
         let signing_key = SigningKey::random(&mut rng);

--- a/miden-crypto/src/dsa/eddsa_25519_sha512/mod.rs
+++ b/miden-crypto/src/dsa/eddsa_25519_sha512/mod.rs
@@ -5,7 +5,7 @@ use alloc::{string::ToString, vec::Vec};
 
 use ed25519_dalek::{Signer, Verifier};
 use miden_crypto_derive::{SilentDebug, SilentDisplay};
-use rand::{CryptoRng, RngCore};
+use rand::{CryptoRng, Rng};
 use thiserror::Error;
 
 use crate::{
@@ -51,9 +51,9 @@ impl SecretKey {
     }
 
     /// Generates a new secret key using RNG.
-    pub fn with_rng<R: CryptoRng + RngCore>(rng: &mut R) -> Self {
+    pub fn with_rng<R: CryptoRng + Rng>(rng: &mut R) -> Self {
         let mut seed = [0u8; SECRET_KEY_BYTES];
-        rand::RngCore::fill_bytes(rng, &mut seed);
+        Rng::fill_bytes(rng, &mut seed);
 
         let inner = ed25519_dalek::SigningKey::from_bytes(&seed);
 

--- a/miden-crypto/src/dsa/falcon512_poseidon2/math/ffsampling.rs
+++ b/miden-crypto/src/dsa/falcon512_poseidon2/math/ffsampling.rs
@@ -199,7 +199,7 @@ pub fn ffsampling<R: Rng>(
 #[cfg(test)]
 mod tests {
     use num_complex::Complex64;
-    use rand::{Rng, SeedableRng};
+    use rand::{Rng, RngExt, SeedableRng};
     use rand_chacha::ChaCha20Rng;
 
     use super::*;

--- a/miden-crypto/src/dsa/falcon512_poseidon2/tests/mod.rs
+++ b/miden-crypto/src/dsa/falcon512_poseidon2/tests/mod.rs
@@ -5,7 +5,7 @@ use data::{
     SYNC_DATA_FOR_TEST_VECTOR,
 };
 use prng::Shake256Testing;
-use rand::{RngCore, SeedableRng};
+use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha20Rng;
 
 use super::{Serializable, math::Polynomial};

--- a/miden-crypto/src/dsa/falcon512_poseidon2/tests/prng.rs
+++ b/miden-crypto/src/dsa/falcon512_poseidon2/tests/prng.rs
@@ -1,7 +1,8 @@
 use alloc::vec::Vec;
+use core::convert::Infallible;
 
-use rand::{Rng, RngCore};
-use rand_core::impls;
+use rand::Rng;
+use rand_core::{TryRng, utils};
 use sha3::{
     Shake256, Shake256ReaderCore,
     digest::{ExtendableOutput, Update, XofReader, core_api::XofReaderCoreWrapper},
@@ -28,8 +29,8 @@ impl Shake256Testing {
         Self(result)
     }
 
-    fn fill_bytes(&mut self, des: &mut [u8]) {
-        self.0.read(des)
+    fn read_bytes(&mut self, dest: &mut [u8]) {
+        self.0.read(dest)
     }
 
     /// A function to help with "syncing" the SHAKE256 PRNG so that it can be used with the test
@@ -37,29 +38,32 @@ impl Shake256Testing {
     pub(crate) fn sync_rng(&mut self) {
         for (bytes, num_seed_sampled) in SYNC_DATA.iter() {
             let mut dummy = vec![0_u8; bytes * 8];
-            self.fill_bytes(&mut dummy);
+            self.read_bytes(&mut dummy);
             let mut nonce_bytes = [0u8; SIG_NONCE_LEN];
-            self.fill_bytes(&mut nonce_bytes);
+            self.read_bytes(&mut nonce_bytes);
 
             for _ in 0..*num_seed_sampled {
                 let mut chacha_seed = [0_u8; CHACHA_SEED_LEN];
-                self.fill_bytes(&mut chacha_seed);
+                self.read_bytes(&mut chacha_seed);
             }
         }
     }
 }
 
-impl RngCore for Shake256Testing {
-    fn next_u32(&mut self) -> u32 {
-        impls::next_u32_via_fill(self)
+impl TryRng for Shake256Testing {
+    type Error = Infallible;
+
+    fn try_next_u32(&mut self) -> Result<u32, Infallible> {
+        utils::next_word_via_fill(self)
     }
 
-    fn next_u64(&mut self) -> u64 {
-        impls::next_u64_via_u32(self)
+    fn try_next_u64(&mut self) -> Result<u64, Infallible> {
+        utils::next_u64_via_u32(self)
     }
 
-    fn fill_bytes(&mut self, dest: &mut [u8]) {
-        self.fill_bytes(dest)
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Infallible> {
+        self.read_bytes(dest);
+        Ok(())
     }
 }
 
@@ -176,18 +180,21 @@ impl ChaCha {
     }
 }
 
-impl RngCore for ChaCha {
-    fn next_u32(&mut self) -> u32 {
-        impls::next_u32_via_fill(self)
+impl TryRng for ChaCha {
+    type Error = Infallible;
+
+    fn try_next_u32(&mut self) -> Result<u32, Infallible> {
+        utils::next_word_via_fill(self)
     }
 
-    fn next_u64(&mut self) -> u64 {
-        impls::next_u64_via_u32(self)
+    fn try_next_u64(&mut self) -> Result<u64, Infallible> {
+        utils::next_u64_via_u32(self)
     }
 
-    fn fill_bytes(&mut self, dest: &mut [u8]) {
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Infallible> {
         let len = dest.len();
         let buffer = self.random_bytes(len);
-        dest.iter_mut().enumerate().for_each(|(i, d)| *d = buffer[i])
+        dest.iter_mut().enumerate().for_each(|(i, d)| *d = buffer[i]);
+        Ok(())
     }
 }

--- a/miden-crypto/src/ecdh/k256.rs
+++ b/miden-crypto/src/ecdh/k256.rs
@@ -16,7 +16,7 @@ use alloc::{string::ToString, vec::Vec};
 
 use hkdf::{Hkdf, hmac::SimpleHmac};
 use k256::{AffinePoint, elliptic_curve::sec1::ToEncodedPoint, sha2::Sha256};
-use rand::{CryptoRng, RngCore};
+use rand::{CryptoRng, Rng};
 
 use crate::{
     dsa::ecdsa_k256_keccak::{PUBLIC_KEY_BYTES, PublicKey, SecretKey},
@@ -110,14 +110,14 @@ impl EphemeralSecretKey {
     }
 
     /// Generates a new ephemeral secret key using the provided random number generator.
-    pub fn with_rng<R: CryptoRng + RngCore>(rng: &mut R) -> Self {
+    pub fn with_rng<R: CryptoRng + Rng>(rng: &mut R) -> Self {
         // we use a seedable CSPRNG and seed it with `rng`
         // this is a work around the fact that the version of the `rand` dependency in our crate
         // is different than the one used in the `k256` one. This solution will no longer be needed
         // once `k256` gets a new release with a version of the `rand` dependency matching ours
         use k256::elliptic_curve::rand_core::SeedableRng;
         let mut seed = Zeroizing::new([0_u8; 32]);
-        rand::RngCore::fill_bytes(rng, &mut *seed);
+        Rng::fill_bytes(rng, &mut *seed);
         let mut rng = rand_hc::Hc128Rng::from_seed(*seed);
 
         let sk_e = k256::ecdh::EphemeralSecret::random(&mut rng);
@@ -192,7 +192,7 @@ impl KeyAgreementScheme for K256 {
 
     type SharedSecret = SharedSecret;
 
-    fn generate_ephemeral_keypair<R: CryptoRng + RngCore>(
+    fn generate_ephemeral_keypair<R: CryptoRng + Rng>(
         rng: &mut R,
     ) -> (Self::EphemeralSecretKey, Self::EphemeralPublicKey) {
         let sk = EphemeralSecretKey::with_rng(rng);

--- a/miden-crypto/src/ecdh/mod.rs
+++ b/miden-crypto/src/ecdh/mod.rs
@@ -2,7 +2,7 @@
 
 use alloc::vec::Vec;
 
-use rand::{CryptoRng, RngCore};
+use rand::{CryptoRng, Rng};
 use thiserror::Error;
 
 use crate::utils::{
@@ -26,7 +26,7 @@ pub(crate) trait KeyAgreementScheme {
     type SharedSecret: AsRef<[u8]> + Zeroize + ZeroizeOnDrop;
 
     /// Returns an ephemeral key pair generated from the provided RNG.
-    fn generate_ephemeral_keypair<R: CryptoRng + RngCore>(
+    fn generate_ephemeral_keypair<R: CryptoRng + Rng>(
         rng: &mut R,
     ) -> (Self::EphemeralSecretKey, Self::EphemeralPublicKey);
 

--- a/miden-crypto/src/ecdh/x25519.rs
+++ b/miden-crypto/src/ecdh/x25519.rs
@@ -16,7 +16,7 @@ use alloc::vec::Vec;
 
 use hkdf::{Hkdf, hmac::SimpleHmac};
 use k256::sha2::Sha256;
-use rand::{CryptoRng, RngCore};
+use rand::{CryptoRng, Rng};
 use subtle::ConstantTimeEq;
 
 use crate::{
@@ -108,7 +108,7 @@ impl EphemeralSecretKey {
     }
 
     /// Generates a new random ephemeral secret key using the provided RNG.
-    pub fn with_rng<R: CryptoRng + RngCore>(rng: &mut R) -> Self {
+    pub fn with_rng<R: CryptoRng + Rng>(rng: &mut R) -> Self {
         // we use a seedable CSPRNG and seed it with `rng`
         // this is a work around the fact that the version of the `rand` dependency in our crate
         // is different than the one used in the `x25519_dalek` one. This solution will no longer be
@@ -116,7 +116,7 @@ impl EphemeralSecretKey {
         // dependency matching ours
         use k256::elliptic_curve::rand_core::SeedableRng;
         let mut seed = Zeroizing::new([0_u8; 32]);
-        rand::RngCore::fill_bytes(rng, &mut *seed);
+        Rng::fill_bytes(rng, &mut *seed);
         let rng = rand_hc::Hc128Rng::from_seed(*seed);
 
         let sk = x25519_dalek::EphemeralSecret::random_from_rng(rng);
@@ -187,7 +187,7 @@ impl KeyAgreementScheme for X25519 {
 
     type SharedSecret = SharedSecret;
 
-    fn generate_ephemeral_keypair<R: CryptoRng + RngCore>(
+    fn generate_ephemeral_keypair<R: CryptoRng + Rng>(
         rng: &mut R,
     ) -> (Self::EphemeralSecretKey, Self::EphemeralPublicKey) {
         let sk = EphemeralSecretKey::with_rng(rng);

--- a/miden-crypto/src/ies/crypto_box.rs
+++ b/miden-crypto/src/ies/crypto_box.rs
@@ -6,7 +6,7 @@
 
 use alloc::vec::Vec;
 
-use rand::{CryptoRng, RngCore};
+use rand::{CryptoRng, Rng};
 
 use super::{IesError, IesScheme};
 use crate::{
@@ -42,7 +42,7 @@ impl<K: KeyAgreementScheme, A: AeadScheme> CryptoBox<K, A> {
     // BYTE-SPECIFIC METHODS
     // --------------------------------------------------------------------------------------------
 
-    pub fn seal_bytes_with_associated_data<R: CryptoRng + RngCore>(
+    pub fn seal_bytes_with_associated_data<R: CryptoRng + Rng>(
         rng: &mut R,
         recipient_public_key: &K::PublicKey,
         scheme: IesScheme,
@@ -103,7 +103,7 @@ impl<K: KeyAgreementScheme, A: AeadScheme> CryptoBox<K, A> {
     // ELEMENT-SPECIFIC METHODS
     // --------------------------------------------------------------------------------------------
 
-    pub fn seal_elements_with_associated_data<R: CryptoRng + RngCore>(
+    pub fn seal_elements_with_associated_data<R: CryptoRng + Rng>(
         rng: &mut R,
         recipient_public_key: &K::PublicKey,
         scheme: IesScheme,

--- a/miden-crypto/src/ies/keys.rs
+++ b/miden-crypto/src/ies/keys.rs
@@ -1,7 +1,7 @@
 use alloc::vec::Vec;
 use core::fmt;
 
-use rand::{CryptoRng, RngCore};
+use rand::{CryptoRng, Rng};
 
 use super::{IesError, IesScheme, crypto_box::CryptoBox, message::SealedMessage};
 use crate::{
@@ -38,7 +38,7 @@ macro_rules! impl_seal_bytes_with_associated_data {
         ///
         /// The returned message can be unsealed with the [UnsealingKey] associated with this
         /// sealing key.
-        pub fn seal_bytes_with_associated_data<R: CryptoRng + RngCore>(
+        pub fn seal_bytes_with_associated_data<R: CryptoRng + Rng>(
             &self,
             rng: &mut R,
             plaintext: &[u8],
@@ -75,7 +75,7 @@ macro_rules! impl_seal_elements_with_associated_data {
         ///
         /// The returned message can be unsealed with the [UnsealingKey] associated with this
         /// sealing key.
-        pub fn seal_elements_with_associated_data<R: CryptoRng + RngCore>(
+        pub fn seal_elements_with_associated_data<R: CryptoRng + Rng>(
             &self,
             rng: &mut R,
             plaintext: &[Felt],
@@ -221,7 +221,7 @@ impl SealingKey {
     ///
     /// The returned message can be unsealed with the [UnsealingKey] associated with this sealing
     /// key.
-    pub fn seal_bytes<R: CryptoRng + RngCore>(
+    pub fn seal_bytes<R: CryptoRng + Rng>(
         &self,
         rng: &mut R,
         plaintext: &[u8],
@@ -240,7 +240,7 @@ impl SealingKey {
     ///
     /// The returned message can be unsealed with the [UnsealingKey] associated with this sealing
     /// key.
-    pub fn seal_elements<R: CryptoRng + RngCore>(
+    pub fn seal_elements<R: CryptoRng + Rng>(
         &self,
         rng: &mut R,
         plaintext: &[Felt],

--- a/miden-crypto/src/ies/tests.rs
+++ b/miden-crypto/src/ies/tests.rs
@@ -3,7 +3,7 @@
 use alloc::vec::Vec;
 
 use proptest::prelude::*;
-use rand::{RngCore, SeedableRng};
+use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha20Rng;
 
 use crate::{

--- a/miden-crypto/src/main.rs
+++ b/miden-crypto/src/main.rs
@@ -9,7 +9,7 @@ use miden_crypto::{
     merkle::smt::{LargeSmt, LargeSmtError, MemoryStorage, SmtStorage},
     rand::test_utils::rand_value,
 };
-use rand::{Rng, prelude::IteratorRandom, rng};
+use rand::{RngExt, prelude::IteratorRandom, rng};
 
 type Storage = Box<dyn SmtStorage>;
 

--- a/miden-crypto/src/merkle/smt/full/concurrent/tests.rs
+++ b/miden-crypto/src/merkle/smt/full/concurrent/tests.rs
@@ -7,7 +7,7 @@ use alloc::{
 
 use assert_matches::assert_matches;
 use proptest::prelude::*;
-use rand::{Rng, SeedableRng, prelude::IteratorRandom};
+use rand::{RngExt, SeedableRng, prelude::IteratorRandom};
 use rand_chacha::ChaCha20Rng;
 
 use super::{
@@ -125,7 +125,7 @@ fn generate_updates(entries: Vec<(Word, Word)>, updates: usize) -> Vec<(Word, Wo
     );
     let mut sorted_entries: Vec<(Word, Word)> = entries
         .into_iter()
-        .choose_multiple(&mut rng, updates)
+        .sample(&mut rng, updates)
         .into_iter()
         .map(|(key, _)| {
             let value = if rng.random_bool(REMOVAL_PROBABILITY) {

--- a/miden-crypto/src/merkle/smt/large/tests.rs
+++ b/miden-crypto/src/merkle/smt/large/tests.rs
@@ -1,6 +1,6 @@
 use alloc::{collections::BTreeSet, vec::Vec};
 
-use rand::{Rng, prelude::IteratorRandom, rng};
+use rand::{RngExt, prelude::IteratorRandom, rng};
 
 use super::MemoryStorage;
 use crate::{
@@ -34,7 +34,7 @@ fn generate_updates(entries: Vec<(Word, Word)>, updates: usize) -> Vec<(Word, Wo
     );
     let mut sorted_entries: Vec<(Word, Word)> = entries
         .into_iter()
-        .choose_multiple(&mut rng, updates)
+        .sample(&mut rng, updates)
         .into_iter()
         .map(|(key, _)| {
             let value = if rng.random_bool(REMOVAL_PROBABILITY) {

--- a/miden-crypto/src/merkle/smt/partial/tests.rs
+++ b/miden-crypto/src/merkle/smt/partial/tests.rs
@@ -2,7 +2,7 @@ use alloc::collections::{BTreeMap, BTreeSet};
 
 use assert_matches::assert_matches;
 use proptest::prelude::*;
-use rand::{Rng, SeedableRng};
+use rand::{Rng, RngExt, SeedableRng};
 use rand_chacha::ChaCha20Rng;
 
 use super::{PartialSmt, SMT_DEPTH};

--- a/miden-crypto/src/rand/coin.rs
+++ b/miden-crypto/src/rand/coin.rs
@@ -1,8 +1,9 @@
 use alloc::string::ToString;
+use core::convert::Infallible;
 
-use rand_core::impls;
+use rand_core::{TryRng, utils};
 
-use super::{Felt, FeltRng, RngCore};
+use super::{Felt, FeltRng, Rng};
 use crate::{
     Word, ZERO,
     field::ExtensionField,
@@ -68,7 +69,7 @@ impl RandomCoin {
 
     /// Fills `dest` with random data.
     pub fn fill_bytes(&mut self, dest: &mut [u8]) {
-        <Self as RngCore>::fill_bytes(self, dest)
+        Rng::fill_bytes(self, dest)
     }
 
     /// Draws a random base field element from the random coin.
@@ -142,20 +143,22 @@ impl FeltRng for RandomCoin {
     }
 }
 
-// RNGCORE IMPLEMENTATION
+// TRY RNG IMPLEMENTATION
 // ------------------------------------------------------------------------------------------------
 
-impl RngCore for RandomCoin {
-    fn next_u32(&mut self) -> u32 {
-        self.draw_basefield().as_canonical_u64() as u32
+impl TryRng for RandomCoin {
+    type Error = Infallible;
+
+    fn try_next_u32(&mut self) -> Result<u32, Infallible> {
+        Ok(self.draw_basefield().as_canonical_u64() as u32)
     }
 
-    fn next_u64(&mut self) -> u64 {
-        impls::next_u64_via_u32(self)
+    fn try_next_u64(&mut self) -> Result<u64, Infallible> {
+        utils::next_u64_via_u32(self)
     }
 
-    fn fill_bytes(&mut self, dest: &mut [u8]) {
-        impls::fill_bytes_via_next(self, dest)
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Infallible> {
+        utils::fill_bytes_via_next_word(dest, || self.try_next_u64())
     }
 }
 

--- a/miden-crypto/src/rand/mod.rs
+++ b/miden-crypto/src/rand/mod.rs
@@ -1,6 +1,6 @@
 //! Pseudo-random element generation.
 
-use rand::RngCore;
+use rand::Rng;
 
 use crate::{Felt, Word};
 
@@ -127,7 +127,7 @@ impl<const N: usize> Randomizable for [u8; N] {
 /// Pseudo-random element generator.
 ///
 /// An instance can be used to draw, uniformly at random, base field elements as well as [Word]s.
-pub trait FeltRng: RngCore {
+pub trait FeltRng: Rng {
     /// Draw, uniformly at random, a base field element.
     fn draw_element(&mut self) -> Felt;
 
@@ -143,7 +143,7 @@ pub trait FeltRng: RngCore {
 /// This function is only available with the `std` feature.
 #[cfg(feature = "std")]
 pub fn random_felt() -> Felt {
-    use rand::Rng;
+    use rand::RngExt;
     let mut rng = rand::rng();
     // Goldilocks field order is 2^64 - 2^32 + 1
     // Generate a random u64 and reduce modulo the field order

--- a/miden-crypto/src/rand/test_utils.rs
+++ b/miden-crypto/src/rand/test_utils.rs
@@ -32,7 +32,7 @@ use crate::rand::Randomizable;
 /// ```
 /// # use miden_crypto::rand::test_utils::seeded_rng;
 /// let mut rng = seeded_rng([0u8; 32]);
-/// // Use rng with any function that accepts impl RngCore
+/// // Use rng with any function that accepts impl Rng
 /// ```
 pub fn seeded_rng(seed: [u8; 32]) -> ChaCha20Rng {
     ChaCha20Rng::from_seed(seed)
@@ -41,7 +41,7 @@ pub fn seeded_rng(seed: [u8; 32]) -> ChaCha20Rng {
 /// Generates a random value of type T from an RNG.
 fn rng_value<T: Randomizable>(rng: &mut impl Rng) -> T {
     let mut bytes = vec![0u8; T::VALUE_SIZE];
-    rng.fill(&mut bytes[..]);
+    rng.fill_bytes(&mut bytes[..]);
     T::from_random_bytes(&bytes).expect("failed to generate random value")
 }
 


### PR DESCRIPTION
## Describe your changes

- upgrade `miden-crypto`'s direct `rand`, `rand_chacha`, and `rand_core` dependencies from `0.9` to `0.10`
- remove the unused `winter-rand-utils` dependency and keep using the local random-data helpers https://github.com/0xMiden/crypto/issues/893#issuecomment-4096935055
- migrate internal RNG glue code and custom RNG implementations to the `rand 0.10` / `rand_core 0.10` APIs
- refresh `Cargo.lock` and update the `cargo deny` comment to reflect the remaining duplicate-version sources more accurately

## Notes

- `rand 0.9` now remains only through `proptest`
- `rand_core/getrandom 0.6/0.2` still remain through external crypto dependencies such as `k256`, `chacha20poly1305`, and `rand_hc`, so the current `skip-tree` entries stay for now
- this addresses the repo-local part of #893, but does not remove every duplicate-version exception yet

## Testing

- `cargo check -p miden-crypto --all-targets`
- `cargo test -p miden-crypto --all-targets --no-run`