### PR TITLE
fix(smt): domain-separate single-entry leaf hashing

### DIFF
--- a/miden-crypto/src/merkle/smt/full/leaf.rs
+++ b/miden-crypto/src/merkle/smt/full/leaf.rs
@@ -11,6 +11,9 @@ use crate::{
 /// The number of field elements in a key-value pair (two Words, 4 Felts each).
 const DOUBLE_WORD_LEN: usize = 8;
 
+/// Domain used when hashing single-entry SMT leaves to keep them distinct from internal nodes.
+const SINGLE_LEAF_DOMAIN: Felt = Felt::new(1);
+
 /// Represents a leaf node in the Sparse Merkle Tree.
 ///
 /// A leaf can be empty, hold a single key-value pair, or multiple key-value pairs.
@@ -183,7 +186,11 @@ impl SmtLeaf {
     pub fn hash(&self) -> Word {
         match self {
             SmtLeaf::Empty(_) => EMPTY_WORD,
-            SmtLeaf::Single((key, value)) => Poseidon2::merge(&[*key, *value]),
+            // Domain-separate single-entry leaves from internal branch nodes to avoid
+            // collisions between `(key, value)` leaf contents and `(left, right)` branch inputs.
+            SmtLeaf::Single((key, value)) => {
+                Poseidon2::merge_in_domain(&[*key, *value], SINGLE_LEAF_DOMAIN)
+            },
             SmtLeaf::Multiple(kvs) => {
                 let elements: Vec<Felt> = kvs.iter().copied().flat_map(kv_to_elements).collect();
                 Poseidon2::hash_elements(&elements)

--- a/miden-crypto/src/merkle/smt/full/tests.rs
+++ b/miden-crypto/src/merkle/smt/full/tests.rs
@@ -629,6 +629,19 @@ fn test_smt_path_to_keys_in_same_leaf_are_equal() {
     assert_eq!(smt.open(&key_1), smt.open(&key_2));
 }
 
+#[test]
+fn test_single_leaf_hash_is_domain_separated_from_inner_nodes() {
+    let key = Word::from([ONE, Felt::new(2), Felt::new(3), Felt::new(4)]);
+    let value = Word::new([Felt::new(5), Felt::new(6), Felt::new(7), Felt::new(8)]);
+
+    let leaf_hash = SmtLeaf::new_single(key, value).hash();
+    let branch_hash = Poseidon2::merge(&[key, value]);
+    let domain_separated_leaf_hash = Poseidon2::merge_in_domain(&[key, value], Felt::new(1));
+
+    assert_eq!(leaf_hash, domain_separated_leaf_hash);
+    assert_ne!(leaf_hash, branch_hash);
+}
+
 /// Tests that an empty leaf hashes to the empty word
 #[test]
 fn test_empty_leaf_hash() {


### PR DESCRIPTION
## Describe your changes

This fixes the single-entry SMT leaf/internal-node collision described in #860.

Today, a single-entry leaf hashes `(key, value)` with `Poseidon2::merge()`, which is the same
primitive and domain used for internal branch nodes hashing `(left, right)`. That means a leaf can
collide with an internal node when the two input words are equal.

This patch keeps internal-node hashing unchanged and domain-separates only single-entry leaf
hashing via `Poseidon2::merge_in_domain()`. I also added a regression test asserting that a single
leaf hash no longer matches the corresponding internal-node hash.

Closes #860.

## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.

## Verification
- `cargo check -p miden-crypto --lib -j 1`
- `cargo check -p miden-crypto --tests -j 1`
