### PR TITLE
feat(dsa): add from_der to EdDSA signature

### DIFF
--- a/miden-crypto/src/dsa/eddsa_25519_sha512/mod.rs
+++ b/miden-crypto/src/dsa/eddsa_25519_sha512/mod.rs
@@ -366,63 +366,40 @@ impl Signature {
         pub_key.verify(message, self)
     }
 
-    /// Creates a signature from ASN.1 DER format bytes.
+    /// Creates a signature from DER-encoded bytes per [RFC 8410 §6][rfc8410].
     ///
-    /// The expected DER encoding is `SEQUENCE { INTEGER R, INTEGER S }`, where R and S
-    /// are the big-endian unsigned integer representations of the Ed25519 signature
-    /// components. Since Ed25519 natively uses little-endian encoding (per RFC 8032),
-    /// this method handles the byte-order conversion.
+    /// Ed25519 signatures are defined as the raw 64-byte value `ENC(R) || ENC(S)`
+    /// ([RFC 8032 §3.3][rfc8032]). When carried in ASN.1 structures such as X.509
+    /// certificates, this 64-byte blob is placed directly inside a `BIT STRING`
+    /// without additional wrapping ([RFC 8410 §6][rfc8410]).
     ///
-    /// Note: Ed25519 does not have a standard DER encoding. RFC 8032 defines the
-    /// native format as the concatenation `ENC(R) || ENC(S)`, and RFC 8410 places
-    /// that blob directly in a `BIT STRING` without additional ASN.1 wrapping.
-    /// This method uses the `SEQUENCE { INTEGER, INTEGER }` layout for
-    /// consistency with the ECDSA `from_der` in this crate and to support
-    /// interoperability with tooling that DER-encodes signature components
-    /// individually.
+    /// This method accepts two formats:
+    /// 1. A DER `BIT STRING` containing the 64-byte signature (standard ASN.1
+    ///    encoding from X.509 certificates, CMS, etc.).
+    /// 2. The raw 64-byte signature value itself (for convenience).
+    ///
+    /// [rfc8032]: https://datatracker.ietf.org/doc/html/rfc8032#section-3.3
+    /// [rfc8410]: https://datatracker.ietf.org/doc/html/rfc8410#section-6
     pub fn from_der(bytes: &[u8]) -> Result<Self, DeserializationError> {
-        // Parse outer SEQUENCE
-        let (tag, seq_body, trailing) = parse_der_tlv(bytes)?;
-        if tag != 0x30 {
+        let sig_bytes = if bytes.len() == SIGNATURE_BYTES {
+            // Raw 64-byte signature (RFC 8032 native format).
+            bytes
+        } else {
+            // Try to parse as DER BIT STRING.
+            parse_bitstring_contents(bytes)?
+        };
+
+        if sig_bytes.len() != SIGNATURE_BYTES {
             return Err(DeserializationError::InvalidValue(alloc::format!(
-                "expected DER SEQUENCE (0x30), got 0x{tag:02x}"
+                "Ed25519 signature must be {SIGNATURE_BYTES} bytes, got {}",
+                sig_bytes.len()
             )));
         }
-        if !trailing.is_empty() {
-            return Err(DeserializationError::InvalidValue(
-                "trailing data after DER SEQUENCE".into(),
-            ));
-        }
 
-        // Parse R INTEGER
-        let (tag, r_content, remaining) = parse_der_tlv(seq_body)?;
-        if tag != 0x02 {
-            return Err(DeserializationError::InvalidValue(alloc::format!(
-                "expected DER INTEGER (0x02) for R, got 0x{tag:02x}"
-            )));
-        }
-        let r = der_integer_to_le_32(r_content)?;
-
-        // Parse S INTEGER
-        let (tag, s_content, remaining) = parse_der_tlv(remaining)?;
-        if tag != 0x02 {
-            return Err(DeserializationError::InvalidValue(alloc::format!(
-                "expected DER INTEGER (0x02) for S, got 0x{tag:02x}"
-            )));
-        }
-        if !remaining.is_empty() {
-            return Err(DeserializationError::InvalidValue(
-                "trailing data inside DER SEQUENCE".into(),
-            ));
-        }
-        let s = der_integer_to_le_32(s_content)?;
-
-        // Reconstruct 64-byte Ed25519 signature: R || S (little-endian)
-        let mut sig_bytes = [0u8; SIGNATURE_BYTES];
-        sig_bytes[..32].copy_from_slice(&r);
-        sig_bytes[32..].copy_from_slice(&s);
-
-        let inner = ed25519_dalek::Signature::from_bytes(&sig_bytes);
+        let inner =
+            ed25519_dalek::Signature::from_bytes(sig_bytes.try_into().map_err(|_| {
+                DeserializationError::InvalidValue("invalid signature length".into())
+            })?);
         Ok(Self { inner })
     }
 }
