### PR TITLE
fix(merkle): return error from MerklePath::new instead of panicking

### DIFF
--- a/miden-crypto/src/merkle/error.rs
+++ b/miden-crypto/src/merkle/error.rs
@@ -34,6 +34,8 @@ pub enum MerkleError {
     NodeIndexNotFoundInStore(Word, NodeIndex),
     #[error("number of provided merkle tree leaves {0} is not a power of two")]
     NumLeavesNotPowerOfTwo(usize),
+    #[error("merkle path length {0} exceeds the maximum of 255")]
+    PathTooLong(usize),
     #[error("root {0:?} is not in the store")]
     RootNotInStore(Word),
     #[error("partial smt does not track the merkle path for key {0}")]

--- a/miden-crypto/src/merkle/merkle_tree.rs
+++ b/miden-crypto/src/merkle/merkle_tree.rs
@@ -106,9 +106,9 @@ impl MerkleTree {
             return Err(MerkleError::DepthTooBig(index.depth() as u64));
         }
 
-        Ok(MerklePath::from(Vec::from_iter(
+        Ok(MerklePath::new(Vec::from_iter(
             index.proof_indices().map(|index| self.get_node(index).unwrap()),
-        )))
+        ))?)
     }
 
     // ITERATORS

--- a/miden-crypto/src/merkle/mmr/full.rs
+++ b/miden-crypto/src/merkle/mmr/full.rs
@@ -134,7 +134,7 @@ impl Mmr {
         }
         let (leaf, path) = self.collect_merkle_path_and_value(pos, forest)?;
 
-        let path = MmrPath::new(forest, pos, MerklePath::new(path));
+        let path = MmrPath::new(forest, pos, MerklePath::new(path).map_err(MmrError::InvalidMerklePath)?);
 
         Ok(MmrProof::new(path, leaf))
     }

--- a/miden-crypto/src/merkle/mmr/partial.rs
+++ b/miden-crypto/src/merkle/mmr/partial.rs
@@ -258,7 +258,7 @@ impl PartialMmr {
             idx = idx.parent();
         }
 
-        let path = MmrPath::new(self.forest, pos, MerklePath::new(nodes));
+        let path = MmrPath::new(self.forest, pos, MerklePath::new(nodes).map_err(MmrError::InvalidMerklePath)?);
         Ok(Some(MmrProof::new(path, leaf)))
     }
 

--- a/miden-crypto/src/merkle/mmr/proof.rs
+++ b/miden-crypto/src/merkle/mmr/proof.rs
@@ -88,7 +88,7 @@ impl MmrPath {
         // Trim the merkle path to the target length
         let trimmed_nodes: Vec<_> =
             self.merkle_path.nodes().iter().take(target_path_len).copied().collect();
-        let trimmed_path = MerklePath::new(trimmed_nodes);
+        let trimmed_path = MerklePath::new(trimmed_nodes).map_err(MmrError::InvalidMerklePath)?;
 
         Ok(MmrPath::new(target_forest, self.position, trimmed_path))
     }

