### PR TITLE
[DO NOT MERGE YET] feat(hashing): Add domain separation in merkle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Added `Signature::from_der()` for EdDSA signatures ([#979](https://github.com/0xMiden/crypto/pull/979)).
 - Added domain-separated hashing support for elements to `AlgebraicSpoonge` as `hash_elements_in_domain(...)`.
 - [BREAKING] Changed the serialization format of `PartialSmt` to be more compact on the wire. If you depended on the serialization format directly (or if it is stored), this will be breaking. This ser/de is now covered by fuzz tests.
+- [BREAKING] Changed `SmtLeaf::hash` to perform domain-separated hashing, reducing the risk of a collision with the hash of an inner node. Miden VM **must** be updated to comply with this.
 
 ## 0.24.0 (2026-04-19)
 

--- a/miden-crypto/src/merkle/smt/forest/tests.rs
+++ b/miden-crypto/src/merkle/smt/forest/tests.rs
@@ -35,10 +35,10 @@ fn test_insert_root_empty() -> Result<(), MerkleError> {
     assert_eq!(
         forest.insert(empty_tree_root, key, value)?,
         Word::new([
-            Felt::new_unchecked(14568730562832515847),
-            Felt::new_unchecked(18252916646450022498),
-            Felt::new_unchecked(41434158889285279),
-            Felt::new_unchecked(9206344219167471937),
+            Felt::new_unchecked(16906950376809463586),
+            Felt::new_unchecked(12041256092349224868),
+            Felt::new_unchecked(1176700509486931830),
+            Felt::new_unchecked(7542611981105929079),
         ]),
     );
     Ok(())
@@ -55,10 +55,10 @@ fn test_insert_multiple_values() -> Result<(), MerkleError> {
     assert_eq!(
         new_root,
         Word::new([
-            Felt::new_unchecked(14568730562832515847),
-            Felt::new_unchecked(18252916646450022498),
-            Felt::new_unchecked(41434158889285279),
-            Felt::new_unchecked(9206344219167471937),
+            Felt::new_unchecked(16906950376809463586),
+            Felt::new_unchecked(12041256092349224868),
+            Felt::new_unchecked(1176700509486931830),
+            Felt::new_unchecked(7542611981105929079),
         ]),
     );
 
@@ -66,10 +66,10 @@ fn test_insert_multiple_values() -> Result<(), MerkleError> {
     assert_eq!(
         new_root,
         Word::new([
-            Felt::new_unchecked(14568730562832515847),
-            Felt::new_unchecked(18252916646450022498),
-            Felt::new_unchecked(41434158889285279),
-            Felt::new_unchecked(9206344219167471937),
+            Felt::new_unchecked(16906950376809463586),
+            Felt::new_unchecked(12041256092349224868),
+            Felt::new_unchecked(1176700509486931830),
+            Felt::new_unchecked(7542611981105929079),
         ]),
     );
 
@@ -82,10 +82,10 @@ fn test_insert_multiple_values() -> Result<(), MerkleError> {
     assert_eq!(
         new_root,
         Word::new([
-            Felt::new_unchecked(8331046026464464586),
-            Felt::new_unchecked(2235589849047307808),
-            Felt::new_unchecked(16989070170732558432),
-            Felt::new_unchecked(14827437307365892589),
+            Felt::new_unchecked(16815662437327551981),
+            Felt::new_unchecked(5197991956083107546),
+            Felt::new_unchecked(1939115207259100000),
+            Felt::new_unchecked(6159513656306598644),
         ])
     );
 
@@ -111,10 +111,10 @@ fn test_batch_insert() -> Result<(), MerkleError> {
         assert_eq!(
             new_root,
             Word::new([
-                Felt::new_unchecked(10190519849202762248),
-                Felt::new_unchecked(435931819697066051),
-                Felt::new_unchecked(16151289788138594836),
-                Felt::new_unchecked(9391498722098326251),
+                Felt::new_unchecked(5427929042044360539),
+                Felt::new_unchecked(6118532261391705453),
+                Felt::new_unchecked(5681692130190572868),
+                Felt::new_unchecked(8495277686282924792),
             ])
         );
 

--- a/miden-crypto/src/merkle/smt/full/leaf.rs
+++ b/miden-crypto/src/merkle/smt/full/leaf.rs
@@ -4,7 +4,7 @@ use super::EMPTY_WORD;
 use crate::{
     Felt, Word,
     hash::poseidon2::Poseidon2,
-    merkle::smt::{LeafIndex, MAX_LEAF_ENTRIES, SMT_DEPTH, SmtLeafError},
+    merkle::smt::{LEAF_DOMAIN, LeafIndex, MAX_LEAF_ENTRIES, SMT_DEPTH, SmtLeafError},
     utils::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable},
 };
 
@@ -183,10 +183,12 @@ impl SmtLeaf {
     pub fn hash(&self) -> Word {
         match self {
             SmtLeaf::Empty(_) => EMPTY_WORD,
-            SmtLeaf::Single((key, value)) => Poseidon2::merge(&[*key, *value]),
+            SmtLeaf::Single((key, value)) => {
+                Poseidon2::merge_in_domain(&[*key, *value], LEAF_DOMAIN)
+            },
             SmtLeaf::Multiple(kvs) => {
                 let elements: Vec<Felt> = kvs.iter().copied().flat_map(kv_to_elements).collect();
-                Poseidon2::hash_elements(&elements)
+                Poseidon2::hash_elements_in_domain(&elements, LEAF_DOMAIN)
             },
         }
     }

--- a/miden-crypto/src/merkle/smt/full/tests.rs
+++ b/miden-crypto/src/merkle/smt/full/tests.rs
@@ -9,8 +9,8 @@ use crate::{
     merkle::{
         EmptySubtreeRoots,
         smt::{
-            Map, MutationSet, NodeMutation, SmtLeafError, SmtProofError, SparseMerkleTree,
-            full::MAX_LEAF_ENTRIES,
+            LEAF_DOMAIN, Map, MutationSet, NodeMutation, SmtLeafError, SmtProofError,
+            SparseMerkleTree, full::MAX_LEAF_ENTRIES,
         },
         store::MerkleStore,
     },
@@ -1228,7 +1228,7 @@ fn build_multiple_leaf_node(kv_pairs: &[(Word, Word)]) -> Word {
         })
         .collect();
 
-    Poseidon2::hash_elements(&elements)
+    Poseidon2::hash_elements_in_domain(&elements, LEAF_DOMAIN)
 }
 
 /// Applies mutations with and without reversion to the given SMT, comparing resulting SMTs,

--- a/miden-crypto/src/merkle/smt/mod.rs
+++ b/miden-crypto/src/merkle/smt/mod.rs
@@ -47,7 +47,7 @@ pub use partial::{NodeValue, PartialSmt, UniqueNodes};
 
 mod forest;
 pub use forest::SmtForest;
-
+use miden_field::Felt;
 // CONSTANTS
 // ================================================================================================
 
@@ -56,6 +56,9 @@ pub const SMT_MIN_DEPTH: u8 = 1;
 
 /// Maximum supported depth.
 pub const SMT_MAX_DEPTH: u8 = 64;
+
+/// The felt used as a domain separator when hashing leaves in merkle trees.
+pub const LEAF_DOMAIN: Felt = Felt::new_unchecked(0x13af);
 
 // SPARSE MERKLE TREE
 // ================================================================================================


### PR DESCRIPTION
## Describe your changes

This commit adds `Poseidon2::hash_elements_in_domain` to allow domain-tagging of hash inputs. This new function is then used in the hashing procedure for `SmtLeaf`, providing domain separation for any client of that type.

Affected downstream data types include `Smt`, `LargeSmt`, and `LargeSmtForest`, all of which use that type.

Note that **THIS REQUIRES CHANGES TO THE VM'S CORELIB**, as without the procedural changes, the clients of the API and of the VM will get different results.

Closes #860. Filed VM-side issue as https://github.com/0xMiden/miden-vm/issues/2996.

## Checklist before requesting a review

- [x] Repo forked and branch created from `next` according to naming convention.
- [x] Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- [x] Relevant issues are linked in the PR description.
- [x] Tests added for new functionality.
- [x] Documentation/comments updated according to changes.