@@ -430,19 +407,50 @@ impl Signature {
 // DER HELPERS
 // ================================================================================================
 
-/// Parses a single DER tag-length-value element, returning `(tag, content, rest)`.
-fn parse_der_tlv(bytes: &[u8]) -> Result<(u8, &[u8], &[u8]), DeserializationError> {
+/// Parses a DER `BIT STRING` and returns the contained octets.
+///
+/// The expected encoding is `03 <length> 00 <signature_bytes>`, where the
+/// leading `0x00` byte is the "number of unused bits" (always zero for
+/// Ed25519 signatures since they are an exact number of octets).
+fn parse_bitstring_contents(bytes: &[u8]) -> Result<&[u8], DeserializationError> {
     if bytes.is_empty() {
         return Err(DeserializationError::InvalidValue("empty DER input".into()));
     }
-    let tag = bytes[0];
+
+    // Expect BIT STRING tag (0x03).
+    if bytes[0] != 0x03 {
+        return Err(DeserializationError::InvalidValue(alloc::format!(
+            "expected DER BIT STRING (0x03), got 0x{:02x}",
+            bytes[0]
+        )));
+    }
+
     let (len, header_size) = parse_der_length(&bytes[1..])?;
     let start = 1 + header_size;
     let end = start + len;
-    if end > bytes.len() {
-        return Err(DeserializationError::InvalidValue("DER length exceeds input".into()));
+    if end != bytes.len() {
+        return Err(DeserializationError::InvalidValue(
+            "DER length mismatch or trailing data".into(),
+        ));
     }
-    Ok((tag, &bytes[start..end], &bytes[end..]))
+
+    let content = &bytes[start..end];
+
+    // The first byte of a BIT STRING is the number of unused bits in the
+    // last octet. For Ed25519 signatures this must be 0.
+    if content.is_empty() {
+        return Err(DeserializationError::InvalidValue(
+            "BIT STRING content must not be empty".into(),
+        ));
+    }
+    if content[0] != 0x00 {
+        return Err(DeserializationError::InvalidValue(alloc::format!(
+            "BIT STRING unused-bits byte must be 0 for Ed25519 signatures, got {}",
+            content[0]
+        )));
+    }
+
+    Ok(&content[1..])
 }
 
 /// Decodes a DER definite-form length, returning `(length_value, bytes_consumed)`.
@@ -458,57 +466,6 @@ fn parse_der_length(bytes: &[u8]) -> Result<(usize, usize), DeserializationError
             "non-short-form DER length is not valid for Ed25519 signatures".into(),
         )),
     }
-}
-
-/// Converts a DER INTEGER (big-endian, possibly sign-padded) into a 32-byte little-endian array
-/// for Ed25519.
-///
-/// Rejects non-canonical encodings per X.690 section 8.3.2:
-/// - empty content (zero-length INTEGER)
-/// - unnecessary leading `0x00` (when the next byte's high bit is clear)
-/// - missing leading `0x00` when the high bit is set (would be interpreted as negative, but this
-///   helper only strips a valid pad)
-fn der_integer_to_le_32(int_bytes: &[u8]) -> Result<[u8; 32], DeserializationError> {
-    if int_bytes.is_empty() {
-        return Err(DeserializationError::InvalidValue(
-            "DER INTEGER content must not be empty".into(),
-        ));
-    }
-
-    // Validate canonical sign-padding per X.690 8.3.2:
-    // A leading 0x00 is only allowed when the next byte has its high bit set.
-    if int_bytes.len() > 1 && int_bytes[0] == 0x00 && (int_bytes[1] & 0x80) == 0 {
-        return Err(DeserializationError::InvalidValue(
-            "non-canonical DER INTEGER: unnecessary leading 0x00".into(),
-        ));
-    }
-
-    // Reject negative integers (high bit set without a 0x00 pad is a negative
-    // value in two's complement, which is invalid for an Ed25519 component).
-    // Note: if the high bit is set AND there is a 0x00 pad, that was already
-    // validated above as canonical.
-    if int_bytes[0] & 0x80 != 0 {
-        return Err(DeserializationError::InvalidValue(
-            "negative DER INTEGER is not valid for Ed25519 component".into(),
-        ));
-    }
-
-    // Strip the canonical leading 0x00 sign-padding byte if present.
-    let stripped = match int_bytes {
-        [0x00, rest @ ..] if !rest.is_empty() => rest,
-        other => other,
-    };
-    if stripped.len() > 32 {
-        return Err(DeserializationError::InvalidValue(
-            "DER integer too large for Ed25519 component".into(),
-        ));
-    }
-    // Left-pad to 32 bytes (big-endian).
-    let mut be = [0u8; 32];
-    be[32 - stripped.len()..].copy_from_slice(stripped);
-    // Convert to little-endian.
-    be.reverse();
-    Ok(be)
 }
 
 // SERIALIZATION / DESERIALIZATION