--- a/miden-crypto/src/merkle/mmr/tests.rs
+++ b/miden-crypto/src/merkle/mmr/tests.rs
@@ -670,7 +670,7 @@ fn test_mmr_open() {
     assert!(mmr.open(7).is_err(), "Element 7 is not in the tree, result should be None");
 
     // node at pos 6 is the root
-    let empty: MerklePath = MerklePath::new(vec![]);
+    let empty: MerklePath = MerklePath::new(vec![]).unwrap();
     let opening = mmr
         .open(6)
         .expect("Element 6 is contained in the tree, expected an opening result.");
@@ -680,7 +680,7 @@ fn test_mmr_open() {
     mmr.peaks().verify(LEAVES[6], opening).unwrap();
 
     // nodes 4,5 are depth 1
-    let root_to_path = MerklePath::new(vec![LEAVES[4]]);
+    let root_to_path = MerklePath::new(vec![LEAVES[4]]).unwrap();
     let opening = mmr
         .open(5)
         .expect("Element 5 is contained in the tree, expected an opening result.");
@@ -689,7 +689,7 @@ fn test_mmr_open() {
     assert_eq!(opening.path().position(), 5);
     mmr.peaks().verify(LEAVES[5], opening).unwrap();
 
-    let root_to_path = MerklePath::new(vec![LEAVES[5]]);
+    let root_to_path = MerklePath::new(vec![LEAVES[5]]).unwrap();
     let opening = mmr
         .open(4)
         .expect("Element 4 is contained in the tree, expected an opening result.");
@@ -699,7 +699,7 @@ fn test_mmr_open() {
     mmr.peaks().verify(LEAVES[4], opening).unwrap();
 
     // nodes 0,1,2,3 are detph 2
-    let root_to_path = MerklePath::new(vec![LEAVES[2], h01]);
+    let root_to_path = MerklePath::new(vec![LEAVES[2], h01]).unwrap();
     let opening = mmr
         .open(3)
         .expect("Element 3 is contained in the tree, expected an opening result.");
@@ -708,7 +708,7 @@ fn test_mmr_open() {
     assert_eq!(opening.path().position(), 3);
     mmr.peaks().verify(LEAVES[3], opening).unwrap();
 
-    let root_to_path = MerklePath::new(vec![LEAVES[3], h01]);
+    let root_to_path = MerklePath::new(vec![LEAVES[3], h01]).unwrap();
     let opening = mmr
         .open(2)
         .expect("Element 2 is contained in the tree, expected an opening result.");
@@ -717,7 +717,7 @@ fn test_mmr_open() {
     assert_eq!(opening.path().position(), 2);
     mmr.peaks().verify(LEAVES[2], opening).unwrap();
 
-    let root_to_path = MerklePath::new(vec![LEAVES[0], h23]);
+    let root_to_path = MerklePath::new(vec![LEAVES[0], h23]).unwrap();
     let opening = mmr
         .open(1)
         .expect("Element 1 is contained in the tree, expected an opening result.");
@@ -726,7 +726,7 @@ fn test_mmr_open() {
     assert_eq!(opening.path().position(), 1);
     mmr.peaks().verify(LEAVES[1], opening).unwrap();
 
-    let root_to_path = MerklePath::new(vec![LEAVES[1], h23]);
+    let root_to_path = MerklePath::new(vec![LEAVES[1], h23]).unwrap();
     let opening = mmr
         .open(0)
         .expect("Element 0 is contained in the tree, expected an opening result.");
@@ -995,7 +995,7 @@ fn test_mmr_open_seven() {
 
     let position = 6;
     let proof = mmr.open(position).unwrap();
-    let merkle_path: MerklePath = [].as_ref().into();
+    let merkle_path: MerklePath = MerklePath::new(vec![]).unwrap();
     assert_eq!(
         proof,
         MmrProof::new(MmrPath::new(forest, position, merkle_path), LEAVES[position])
@@ -1378,7 +1378,7 @@ fn test_mmr_add_invalid_odd_leaf() {
     let acc = mmr.peaks();
     let mut partial: PartialMmr = acc.clone().into();
 
-    let empty = MerklePath::new(Vec::new());
+    let empty = MerklePath::new(Vec::new()).unwrap();
 
     // None of the other leaves should work
     for node in LEAVES.iter().cloned().rev().skip(1) {
@@ -1397,7 +1397,7 @@ fn test_partial_track_rejects_path_depth_too_large() {
     full.add(leaf).unwrap();
     let mut partial: PartialMmr = full.peaks().into();
 
-    let deep_path = MerklePath::new(vec![Word::empty(); u8::MAX as usize]);
+    let deep_path = MerklePath::new(vec![Word::empty(); u8::MAX as usize]).unwrap();
     let result = partial.track(0, leaf, &deep_path);
     assert_matches!(result, Err(MmrError::UnknownPeak(depth)) if depth == u8::MAX);
 }

--- a/miden-crypto/src/merkle/partial_mt/mod.rs
+++ b/miden-crypto/src/merkle/partial_mt/mod.rs
@@ -253,7 +253,7 @@ impl PartialMerkleTree {
                 self.nodes.get(&sibling_index).cloned().expect("Sibling node not in the map");
             path.push(sibling);
         }
-        Ok(MerklePath::new(path))
+        MerklePath::new(path)
     }
 
     // ITERATORS

--- a/miden-crypto/src/merkle/path.rs
+++ b/miden-crypto/src/merkle/path.rs
@@ -27,9 +27,14 @@ impl MerklePath {
     /// Creates a new Merkle path from a list of nodes.
     ///
     /// The list must be in order of deepest to shallowest.
-    pub fn new(nodes: Vec<Word>) -> Self {
-        assert!(nodes.len() <= u8::MAX.into(), "MerklePath may have at most 256 items");
-        Self { nodes }
+    ///
+    /// # Errors
+    /// Returns an error if `nodes` contains more than [`u8::MAX`] elements.
+    pub fn new(nodes: Vec<Word>) -> Result<Self, MerkleError> {
+        if nodes.len() > u8::MAX as usize {
+            return Err(MerkleError::PathTooLong(nodes.len()));
+        }
+        Ok(Self { nodes })
     }
 
     // PROVIDERS
@@ -123,14 +128,18 @@ impl From<MerklePath> for Vec<Word> {
     }
 }
 
-impl From<Vec<Word>> for MerklePath {
-    fn from(path: Vec<Word>) -> Self {
+impl TryFrom<Vec<Word>> for MerklePath {
+    type Error = MerkleError;
+
+    fn try_from(path: Vec<Word>) -> Result<Self, Self::Error> {
         Self::new(path)
     }
 }
 
-impl From<&[Word]> for MerklePath {
-    fn from(path: &[Word]) -> Self {
+impl TryFrom<&[Word]> for MerklePath {
+    type Error = MerkleError;
+
+    fn try_from(path: &[Word]) -> Result<Self, Self::Error> {
         Self::new(path.to_vec())
     }
 }
@@ -156,7 +165,7 @@ impl DerefMut for MerklePath {
 
 impl FromIterator<Word> for MerklePath {
     fn from_iter<T: IntoIterator<Item = Word>>(iter: T) -> Self {
-        Self::new(iter.into_iter().collect())
+        Self::new(iter.into_iter().collect()).expect("MerklePath may have at most 255 items")
     }
 }
 
@@ -294,7 +303,7 @@ mod tests {
     #[test]
     fn test_inner_nodes() {
         let nodes = vec![int_to_node(1), int_to_node(2), int_to_node(3), int_to_node(4)];
-        let merkle_path = MerklePath::new(nodes);
+        let merkle_path = MerklePath::new(nodes).unwrap();
 
         let index = 6;
         let node = int_to_node(5);

--- a/miden-crypto/src/merkle/sparse_path.rs
+++ b/miden-crypto/src/merkle/sparse_path.rs
@@ -641,7 +641,7 @@ mod tests {
 
         fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
             prop::collection::vec(any::<Word>(), 0..=SMT_MAX_DEPTH as usize)
-                .prop_map(MerklePath::new)
+                .prop_map(|v| MerklePath::new(v).expect("depth <= SMT_MAX_DEPTH"))
                 .boxed()
         }
     }
@@ -853,7 +853,7 @@ mod tests {
         // This test documents API differences between MerklePath and SparseMerklePath
 
         // 1. MerklePath has Deref/DerefMut to Vec<Word> - SparseMerklePath does not
-        let merkle = MerklePath::new(vec![Word::default(); 3]);
+        let merkle = MerklePath::new(vec![Word::default(); 3]).unwrap();
         let _vec_ref: &Vec<Word> = &merkle; // This works due to Deref
         let _vec_mut: &mut Vec<Word> = &mut merkle.clone(); // This works due to DerefMut
 

--- a/miden-crypto/src/merkle/store/mod.rs
+++ b/miden-crypto/src/merkle/store/mod.rs
@@ -182,7 +182,7 @@ impl MerkleStore {
         // the path is computed from root to leaf, so it must be reversed
         path.reverse();
 
-        Ok(MerkleProof::new(hash, MerklePath::new(path)))
+        Ok(MerkleProof::new(hash, MerklePath::new(path)?))
     }
 
     /// Returns `true` if a valid path exists from `root` to the specified `index`, `false`

--- a/miden-crypto/src/merkle/store/tests.rs
+++ b/miden-crypto/src/merkle/store/tests.rs
@@ -584,7 +584,7 @@ fn store_path_opens_from_leaf() {
     let store = MerkleStore::from(&mtree);
     let path = store.get_path(root, NodeIndex::make(3, 1)).unwrap().path;
 
-    let expected = MerklePath::new([a, j, n].to_vec());
+    let expected = MerklePath::new([a, j, n].to_vec()).unwrap();
     assert_eq!(path, expected);
 }
 


### PR DESCRIPTION
## Summary

Converts the \ssert!\ in \MerklePath::new()\ into a proper \Result\ return, so callers can handle oversized paths without a panic.

## Changes

- Add \MerkleError::PathTooLong(usize)\ variant
- Change \MerklePath::new()\ signature from \-> Self\ to \-> Result<Self, MerkleError>\
- Convert \From<Vec<Word>>\ and \From<&[Word]>\ impls to \TryFrom\ equivalents
- Update all call sites: internal callers propagate the error via \?\ or \map_err\, tests use \.unwrap()\

## Verification

- \cargo check -p miden-crypto\ passes

Closes #233