### PR TITLE
ci: trim duplicate nextest work and move heavy test lanes to WarpBuild

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,5 +1,6 @@
 [profile.default]
-default-filter = 'not (test(merkle::smt::full::concurrent) or test(merkle::smt::full::large) or binary(rocksdb_large_smt))'
+# The large-SMT module path is merkle::smt::large::...
+default-filter = 'not (test(merkle::smt::full::concurrent) or test(merkle::smt::large) or binary(rocksdb_large_smt))'
 fail-fast      = false
 failure-output = "immediate-final"
 
@@ -9,6 +10,6 @@ fail-fast      = false
 failure-output = "immediate-final"
 
 [profile.large-smt]
-default-filter = '(test(merkle::smt::full::large) or binary(rocksdb_large_smt))'
+default-filter = '(test(merkle::smt::large) or binary(rocksdb_large_smt))'
 fail-fast      = false
 failure-output = "immediate-final"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,12 +18,17 @@ permissions:
 
 jobs:
   test:
+    # Local timings from 2026-04-13 show these nextest jobs are overwhelmingly compile-bound:
+    # default 94.28s cold / 2.43s warm, no-std 28.84s / 1.25s, large-smt 137.33s / 0.77s.
+    # Restore rust-cache here so cache hits can avoid rebuilding those artifacts from scratch.
     name: test ${{matrix.toolchain}} on ${{matrix.os}} with ${{matrix.args}}
     runs-on: ${{matrix.os}}-latest
     strategy:
       fail-fast: false
       matrix:
-        toolchain: [stable, nightly]
+        # Stable and nightly nextest jobs exercised the same test commands with near-identical
+        # durations in CI, so keep the stable lane and let nightly coverage live elsewhere.
+        toolchain: [stable]
         os: [ubuntu]
         args: [default, no-std, large-smt]
     timeout-minutes: 30
@@ -32,6 +37,7 @@ jobs:
       - name: Cleanup large tools for build space
         uses: ./.github/actions/cleanup-runner
       - uses: taiki-e/install-action@nextest
+      - uses: Swatinem/rust-cache@v2
       - name: Install LLVM/Clang
         if: ${{ matrix.args == 'large-smt' }}
         uses: ./.github/actions/install-llvm
@@ -44,19 +50,22 @@ jobs:
           make test-${{matrix.args}}
 
   test-smt-concurrent:
+    # This nextest lane is also compile-heavy, and stable/nightly timings were effectively the
+    # same in CI (4.25m stable vs 4.38m nightly for the test step).
     name: test-smt-concurrent ${{ matrix.toolchain }}
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'pull_request' && (github.base_ref == 'main' || github.base_ref == 'next') }}
     strategy:
       fail-fast: false
       matrix:
-        toolchain: [stable, nightly]
+        toolchain: [stable]
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@main
       - name: Cleanup large tools for build space
         uses: ./.github/actions/cleanup-runner
       - uses: taiki-e/install-action@nextest
+      - uses: Swatinem/rust-cache@v2
       - name: Perform concurrent SMT tests
         run: |
           rustup update --no-self-update ${{matrix.toolchain}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,18 +18,12 @@ permissions:
 
 jobs:
   test:
-    # Local timings from 2026-04-13 show these nextest jobs are overwhelmingly compile-bound:
-    # default 94.28s cold / 2.43s warm, no-std 28.84s / 1.25s, large-smt 137.33s / 0.77s.
-    # Restore rust-cache here so cache hits can avoid rebuilding those artifacts from scratch.
-    name: test ${{matrix.toolchain}} on ${{matrix.os}} with ${{matrix.args}}
-    runs-on: ${{matrix.os}}-latest
+    name: test ${{matrix.toolchain}} on ubuntu with ${{matrix.args}}
+    runs-on: warp-ubuntu-latest-x64-4x
     strategy:
       fail-fast: false
       matrix:
-        # Stable and nightly nextest jobs exercised the same test commands with near-identical
-        # durations in CI, so keep the stable lane and let nightly coverage live elsewhere.
         toolchain: [stable]
-        os: [ubuntu]
         args: [default, no-std, large-smt]
     timeout-minutes: 30
     steps:
@@ -37,7 +31,9 @@ jobs:
       - name: Cleanup large tools for build space
         uses: ./.github/actions/cleanup-runner
       - uses: taiki-e/install-action@nextest
-      - uses: Swatinem/rust-cache@v2
+      - uses: WarpBuilds/rust-cache@v2
+        with:
+          save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/next' }}
       - name: Install LLVM/Clang
         if: ${{ matrix.args == 'large-smt' }}
         uses: ./.github/actions/install-llvm
@@ -50,10 +46,8 @@ jobs:
           make test-${{matrix.args}}
 
   test-smt-concurrent:
-    # This nextest lane is also compile-heavy, and stable/nightly timings were effectively the
-    # same in CI (4.25m stable vs 4.38m nightly for the test step).
     name: test-smt-concurrent ${{ matrix.toolchain }}
-    runs-on: ubuntu-latest
+    runs-on: warp-ubuntu-latest-x64-4x
     if: ${{ github.event_name == 'pull_request' && (github.base_ref == 'main' || github.base_ref == 'next') }}
     strategy:
       fail-fast: false
@@ -65,7 +59,9 @@ jobs:
       - name: Cleanup large tools for build space
         uses: ./.github/actions/cleanup-runner
       - uses: taiki-e/install-action@nextest
-      - uses: Swatinem/rust-cache@v2
+      - uses: WarpBuilds/rust-cache@v2
+        with:
+          save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/next' }}
       - name: Perform concurrent SMT tests
         run: |
           rustup update --no-self-update ${{matrix.toolchain}}

--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ test-p3-parallel: ## Run Miden STARK crate tests with the parallel feature enabl
 	cargo test $(MIDEN_STARK_TEST_PACKAGES) -F miden-lifted-stark/parallel
 
 .PHONY: test-large-smt
-test-large-smt: ## Run only large SMT tests
+test-large-smt: ## Run large SMT unit tests and RocksDB integration tests
 	cargo nextest run --success-output immediate --profile large-smt --cargo-profile test-release --features rocksdb
 
 .PHONY: test


### PR DESCRIPTION
CI on next times out after 30 min: https://github.com/0xMiden/crypto/actions/runs/24340170963/job/71066858775

The long pole here is compile time. The heavy `nextest` jobs are compile-bound, stable and nightly were duplicating the same work, and the large-SMT filter was stale. This moves the heavy `nextest` lanes to WarpBuild with WarpBuild cache, drops nightly `nextest` rows, and fixes the large-SMT filter so the split matches the real test paths and stays disjoint.

On the large-smt filter:
  - before: default 745, large-smt 9, no-std 568
  - after: default 631, large-smt 123, no-std 494