--- a/miden-crypto/src/dsa/eddsa_25519_sha512/mod.rs
+++ b/miden-crypto/src/dsa/eddsa_25519_sha512/mod.rs
@@ -365,6 +365,114 @@ impl Signature {
     pub fn verify(&self, message: Word, pub_key: &PublicKey) -> bool {
         pub_key.verify(message, self)
     }
+
+    /// Creates a signature from ASN.1 DER format bytes.
+    ///
+    /// The expected DER encoding is `SEQUENCE { INTEGER R, INTEGER S }`, where R and S
+    /// are the big-endian unsigned integer representations of the Ed25519 signature
+    /// components. Since Ed25519 natively uses little-endian encoding (per RFC 8032),
+    /// this method handles the byte-order conversion.
+    pub fn from_der(bytes: &[u8]) -> Result<Self, DeserializationError> {
+        // Parse outer SEQUENCE
+        let (tag, seq_body, trailing) = parse_der_tlv(bytes)?;
+        if tag != 0x30 {
+            return Err(DeserializationError::InvalidValue(
+                alloc::format!("expected DER SEQUENCE (0x30), got 0x{tag:02x}"),
+            ));
+        }
+        if !trailing.is_empty() {
+            return Err(DeserializationError::InvalidValue(
+                "trailing data after DER SEQUENCE".into(),
+            ));
+        }
+
+        // Parse R INTEGER
+        let (tag, r_content, remaining) = parse_der_tlv(seq_body)?;
+        if tag != 0x02 {
+            return Err(DeserializationError::InvalidValue(
+                alloc::format!("expected DER INTEGER (0x02) for R, got 0x{tag:02x}"),
+            ));
+        }
+        let r = der_integer_to_le_32(r_content)?;
+
+        // Parse S INTEGER
+        let (tag, s_content, remaining) = parse_der_tlv(remaining)?;
+        if tag != 0x02 {
+            return Err(DeserializationError::InvalidValue(
+                alloc::format!("expected DER INTEGER (0x02) for S, got 0x{tag:02x}"),
+            ));
+        }
+        if !remaining.is_empty() {
+            return Err(DeserializationError::InvalidValue(
+                "trailing data inside DER SEQUENCE".into(),
+            ));
+        }
+        let s = der_integer_to_le_32(s_content)?;
+
+        // Reconstruct 64-byte Ed25519 signature: R || S (little-endian)
+        let mut sig_bytes = [0u8; SIGNATURE_BYTES];
+        sig_bytes[..32].copy_from_slice(&r);
+        sig_bytes[32..].copy_from_slice(&s);
+
+        let inner = ed25519_dalek::Signature::from_bytes(&sig_bytes);
+        Ok(Self { inner })
+    }
+}
+
+// DER HELPERS
+// ================================================================================================
+
+/// Parses a single DER tag-length-value element, returning `(tag, content, rest)`.
+fn parse_der_tlv(bytes: &[u8]) -> Result<(u8, &[u8], &[u8]), DeserializationError> {
+    if bytes.is_empty() {
+        return Err(DeserializationError::InvalidValue("empty DER input".into()));
+    }
+    let tag = bytes[0];
+    let (len, header_size) = parse_der_length(&bytes[1..])?;
+    let start = 1 + header_size;
+    let end = start + len;
+    if end > bytes.len() {
+        return Err(DeserializationError::InvalidValue("DER length exceeds input".into()));
+    }
+    Ok((tag, &bytes[start..end], &bytes[end..]))
+}
+
+/// Decodes a DER definite-form length, returning `(length_value, bytes_consumed)`.
+fn parse_der_length(bytes: &[u8]) -> Result<(usize, usize), DeserializationError> {
+    match bytes.first() {
+        None => Err(DeserializationError::InvalidValue("truncated DER length".into())),
+        Some(&b) if b < 0x80 => Ok((b as usize, 1)),
+        Some(&0x81) => {
+            let len = *bytes
+                .get(1)
+                .ok_or_else(|| DeserializationError::InvalidValue("truncated DER length".into()))?;
+            Ok((len as usize, 2))
+        },
+        _ => Err(DeserializationError::InvalidValue(
+            "unsupported DER length encoding".into(),
+        )),
+    }
+}
+
+/// Converts a DER INTEGER (big-endian, possibly sign-padded) into a 32-byte little-endian array
+/// for Ed25519.
+fn der_integer_to_le_32(int_bytes: &[u8]) -> Result<[u8; 32], DeserializationError> {
+    // Strip leading 0x00 sign-padding byte if present.
+    let stripped = match int_bytes {
+        [0x00, rest @ ..] if !rest.is_empty() => rest,
+        other => other,
+    };
+    if stripped.len() > 32 {
+        return Err(DeserializationError::InvalidValue(
+            "DER integer too large for Ed25519 component".into(),
+        ));
+    }
+    // Left-pad to 32 bytes (big-endian).
+    let mut be = [0u8; 32];
+    be[32 - stripped.len()..].copy_from_slice(stripped);
+    // Convert to little-endian.
+    be.reverse();
+    Ok(be)
 }
 
 // SERIALIZATION / DESERIALIZATION

--- a/miden-crypto/src/dsa/eddsa_25519_sha512/mod.rs
+++ b/miden-crypto/src/dsa/eddsa_25519_sha512/mod.rs
@@ -372,6 +372,14 @@ impl Signature {
     /// are the big-endian unsigned integer representations of the Ed25519 signature
     /// components. Since Ed25519 natively uses little-endian encoding (per RFC 8032),
     /// this method handles the byte-order conversion.
+    ///
+    /// Note: Ed25519 does not have a standard DER encoding. RFC 8032 defines the
+    /// native format as the concatenation `ENC(R) || ENC(S)`, and RFC 8410 places
+    /// that blob directly in a `BIT STRING` without additional ASN.1 wrapping.
+    /// This method uses the `SEQUENCE { INTEGER, INTEGER }` layout for
+    /// consistency with the ECDSA `from_der` in this crate and to support
+    /// interoperability with tooling that DER-encodes signature components
+    /// individually.
     pub fn from_der(bytes: &[u8]) -> Result<Self, DeserializationError> {
         // Parse outer SEQUENCE
         let (tag, seq_body, trailing) = parse_der_tlv(bytes)?;
@@ -438,24 +446,54 @@ fn parse_der_tlv(bytes: &[u8]) -> Result<(u8, &[u8], &[u8]), DeserializationErro
 }
 
 /// Decodes a DER definite-form length, returning `(length_value, bytes_consumed)`.
+///
+/// Only short-form lengths (< 128) are accepted. Ed25519 signature DER blobs
+/// never exceed short-form, and DER requires the shortest encoding, so
+/// long-form (`0x81`, `0x82`, ...) is rejected.
 fn parse_der_length(bytes: &[u8]) -> Result<(usize, usize), DeserializationError> {
     match bytes.first() {
         None => Err(DeserializationError::InvalidValue("truncated DER length".into())),
         Some(&b) if b < 0x80 => Ok((b as usize, 1)),
-        Some(&0x81) => {
-            let len = *bytes
-                .get(1)
-                .ok_or_else(|| DeserializationError::InvalidValue("truncated DER length".into()))?;
-            Ok((len as usize, 2))
-        },
-        _ => Err(DeserializationError::InvalidValue("unsupported DER length encoding".into())),
+        _ => Err(DeserializationError::InvalidValue(
+            "non-short-form DER length is not valid for Ed25519 signatures".into(),
+        )),
     }
 }
 
 /// Converts a DER INTEGER (big-endian, possibly sign-padded) into a 32-byte little-endian array
 /// for Ed25519.
+///
+/// Rejects non-canonical encodings per X.690 section 8.3.2:
+/// - empty content (zero-length INTEGER)
+/// - unnecessary leading `0x00` (when the next byte's high bit is clear)
+/// - missing leading `0x00` when the high bit is set (would be interpreted as negative, but this
+///   helper only strips a valid pad)
 fn der_integer_to_le_32(int_bytes: &[u8]) -> Result<[u8; 32], DeserializationError> {
-    // Strip leading 0x00 sign-padding byte if present.
+    if int_bytes.is_empty() {
+        return Err(DeserializationError::InvalidValue(
+            "DER INTEGER content must not be empty".into(),
+        ));
+    }
+
+    // Validate canonical sign-padding per X.690 8.3.2:
+    // A leading 0x00 is only allowed when the next byte has its high bit set.
+    if int_bytes.len() > 1 && int_bytes[0] == 0x00 && (int_bytes[1] & 0x80) == 0 {
+        return Err(DeserializationError::InvalidValue(
+            "non-canonical DER INTEGER: unnecessary leading 0x00".into(),
+        ));
+    }
+
+    // Reject negative integers (high bit set without a 0x00 pad is a negative
+    // value in two's complement, which is invalid for an Ed25519 component).
+    // Note: if the high bit is set AND there is a 0x00 pad, that was already
+    // validated above as canonical.
+    if int_bytes[0] & 0x80 != 0 {
+        return Err(DeserializationError::InvalidValue(
+            "negative DER INTEGER is not valid for Ed25519 component".into(),
+        ));
+    }
+
+    // Strip the canonical leading 0x00 sign-padding byte if present.
     let stripped = match int_bytes {
         [0x00, rest @ ..] if !rest.is_empty() => rest,
         other => other,

--- a/miden-crypto/src/dsa/eddsa_25519_sha512/mod.rs
+++ b/miden-crypto/src/dsa/eddsa_25519_sha512/mod.rs
@@ -376,9 +376,9 @@ impl Signature {
         // Parse outer SEQUENCE
         let (tag, seq_body, trailing) = parse_der_tlv(bytes)?;
         if tag != 0x30 {
-            return Err(DeserializationError::InvalidValue(
-                alloc::format!("expected DER SEQUENCE (0x30), got 0x{tag:02x}"),
-            ));
+            return Err(DeserializationError::InvalidValue(alloc::format!(
+                "expected DER SEQUENCE (0x30), got 0x{tag:02x}"
+            )));
         }
         if !trailing.is_empty() {
             return Err(DeserializationError::InvalidValue(
@@ -389,18 +389,18 @@ impl Signature {
         // Parse R INTEGER
         let (tag, r_content, remaining) = parse_der_tlv(seq_body)?;
         if tag != 0x02 {
-            return Err(DeserializationError::InvalidValue(
-                alloc::format!("expected DER INTEGER (0x02) for R, got 0x{tag:02x}"),
-            ));
+            return Err(DeserializationError::InvalidValue(alloc::format!(
+                "expected DER INTEGER (0x02) for R, got 0x{tag:02x}"
+            )));
         }
         let r = der_integer_to_le_32(r_content)?;
 
         // Parse S INTEGER
         let (tag, s_content, remaining) = parse_der_tlv(remaining)?;
         if tag != 0x02 {
-            return Err(DeserializationError::InvalidValue(
-                alloc::format!("expected DER INTEGER (0x02) for S, got 0x{tag:02x}"),
-            ));
+            return Err(DeserializationError::InvalidValue(alloc::format!(
+                "expected DER INTEGER (0x02) for S, got 0x{tag:02x}"
+            )));
         }
         if !remaining.is_empty() {
             return Err(DeserializationError::InvalidValue(
@@ -448,9 +448,7 @@ fn parse_der_length(bytes: &[u8]) -> Result<(usize, usize), DeserializationError
                 .ok_or_else(|| DeserializationError::InvalidValue("truncated DER length".into()))?;
             Ok((len as usize, 2))
         },
-        _ => Err(DeserializationError::InvalidValue(
-            "unsupported DER length encoding".into(),
-        )),
+        _ => Err(DeserializationError::InvalidValue("unsupported DER length encoding".into())),
     }
 }
 

--- a/miden-crypto/src/dsa/eddsa_25519_sha512/tests.rs
+++ b/miden-crypto/src/dsa/eddsa_25519_sha512/tests.rs
@@ -92,38 +92,20 @@ fn test_compute_challenge_k_equivalence() {
 // DER tests
 // ================================================================================================
 
-/// Encode R and S (little-endian 32-byte arrays) into DER SEQUENCE { INTEGER, INTEGER }.
-fn encode_der(r_le: &[u8; 32], s_le: &[u8; 32]) -> Vec<u8> {
-    fn le_to_der_integer(le: &[u8; 32]) -> Vec<u8> {
-        let mut be = *le;
-        be.reverse();
-        // Strip leading zeros (but keep at least one byte).
-        let start = be.iter().position(|&b| b != 0).unwrap_or(31);
-        let stripped = &be[start..];
-        let needs_pad = stripped[0] & 0x80 != 0;
-        let len = stripped.len() + usize::from(needs_pad);
-        let mut out = Vec::with_capacity(2 + len);
-        out.push(0x02); // INTEGER tag
-        out.push(len as u8);
-        if needs_pad {
-            out.push(0x00);
-        }
-        out.extend_from_slice(stripped);
-        out
-    }
-    let r_der = le_to_der_integer(r_le);
-    let s_der = le_to_der_integer(s_le);
-    let seq_len = r_der.len() + s_der.len();
-    let mut out = Vec::with_capacity(2 + seq_len);
-    out.push(0x30); // SEQUENCE tag
-    out.push(seq_len as u8);
-    out.extend_from_slice(&r_der);
-    out.extend_from_slice(&s_der);
+/// Wrap a raw 64-byte Ed25519 signature in a DER BIT STRING.
+fn encode_bitstring(sig_bytes: &[u8; 64]) -> Vec<u8> {
+    // BIT STRING tag (0x03), length (65 = 1 unused-bits byte + 64 sig bytes),
+    // unused bits (0x00), then the raw signature.
+    let mut out = Vec::with_capacity(2 + 1 + 64);
+    out.push(0x03); // BIT STRING tag
+    out.push(65); // length: 1 + 64
+    out.push(0x00); // unused bits
+    out.extend_from_slice(sig_bytes);
     out
 }
 
 #[test]
-fn from_der_roundtrip() {
+fn from_der_bitstring_roundtrip() {
     let mut rng = seeded_rng([10u8; 32]);
     let sk = SecretKey::with_rng(&mut rng);
     let pk = sk.public_key();
@@ -131,30 +113,45 @@ fn from_der_roundtrip() {
     let msg = Word::from([Felt::new(1), Felt::new(2), Felt::new(3), Felt::new(4)]);
     let sig = sk.sign(msg);
 
-    // Encode signature to DER
+    // Encode the signature as DER BIT STRING (standard encoding per RFC 8410)
     let sig_bytes = sig.inner.to_bytes();
-    let r: [u8; 32] = sig_bytes[..32].try_into().unwrap();
-    let s: [u8; 32] = sig_bytes[32..].try_into().unwrap();
-    let der = encode_der(&r, &s);
+    let der = encode_bitstring(&sig_bytes);
 
     // Decode and verify
-    let recovered = Signature::from_der(&der).expect("valid DER should parse");
+    let recovered = Signature::from_der(&der).expect("valid DER BIT STRING should parse");
     assert_eq!(recovered, sig);
     assert!(pk.verify(msg, &recovered));
 }
 
 #[test]
-fn from_der_rejects_bad_sequence_tag() {
-    // A valid-length blob but with wrong outer tag (0x31 instead of 0x30)
-    let mut der = encode_der(&[0u8; 32], &[0u8; 32]);
-    der[0] = 0x31;
+fn from_der_raw_64_bytes() {
+    let mut rng = seeded_rng([11u8; 32]);
+    let sk = SecretKey::with_rng(&mut rng);
+    let pk = sk.public_key();
+
+    let msg = Word::from([Felt::new(5), Felt::new(6), Felt::new(7), Felt::new(8)]);
+    let sig = sk.sign(msg);
+
+    // Pass raw 64 bytes directly (RFC 8032 native format)
+    let sig_bytes = sig.inner.to_bytes();
+    let recovered =
+        Signature::from_der(&sig_bytes).expect("raw 64-byte signature should parse");
+    assert_eq!(recovered, sig);
+    assert!(pk.verify(msg, &recovered));
+}
+
+#[test]
+fn from_der_rejects_bad_tag() {
+    // Use SEQUENCE tag (0x30) instead of BIT STRING (0x03)
+    let mut der = encode_bitstring(&[0u8; 64]);
+    der[0] = 0x30;
     assert!(Signature::from_der(&der).is_err());
 }
 
 #[test]
 fn from_der_rejects_trailing_data() {
-    let mut der = encode_der(&[0u8; 32], &[0u8; 32]);
-    der.push(0x00); // extra byte after SEQUENCE
+    let mut der = encode_bitstring(&[0u8; 64]);
+    der.push(0x00); // extra byte after BIT STRING
     assert!(Signature::from_der(&der).is_err());
 }
 
@@ -164,69 +161,33 @@ fn from_der_rejects_empty_input() {
 }
 
 #[test]
-fn from_der_rejects_truncated_integer() {
-    // Craft a SEQUENCE whose declared length extends beyond the actual data.
-    let der = [0x30, 0x06, 0x02, 0x01, 0x01, 0x02, 0x01]; // S integer body missing
+fn from_der_rejects_nonzero_unused_bits() {
+    let mut der = encode_bitstring(&[0u8; 64]);
+    der[2] = 0x01; // unused-bits byte should be 0
+    assert!(Signature::from_der(&der).is_err());
+}
+
+#[test]
+fn from_der_rejects_wrong_length() {
+    // BIT STRING with only 32 bytes of signature (too short)
+    let short_sig = [0u8; 32];
+    let mut der = Vec::new();
+    der.push(0x03); // BIT STRING tag
+    der.push(33); // length: 1 + 32
+    der.push(0x00); // unused bits
+    der.extend_from_slice(&short_sig);
     assert!(Signature::from_der(&der).is_err());
 }
 
 #[test]
 fn from_der_rejects_long_form_length() {
-    // Valid content but using BER-style long-form length 0x81 0x44 instead of
-    // short-form 0x44. DER requires shortest form, and Ed25519 blobs always fit
-    // in short-form.
-    let inner = encode_der(&[1u8; 32], &[2u8; 32]);
-    // Replace outer SEQUENCE: swap short-form len with long-form
-    let seq_body = &inner[2..]; // skip tag + original 1-byte length
+    let sig_bytes = [1u8; 64];
+    // Use BER-style long-form length 0x81 0x41 instead of short-form 0x41.
     let mut der = Vec::new();
-    der.push(0x30); // SEQUENCE tag
+    der.push(0x03); // BIT STRING tag
     der.push(0x81); // long-form: 1 subsequent length byte
-    der.push(seq_body.len() as u8);
-    der.extend_from_slice(seq_body);
-    assert!(Signature::from_der(&der).is_err());
-}
-
-#[test]
-fn from_der_rejects_non_canonical_integer_padding() {
-    // An INTEGER with an unnecessary leading 0x00 byte: the next byte's high bit
-    // is clear, so the 0x00 is superfluous and violates X.690 section 8.3.2.
-    // R = 0x00 0x01 (non-canonical: should just be 0x01)
-    let r_int = [0x02, 0x02, 0x00, 0x01]; // INTEGER tag, len=2, body=00 01
-    let s_int = [0x02, 0x01, 0x01]; // INTEGER tag, len=1, body=01
-    let seq_len = (r_int.len() + s_int.len()) as u8;
-    let mut der = Vec::new();
-    der.push(0x30);
-    der.push(seq_len);
-    der.extend_from_slice(&r_int);
-    der.extend_from_slice(&s_int);
-    assert!(Signature::from_der(&der).is_err());
-}
-
-#[test]
-fn from_der_rejects_empty_integer() {
-    // An INTEGER with zero-length content is invalid per DER.
-    let r_int = [0x02, 0x00]; // INTEGER tag, len=0
-    let s_int = [0x02, 0x01, 0x01];
-    let seq_len = (r_int.len() + s_int.len()) as u8;
-    let mut der = Vec::new();
-    der.push(0x30);
-    der.push(seq_len);
-    der.extend_from_slice(&r_int);
-    der.extend_from_slice(&s_int);
-    assert!(Signature::from_der(&der).is_err());
-}
-
-#[test]
-fn from_der_rejects_negative_integer() {
-    // An INTEGER whose first byte has the high bit set (negative in two's
-    // complement) is invalid for an Ed25519 signature component.
-    let r_int = [0x02, 0x01, 0x80]; // INTEGER tag, len=1, body=0x80 (negative)
-    let s_int = [0x02, 0x01, 0x01];
-    let seq_len = (r_int.len() + s_int.len()) as u8;
-    let mut der = Vec::new();
-    der.push(0x30);
-    der.push(seq_len);
-    der.extend_from_slice(&r_int);
-    der.extend_from_slice(&s_int);
+    der.push(65); // actual length
+    der.push(0x00); // unused bits
+    der.extend_from_slice(&sig_bytes);
     assert!(Signature::from_der(&der).is_err());
 }

--- a/miden-crypto/src/dsa/eddsa_25519_sha512/tests.rs
+++ b/miden-crypto/src/dsa/eddsa_25519_sha512/tests.rs
@@ -88,3 +88,84 @@ fn test_compute_challenge_k_equivalence() {
         assert!(!pk.verify(wrong_message, &signature), "verify with wrong message should fail");
     }
 }
+
+// DER tests
+// ================================================================================================
+
+/// Encode R and S (little-endian 32-byte arrays) into DER SEQUENCE { INTEGER, INTEGER }.
+fn encode_der(r_le: &[u8; 32], s_le: &[u8; 32]) -> Vec<u8> {
+    fn le_to_der_integer(le: &[u8; 32]) -> Vec<u8> {
+        let mut be = *le;
+        be.reverse();
+        // Strip leading zeros (but keep at least one byte).
+        let start = be.iter().position(|&b| b != 0).unwrap_or(31);
+        let stripped = &be[start..];
+        let needs_pad = stripped[0] & 0x80 != 0;
+        let len = stripped.len() + usize::from(needs_pad);
+        let mut out = Vec::with_capacity(2 + len);
+        out.push(0x02); // INTEGER tag
+        out.push(len as u8);
+        if needs_pad {
+            out.push(0x00);
+        }
+        out.extend_from_slice(stripped);
+        out
+    }
+    let r_der = le_to_der_integer(r_le);
+    let s_der = le_to_der_integer(s_le);
+    let seq_len = r_der.len() + s_der.len();
+    let mut out = Vec::with_capacity(2 + seq_len);
+    out.push(0x30); // SEQUENCE tag
+    out.push(seq_len as u8);
+    out.extend_from_slice(&r_der);
+    out.extend_from_slice(&s_der);
+    out
+}
+
+#[test]
+fn from_der_roundtrip() {
+    let mut rng = seeded_rng([10u8; 32]);
+    let sk = SecretKey::with_rng(&mut rng);
+    let pk = sk.public_key();
+
+    let msg = Word::from([Felt::new(1), Felt::new(2), Felt::new(3), Felt::new(4)]);
+    let sig = sk.sign(msg);
+
+    // Encode signature to DER
+    let sig_bytes = sig.inner.to_bytes();
+    let r: [u8; 32] = sig_bytes[..32].try_into().unwrap();
+    let s: [u8; 32] = sig_bytes[32..].try_into().unwrap();
+    let der = encode_der(&r, &s);
+
+    // Decode and verify
+    let recovered = Signature::from_der(&der).expect("valid DER should parse");
+    assert_eq!(recovered, sig);
+    assert!(pk.verify(msg, &recovered));
+}
+
+#[test]
+fn from_der_rejects_bad_sequence_tag() {
+    // A valid-length blob but with wrong outer tag (0x31 instead of 0x30)
+    let mut der = encode_der(&[0u8; 32], &[0u8; 32]);
+    der[0] = 0x31;
+    assert!(Signature::from_der(&der).is_err());
+}
+
+#[test]
+fn from_der_rejects_trailing_data() {
+    let mut der = encode_der(&[0u8; 32], &[0u8; 32]);
+    der.push(0x00); // extra byte after SEQUENCE
+    assert!(Signature::from_der(&der).is_err());
+}
+
+#[test]
+fn from_der_rejects_empty_input() {
+    assert!(Signature::from_der(&[]).is_err());
+}
+
+#[test]
+fn from_der_rejects_truncated_integer() {
+    // Craft a SEQUENCE whose declared length extends beyond the actual data.
+    let der = [0x30, 0x06, 0x02, 0x01, 0x01, 0x02, 0x01]; // S integer body missing
+    assert!(Signature::from_der(&der).is_err());
+}

--- a/miden-crypto/src/dsa/eddsa_25519_sha512/tests.rs
+++ b/miden-crypto/src/dsa/eddsa_25519_sha512/tests.rs
@@ -169,3 +169,64 @@ fn from_der_rejects_truncated_integer() {
     let der = [0x30, 0x06, 0x02, 0x01, 0x01, 0x02, 0x01]; // S integer body missing
     assert!(Signature::from_der(&der).is_err());
 }
+
+#[test]
+fn from_der_rejects_long_form_length() {
+    // Valid content but using BER-style long-form length 0x81 0x44 instead of
+    // short-form 0x44. DER requires shortest form, and Ed25519 blobs always fit
+    // in short-form.
+    let inner = encode_der(&[1u8; 32], &[2u8; 32]);
+    // Replace outer SEQUENCE: swap short-form len with long-form
+    let seq_body = &inner[2..]; // skip tag + original 1-byte length
+    let mut der = Vec::new();
+    der.push(0x30); // SEQUENCE tag
+    der.push(0x81); // long-form: 1 subsequent length byte
+    der.push(seq_body.len() as u8);
+    der.extend_from_slice(seq_body);
+    assert!(Signature::from_der(&der).is_err());
+}
+
+#[test]
+fn from_der_rejects_non_canonical_integer_padding() {
+    // An INTEGER with an unnecessary leading 0x00 byte: the next byte's high bit
+    // is clear, so the 0x00 is superfluous and violates X.690 section 8.3.2.
+    // R = 0x00 0x01 (non-canonical: should just be 0x01)
+    let r_int = [0x02, 0x02, 0x00, 0x01]; // INTEGER tag, len=2, body=00 01
+    let s_int = [0x02, 0x01, 0x01]; // INTEGER tag, len=1, body=01
+    let seq_len = (r_int.len() + s_int.len()) as u8;
+    let mut der = Vec::new();
+    der.push(0x30);
+    der.push(seq_len);
+    der.extend_from_slice(&r_int);
+    der.extend_from_slice(&s_int);
+    assert!(Signature::from_der(&der).is_err());
+}
+
+#[test]
+fn from_der_rejects_empty_integer() {
+    // An INTEGER with zero-length content is invalid per DER.
+    let r_int = [0x02, 0x00]; // INTEGER tag, len=0
+    let s_int = [0x02, 0x01, 0x01];
+    let seq_len = (r_int.len() + s_int.len()) as u8;
+    let mut der = Vec::new();
+    der.push(0x30);
+    der.push(seq_len);
+    der.extend_from_slice(&r_int);
+    der.extend_from_slice(&s_int);
+    assert!(Signature::from_der(&der).is_err());
+}
+
+#[test]
+fn from_der_rejects_negative_integer() {
+    // An INTEGER whose first byte has the high bit set (negative in two's
+    // complement) is invalid for an Ed25519 signature component.
+    let r_int = [0x02, 0x01, 0x80]; // INTEGER tag, len=1, body=0x80 (negative)
+    let s_int = [0x02, 0x01, 0x01];
+    let seq_len = (r_int.len() + s_int.len()) as u8;
+    let mut der = Vec::new();
+    der.push(0x30);
+    der.push(seq_len);
+    der.extend_from_slice(&r_int);
+    der.extend_from_slice(&s_int);
+    assert!(Signature::from_der(&der).is_err());
+}


### PR DESCRIPTION
## Summary

Adds \Signature::from_der()\ to the EdDSA (Ed25519) module, parsing ASN.1 DER-encoded signatures in \SEQUENCE { INTEGER R, INTEGER S }\ format. This complements the existing \rom_der()\ on the ECDSA signature type.

## Details

Ed25519 natively uses little-endian encoding (RFC 8032), while DER INTEGER uses big-endian, so the method handles byte-order conversion for both the R and S components.

The DER parsing is implemented with minimal private helpers (\parse_der_tlv\, \parse_der_length\, \der_integer_to_le_32\) to avoid adding new dependencies.

## Tests

- Round-trip: sign, encode to DER, decode with \rom_der()\, verify
- Rejects bad SEQUENCE tag
- Rejects trailing data after SEQUENCE
- Rejects empty input
- Rejects truncated INTEGER body

## Verification

- \cargo check -p miden-crypto\ passes
- \cargo test -p miden-crypto -- eddsa\ passes (9 tests, 5 new)

Closes #844