### PR TITLE
Add fuzzing for PartialSmt deserialization

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -49,7 +49,7 @@ jobs:
       fail-fast: false
       max-parallel: 1
       matrix:
-        target: [word, merkle, merkle_store, smt_serde, mmr, crypto, aead, signatures]
+        target: [word, merkle, merkle_store, smt_serde, partial_smt, mmr, crypto, aead, signatures]
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - [BREAKING] Per-instance log trace heights moved from `AirInstance` into `StarkProof`; `prove_multi` / `verify_multi` now observe them into the Fiat-Shamir challenger internally ([#956](https://github.com/0xMiden/crypto/pull/956)). Consumers on the temporary `(log_trace_height, proof)` serialization path must drop the wrapper and stop pre-observing the height, or it will be bound twice. `StarkProof` no longer exposes per-instance heights directly — parse the proof with `StarkTranscript::from_proof` to read them; `num_traces()` is available for the count.
 - [BREAKING] Split the `SecretKey` type for both ECDSA-k256 and EdDSA-25519 into `SigningKey` and `KeyExchangeKey` to help enforce better practices around key reuse. `SecretKey` is no longer available in the public API; all usages should be moved to one of the new key types.
 - [BREAKING] Changed the serialization format of `PartialSmt` to be more compact on the wire. If you depended on the serialization format directly (or if it is stored), this will be breaking.
+- Added fuzz coverage for `PartialSmt` deserialization ([#968](https://github.com/0xMiden/crypto/pull/968)).
 
 ## 0.23.0 (2026-03-11)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Optimize field operations for `Goldilocks` ([#926](https://github.com/0xMiden/crypto/pull/926)).
 - [BREAKING] Per-instance log trace heights moved from `AirInstance` into `StarkProof`; `prove_multi` / `verify_multi` now observe them into the Fiat-Shamir challenger internally ([#956](https://github.com/0xMiden/crypto/pull/956)). Consumers on the temporary `(log_trace_height, proof)` serialization path must drop the wrapper and stop pre-observing the height, or it will be bound twice. `StarkProof` no longer exposes per-instance heights directly — parse the proof with `StarkTranscript::from_proof` to read them; `num_traces()` is available for the count.
 - [BREAKING] Split the `SecretKey` type for both ECDSA-k256 and EdDSA-25519 into `SigningKey` and `KeyExchangeKey` to help enforce better practices around key reuse. `SecretKey` is no longer available in the public API; all usages should be moved to one of the new key types.
+- [BREAKING] Changed the serialization format of `PartialSmt` to be more compact on the wire. If you depended on the serialization format directly (or if it is stored), this will be breaking.
 
 ## 0.23.0 (2026-03-11)
 

--- a/Makefile
+++ b/Makefile
@@ -192,6 +192,10 @@ fuzz-merkle-store: ## Run fuzzing for MerkleStore deserialization
 fuzz-smt-serde: ## Run fuzzing for SMT serialization
 	cargo +nightly fuzz run smt_serde --release --fuzz-dir miden-crypto-fuzz
 
+.PHONY: fuzz-partial-smt
+fuzz-partial-smt: ## Run fuzzing for PartialSmt deserialization
+	cargo +nightly fuzz run partial_smt --release --fuzz-dir miden-crypto-fuzz
+
 .PHONY: fuzz-mmr
 fuzz-mmr: ## Run fuzzing for MMR structures serialization
 	cargo +nightly fuzz run mmr --release --fuzz-dir miden-crypto-fuzz

--- a/miden-crypto-fuzz/Cargo.lock
+++ b/miden-crypto-fuzz/Cargo.lock
@@ -600,6 +600,7 @@ dependencies = [
  "p3-challenger",
  "p3-field",
  "p3-goldilocks",
+ "p3-util",
  "paste",
  "rand 0.10.1",
  "serde",

--- a/miden-crypto-fuzz/Cargo.toml
+++ b/miden-crypto-fuzz/Cargo.toml
@@ -49,6 +49,13 @@ name  = "smt_serde"
 path  = "fuzz_targets/smt_serde.rs"
 test  = false
 
+[[bin]]
+bench = false
+doc   = false
+name  = "partial_smt"
+path  = "fuzz_targets/partial_smt.rs"
+test  = false
+
 # MMR structures fuzz target
 [[bin]]
 bench = false

--- a/miden-crypto-fuzz/fuzz_targets/partial_smt.rs
+++ b/miden-crypto-fuzz/fuzz_targets/partial_smt.rs
@@ -4,9 +4,15 @@ use core::mem::size_of;
 
 use libfuzzer_sys::fuzz_target;
 use miden_crypto::{
-    merkle::smt::{LeafIndex, PartialSmt, SmtLeaf, UniqueNodes},
+    Felt, Map, Word,
+    merkle::smt::{LeafIndex, NodeValue, PartialSmt, SMT_DEPTH, SmtLeaf, UniqueNodes},
     utils::{Deserializable, Serializable},
 };
+
+const MAX_LEVELS: usize = 16;
+const MAX_NODES_PER_LEVEL: usize = 8;
+const MAX_LEAVES: usize = 16;
+const MAX_MULTI_LEAF_ENTRIES: usize = 6;
 
 fuzz_target!(|data: &[u8]| {
     // Exercise the public deserializer directly, matching the other serde fuzz targets.
@@ -15,22 +21,183 @@ fuzz_target!(|data: &[u8]| {
     let _ = Option::<PartialSmt>::read_from_bytes(data);
     let _ = <[PartialSmt; 1]>::read_from_bytes(data);
 
-    // Keep the fuzzer close to parse-valid compact PartialSmt encodings so it can reach
-    // reconstruction paths guarded by structural invariants rather than byte parsing.
-    if let Some(leaf_index) = leaf_index_from_prefix(data) {
-        let unique_nodes = UniqueNodes {
-            leaves: vec![(
-                leaf_index,
-                SmtLeaf::new_empty(LeafIndex::new_max_depth(leaf_index)),
-            )],
-            ..UniqueNodes::empty()
-        };
-
-        let _ = PartialSmt::read_from_bytes(&unique_nodes.to_bytes());
+    if data.is_empty() {
+        return;
     }
+
+    // Generate parse-valid compact PartialSmt encodings from the input bytes. This gives the fuzzer
+    // enough structure to regularly reach reconstruction and validation, not just byte parsing.
+    let unique_nodes = StructuredInput::new(data).unique_nodes();
+    let _ = PartialSmt::read_from_bytes(&unique_nodes.to_bytes());
+
+    // Also try the same leaves without reconstruction nodes. This preserves direct coverage for
+    // missing-node cases like the panic path reported in roborev review 3329.
+    if !unique_nodes.leaves.is_empty() {
+        let mut missing_nodes = unique_nodes;
+        missing_nodes.nodes.clear();
+        let _ = PartialSmt::read_from_bytes(&missing_nodes.to_bytes());
+    }
+
+    // Keep a minimal missing-node shape in the corpus so short inputs can still reach the reviewed
+    // failure mode without first discovering the broader structured encoding.
+    let _ = PartialSmt::read_from_bytes(&focused_missing_node_payload(data));
 });
 
-fn leaf_index_from_prefix(data: &[u8]) -> Option<u64> {
-    let prefix = data.get(..size_of::<u64>())?;
-    Some(u64::from_le_bytes(prefix.try_into().expect("prefix length is checked")))
+fn focused_missing_node_payload(data: &[u8]) -> Vec<u8> {
+    let leaf_index = leaf_index_from_prefix(data);
+    UniqueNodes {
+        leaves: vec![(
+            leaf_index,
+            SmtLeaf::new_empty(LeafIndex::new_max_depth(leaf_index)),
+        )],
+        ..UniqueNodes::empty()
+    }
+    .to_bytes()
+}
+
+fn leaf_index_from_prefix(data: &[u8]) -> u64 {
+    let mut bytes = [0; size_of::<u64>()];
+    let prefix_len = data.len().min(bytes.len());
+    bytes[..prefix_len].copy_from_slice(&data[..prefix_len]);
+    u64::from_le_bytes(bytes)
+}
+
+struct StructuredInput<'a> {
+    data: &'a [u8],
+    cursor: usize,
+}
+
+impl<'a> StructuredInput<'a> {
+    fn new(data: &'a [u8]) -> Self {
+        Self { data, cursor: 0 }
+    }
+
+    fn unique_nodes(&mut self) -> UniqueNodes {
+        let root = if self.next_bool() {
+            self.next_word()
+        } else {
+            UniqueNodes::empty().root
+        };
+
+        let mut nodes = Map::new();
+        for _ in 0..self.next_count(MAX_LEVELS) {
+            let depth = self.next_node_depth();
+            let node_count = self.next_count(MAX_NODES_PER_LEVEL);
+            let level_nodes = nodes.entry(depth).or_insert_with(Vec::new);
+
+            for _ in 0..node_count {
+                level_nodes.push((self.next_node_position(depth), self.next_node_value()));
+            }
+        }
+
+        let mut leaves = Vec::new();
+        for _ in 0..self.next_count(MAX_LEAVES) {
+            leaves.push(self.next_leaf_entry());
+        }
+
+        UniqueNodes { root, nodes, leaves }
+    }
+
+    fn next_leaf_entry(&mut self) -> (u64, SmtLeaf) {
+        let outer_index = self.next_u64();
+        let leaf_index = if self.next_bool() {
+            outer_index
+        } else {
+            self.next_u64()
+        };
+
+        let leaf = match self.next_u8() % 3 {
+            0 => SmtLeaf::new_empty(LeafIndex::new_max_depth(leaf_index)),
+            1 => SmtLeaf::new_single(self.next_key_for_leaf(leaf_index), self.next_word()),
+            _ => self.next_multiple_leaf(leaf_index),
+        };
+
+        (outer_index, leaf)
+    }
+
+    fn next_multiple_leaf(&mut self, leaf_index: u64) -> SmtLeaf {
+        let count = 2 + self.next_count(MAX_MULTI_LEAF_ENTRIES.saturating_sub(2));
+        let entries = (0..count)
+            .map(|_| (self.next_key_for_leaf(leaf_index), self.next_word()))
+            .collect();
+
+        SmtLeaf::new_multiple(entries)
+            .unwrap_or_else(|_| SmtLeaf::new_empty(LeafIndex::new_max_depth(leaf_index)))
+    }
+
+    fn next_key_for_leaf(&mut self, leaf_index: u64) -> Word {
+        Word::new([
+            self.next_felt(),
+            self.next_felt(),
+            self.next_felt(),
+            Felt::new_unchecked(leaf_index % Felt::ORDER),
+        ])
+    }
+
+    fn next_node_value(&mut self) -> NodeValue {
+        if self.next_bool() {
+            NodeValue::Present(self.next_word())
+        } else {
+            NodeValue::EmptySubtreeRoot
+        }
+    }
+
+    fn next_node_depth(&mut self) -> u8 {
+        self.next_u8() % SMT_DEPTH
+    }
+
+    fn next_node_position(&mut self, depth: u8) -> u64 {
+        let position = self.next_u64();
+        if self.next_bool() {
+            bounded_position(depth, position)
+        } else {
+            position
+        }
+    }
+
+    fn next_word(&mut self) -> Word {
+        Word::new([
+            self.next_felt(),
+            self.next_felt(),
+            self.next_felt(),
+            self.next_felt(),
+        ])
+    }
+
+    fn next_felt(&mut self) -> Felt {
+        Felt::new_unchecked(self.next_u64() % Felt::ORDER)
+    }
+
+    fn next_count(&mut self, max: usize) -> usize {
+        if max == 0 {
+            return 0;
+        }
+        usize::from(self.next_u8()) % (max + 1)
+    }
+
+    fn next_bool(&mut self) -> bool {
+        self.next_u8() & 1 == 1
+    }
+
+    fn next_u8(&mut self) -> u8 {
+        let value = self.data[self.cursor % self.data.len()];
+        self.cursor += 1;
+        value
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        let mut bytes = [0; size_of::<u64>()];
+        for byte in &mut bytes {
+            *byte = self.next_u8();
+        }
+        u64::from_le_bytes(bytes)
+    }
+}
+
+fn bounded_position(depth: u8, position: u64) -> u64 {
+    match depth {
+        0 => 0,
+        1..=63 => position & ((1_u64 << depth) - 1),
+        _ => position,
+    }
 }

--- a/miden-crypto-fuzz/fuzz_targets/partial_smt.rs
+++ b/miden-crypto-fuzz/fuzz_targets/partial_smt.rs
@@ -1,0 +1,36 @@
+#![no_main]
+
+use core::mem::size_of;
+
+use libfuzzer_sys::fuzz_target;
+use miden_crypto::{
+    merkle::smt::{LeafIndex, PartialSmt, SmtLeaf, UniqueNodes},
+    utils::{Deserializable, Serializable},
+};
+
+fuzz_target!(|data: &[u8]| {
+    // Exercise the public deserializer directly, matching the other serde fuzz targets.
+    let _ = PartialSmt::read_from_bytes(data);
+    let _ = Vec::<PartialSmt>::read_from_bytes(data);
+    let _ = Option::<PartialSmt>::read_from_bytes(data);
+    let _ = <[PartialSmt; 1]>::read_from_bytes(data);
+
+    // Keep the fuzzer close to parse-valid compact PartialSmt encodings so it can reach
+    // reconstruction paths guarded by structural invariants rather than byte parsing.
+    if let Some(leaf_index) = leaf_index_from_prefix(data) {
+        let unique_nodes = UniqueNodes {
+            leaves: vec![(
+                leaf_index,
+                SmtLeaf::new_empty(LeafIndex::new_max_depth(leaf_index)),
+            )],
+            ..UniqueNodes::empty()
+        };
+
+        let _ = PartialSmt::read_from_bytes(&unique_nodes.to_bytes());
+    }
+});
+
+fn leaf_index_from_prefix(data: &[u8]) -> Option<u64> {
+    let prefix = data.get(..size_of::<u64>())?;
+    Some(u64::from_le_bytes(prefix.try_into().expect("prefix length is checked")))
+}

--- a/miden-crypto/src/merkle/smt/mod.rs
+++ b/miden-crypto/src/merkle/smt/mod.rs
@@ -43,7 +43,7 @@ mod simple;
 pub use simple::{SimpleSmt, SimpleSmtProof};
 
 mod partial;
-pub use partial::PartialSmt;
+pub use partial::{NodeValue, PartialSmt, UniqueNodes};
 
 mod forest;
 pub use forest::SmtForest;

--- a/miden-crypto/src/merkle/smt/partial/mod.rs
+++ b/miden-crypto/src/merkle/smt/partial/mod.rs
@@ -1,6 +1,8 @@
+use alloc::{collections::VecDeque, vec::Vec};
+
 use super::{EmptySubtreeRoots, LeafIndex, SMT_DEPTH};
 use crate::{
-    EMPTY_WORD, Word,
+    EMPTY_WORD, Map, Word,
     merkle::{
         InnerNodeInfo, MerkleError, NodeIndex, SparseMerklePath,
         smt::{InnerNode, InnerNodes, Leaves, SmtLeaf, SmtLeafError, SmtProof},
@@ -8,8 +10,11 @@ use crate::{
     utils::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable},
 };
 
+mod serialization;
 #[cfg(test)]
 mod tests;
+
+pub use serialization::{NodeValue, UniqueNodes};
 
 /// A partial version of an [`super::Smt`].
 ///
@@ -289,6 +294,203 @@ impl PartialSmt {
         Ok(())
     }
 
+    // UNIQUE NODES
+    // --------------------------------------------------------------------------------------------
+
+    /// Converts `self` into the [`UniqueNodes`] serialization representation for compact
+    /// serialization.
+    ///
+    /// This method assumes that the `PartialSmt` is in a valid state.
+    ///
+    /// # Reconstructable Sets
+    ///
+    /// We define the notion of a reconstructable set as one which stores the minimum amount of
+    /// information necessary in order to reconstruct the full state of the tree. We build this set
+    /// as follows:
+    ///
+    /// 1. Start at the leaves and traverse toward the root.
+    /// 2. Wherever a node's value is determined solely by children already implicitly contained
+    ///    within the set, store no new information. If additional information is required (e.g. a
+    ///    sibling node) store that.
+    /// 3. Repeat until the root is reached.
+    ///
+    /// To reconstruct the tree, we just start at the leaves and compute all intermediary nodes from
+    /// the data stored in the reconstructible set.
+    pub fn to_unique_nodes(&self) -> UniqueNodes {
+        // We start by getting all the known leaves, as these give us the starting point for the
+        // reconstruction.
+        let leaf_nodes = self
+            .leaves()
+            .map(|(k, v)| (k, v.clone()))
+            .collect::<Map<LeafIndex<SMT_DEPTH>, SmtLeaf>>();
+
+        // We also create storage for the nodes necessary for reconstruction of the tree...
+        let mut needed_nodes: Map<NodeIndex, NodeValue> = Map::new();
+
+        // ... and grab the full set of inner nodes to work from as a queue for easy use. We sort
+        // them from the bottom of the tree to the top, but retain the standard left-to-right
+        // ordering.
+        let mut inner_nodes = self.inner_node_indices().collect::<Vec<(NodeIndex, InnerNode)>>();
+        inner_nodes.sort_by(|(il, _), (ir, _)| {
+            ir.depth().cmp(&il.depth()).then(il.position().cmp(&ir.position()))
+        });
+        let mut inner_nodes = inner_nodes.into_iter().collect::<VecDeque<(NodeIndex, InnerNode)>>();
+
+        // We then need to iterate over all the nodes to work out which ones are reconstructible,
+        // and which need us to store additional data to be reconstructible.
+        while let Some((ix, v)) = inner_nodes.pop_front() {
+            // There must be data available for both of the node's children for it to be
+            // reconstructible. Missing leaf nodes are handled by absence in the compact rep, so we
+            // can skip adding those as they always result in the same value.
+            for (child, val) in [(ix.left_child(), v.left), (ix.right_child(), v.right)] {
+                if child.depth() != SMT_DEPTH {
+                    // A child of the node `v` can be in one of three states:
+                    //
+                    // 1. The child does not exist as a physical node in `self`, but its value as
+                    //    stored in `v` is real.
+                    // 2. The child does not exist as a physical node in `self`, but its value is
+                    //    the default empty subtree root.
+                    // 3. The child does exist as a physical node in `self`. By induction, as this
+                    //    algorithm runs bottom-up, the data to reconstruct the node already exists.
+                    if self.get_inner_node(child).is_none() {
+                        // In this case, the node does not exist physically, so we have to work out
+                        // which of the other cases it is.
+                        let new = if val == *EmptySubtreeRoots::entry(SMT_DEPTH, child.depth()) {
+                            NodeValue::EmptySubtreeRoot
+                        } else {
+                            NodeValue::Present(val)
+                        };
+
+                        // We allow overwriting existing inserts for algorithmic simplicity, but we
+                        // always check that it is the same value if an overwrite occurs.
+                        if let Some(v) = needed_nodes.insert(child, new.clone())
+                            && v != new
+                        {
+                            panic!("Overwrite occurred with a different value ")
+                        }
+                    } else {
+                        // Here, the node exists physically, so by induction, it is reconstructible.
+                        // We fall-through with an explicit `continue` for algorithmic clarity.
+                        continue;
+                    }
+                }
+            }
+        }
+
+        // With all the data gathered, we can convert our types as necessary to create our output.
+        let leaves = leaf_nodes.into_iter().map(|(i, l)| (i.position(), l)).collect::<Vec<_>>();
+        let mut nodes: Map<u8, Vec<(u64, NodeValue)>> = Map::new();
+
+        for (ix, value) in needed_nodes {
+            nodes.entry(ix.depth()).or_default().push((ix.position(), value));
+        }
+
+        UniqueNodes { root: self.root(), leaves, nodes }
+    }
+
+    /// Constructs a new `PartialSmt` from the provided `unique_nodes`, reconstituting the full data
+    /// from the compact representation.
+    ///
+    /// This method assumes that the `unique_nodes` represent a valid `PartialSmt` instance.
+    ///
+    /// See the documentation of [`Self::to_unique_nodes`] for the reconstruction algorithm.
+    ///
+    /// # Errors
+    ///
+    /// - [`MerkleError::NodeIndexNotFoundInStore`] if any node necessary for reconstruction is not
+    ///   available in the provided `unique_nodes` data.
+    pub fn from_unique_nodes(unique_nodes: UniqueNodes) -> Result<Self, DeserializationError> {
+        // We perform our transformation by directly mutating a new instance of `Self`.
+        let mut smt = Self::new(unique_nodes.root);
+
+        // We rely on a minimal set of node values and leaf values to reconstruct the tree, so we
+        // have to be able to perform lookups.
+        let nodes = unique_nodes
+            .nodes
+            .into_iter()
+            .flat_map(|(depth, nodes)| {
+                nodes
+                    .into_iter()
+                    .map(move |(ix, val)| (NodeIndex::new_unchecked(depth, ix), val))
+            })
+            .collect::<Map<NodeIndex, NodeValue>>();
+        let all_leaves = unique_nodes
+            .leaves
+            .into_iter()
+            .map(|(ix, l)| (NodeIndex::new_unchecked(SMT_DEPTH, ix), l))
+            .collect::<Map<_, _>>();
+
+        // We then want to process leaf by leaf, with a queue of parent nodes that need visiting.
+        // Rather than trying to de-duplicate on the fly, we instead just discard nodes that have
+        // already been processed when we see them.
+        //
+        // It must be ensured that at no point an index that is lower in the tree than any index
+        // preceding it is inserted.
+        let mut nodes_to_visit = all_leaves.keys().map(|k| k.parent()).collect::<VecDeque<_>>();
+
+        while let Some(ix) = nodes_to_visit.pop_front() {
+            // To avoid re-doing work we immediately discard a node that is already in our tree.
+            if smt.inner_nodes.contains_key(&ix) {
+                continue;
+            }
+
+            if ix.depth() + 1 == SMT_DEPTH {
+                // We have to handle the case where the children are the leaves specially. If one is
+                // not present, that means that it had the default value and hence can be
+                // reconstituted.
+                let left_child = ix.left_child();
+                let left = all_leaves
+                    .get(&left_child)
+                    .cloned()
+                    .unwrap_or(SmtLeaf::new_empty(LeafIndex::new_max_depth(left_child.position())))
+                    .hash();
+                let right_child = ix.right_child();
+                let right = all_leaves
+                    .get(&right_child)
+                    .cloned()
+                    .unwrap_or(SmtLeaf::new_empty(LeafIndex::new_max_depth(right_child.position())))
+                    .hash();
+
+                smt.insert_inner_node(ix, InnerNode { left, right })
+            } else {
+                // If the children are not in the leaves, they can be either in the tree already
+                // (having been reconstructed) or as a value in the nodes from the unique nodes
+                // structure.
+                let [left, right] = [ix.left_child(), ix.right_child()].map(|ix| {
+                    smt.get_inner_node(ix).map(|n| Ok(n.hash())).unwrap_or_else(|| {
+                        match nodes.get(&ix).ok_or_else(|| {
+                            DeserializationError::InvalidValue(format!(
+                                "Node {ix} not found but was required"
+                            ))
+                        })? {
+                            NodeValue::EmptySubtreeRoot => {
+                                Ok(*EmptySubtreeRoots::entry(SMT_DEPTH, ix.depth()))
+                            },
+                            NodeValue::Present(v) => Ok(*v),
+                        }
+                    })
+                });
+                let left = left?;
+                let right = right?;
+
+                smt.insert_inner_node(ix, InnerNode { left, right });
+            }
+
+            // Finally, we push the node's parent into the queue.
+            nodes_to_visit.push_back(ix.parent());
+        }
+
+        // With that done, we simply have to write the remaining keys into the tree.
+        all_leaves.into_iter().for_each(|(ix, leaf)| {
+            smt.num_entries += leaf.num_entries();
+            smt.leaves.insert(ix.position(), leaf);
+        });
+
+        smt.validate()?;
+
+        Ok(smt)
+    }
+
     // PRIVATE HELPERS
     // --------------------------------------------------------------------------------------------
 
@@ -539,43 +741,15 @@ impl From<super::Smt> for PartialSmt {
 
 impl Serializable for PartialSmt {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
-        target.write(self.root());
-        target.write_usize(self.leaves.len());
-        for (i, leaf) in &self.leaves {
-            target.write_u64(*i);
-            target.write(leaf);
-        }
-        target.write_usize(self.inner_nodes.len());
-        for (idx, node) in &self.inner_nodes {
-            target.write(idx);
-            target.write(node);
-        }
+        let unique_rep = self.to_unique_nodes();
+        unique_rep.write_into(target);
     }
 }
 
 impl Deserializable for PartialSmt {
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
-        let root: Word = source.read()?;
-
-        let mut leaves = Leaves::<SmtLeaf>::default();
-        for _ in 0..source.read_usize()? {
-            let pos: u64 = source.read()?;
-            let leaf: SmtLeaf = source.read()?;
-            leaves.insert(pos, leaf);
-        }
-
-        let mut inner_nodes = InnerNodes::default();
-        for _ in 0..source.read_usize()? {
-            let idx: NodeIndex = source.read()?;
-            let node: InnerNode = source.read()?;
-            inner_nodes.insert(idx, node);
-        }
-
-        let num_entries = leaves.values().map(SmtLeaf::num_entries).sum();
-
-        let partial = Self { root, num_entries, leaves, inner_nodes };
-        partial.validate()?;
-
-        Ok(partial)
+        let unique_rep = UniqueNodes::read_from(source)?;
+        PartialSmt::from_unique_nodes(unique_rep)
+            .map_err(|e| DeserializationError::InvalidValue(format!("{e}")))
     }
 }

--- a/miden-crypto/src/merkle/smt/partial/mod.rs
+++ b/miden-crypto/src/merkle/smt/partial/mod.rs
@@ -426,9 +426,34 @@ impl PartialSmt {
         //
         // It must be ensured that at no point an index that is lower in the tree than any index
         // preceding it is inserted.
-        let mut nodes_to_visit = all_leaves.keys().map(|k| k.parent()).collect::<VecDeque<_>>();
+        let mut node_indices_to_visit =
+            all_leaves.keys().map(|k| k.parent()).collect::<VecDeque<_>>();
 
-        while let Some(ix) = nodes_to_visit.pop_front() {
+        // We also, however, need to account for inner nodes which are not reachable in a parent
+        // chain from a leaf, such as those from an exclusion proof. These are all nodes that do not
+        // have a (present) child in the set of nodes or leaves, so to enforce our layering
+        // invariant we add them in sorted order from bottom to top, left to right.
+        let mut origin_node_indices = nodes
+            .iter()
+            .filter_map(|(i, _)| {
+                let left_sub_root =
+                    matches!(nodes.get(&i.left_child()), Some(NodeValue::EmptySubtreeRoot));
+                let right_sub_root =
+                    matches!(nodes.get(&i.right_child()), Some(NodeValue::EmptySubtreeRoot));
+                let left_in_leaves = all_leaves.contains_key(&i.left_child());
+                let right_in_leaves = all_leaves.contains_key(&i.right_child());
+                if (left_sub_root && right_sub_root) || (!left_in_leaves && !right_in_leaves) {
+                    Some(i)
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<_>>();
+        origin_node_indices
+            .sort_by(|il, ir| ir.depth().cmp(&il.depth()).then(il.position().cmp(&ir.position())));
+        node_indices_to_visit.extend(origin_node_indices.into_iter());
+
+        while let Some(ix) = node_indices_to_visit.pop_front() {
             // To avoid re-doing work we immediately discard a node that is already in our tree.
             if smt.inner_nodes.contains_key(&ix) {
                 continue;
@@ -460,7 +485,7 @@ impl PartialSmt {
                     smt.get_inner_node(ix).map(|n| Ok(n.hash())).unwrap_or_else(|| {
                         match nodes.get(&ix).ok_or_else(|| {
                             DeserializationError::InvalidValue(format!(
-                                "Node {ix} not found but was required"
+                                "Node at {ix} not found but is required"
                             ))
                         })? {
                             NodeValue::EmptySubtreeRoot => {
@@ -477,7 +502,7 @@ impl PartialSmt {
             }
 
             // Finally, we push the node's parent into the queue.
-            nodes_to_visit.push_back(ix.parent());
+            node_indices_to_visit.push_back(ix.parent());
         }
 
         // With that done, we simply have to write the remaining keys into the tree.

--- a/miden-crypto/src/merkle/smt/partial/serialization/mod.rs
+++ b/miden-crypto/src/merkle/smt/partial/serialization/mod.rs
@@ -1,0 +1,199 @@
+//! This module contains a system for producing compact serialized representations of the
+//! `PartialSmt` data structure, intended to reduce data sent over the wire through de-duplication.
+
+pub mod property_tests;
+mod tests;
+
+use alloc::{string::ToString, vec::Vec};
+
+use miden_field::{Felt, FeltFromIntError, Word};
+use miden_serde_utils::{
+    ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable,
+};
+
+use crate::{
+    Map,
+    merkle::{
+        EmptySubtreeRoots,
+        smt::{SMT_DEPTH, SmtLeaf},
+    },
+};
+
+// UNIQUE NODES
+// ================================================================================================
+
+/// A representation of a partial SMT that contains only the unique nodes in the tree, designed for
+/// better efficiency when sending data across the wire.
+///
+/// It _explicitly_ does not need to contain a fully-realized SMT, and instead may contain some
+/// subset of a full tree. It contains the minimal set of data necessary to reconstruct its input.
+///
+/// # Versioning
+///
+/// Note that this structure is explicitly **not intended to be versioned**. This structure should
+/// be used as part of a broader serialization solution that does include this if necessary.
+///
+/// # Serialization
+///
+/// The serialization and deserialization process does not validate that node or leaf indices are
+/// valid for their level. This is the responsibility of the client of this type.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct UniqueNodes {
+    /// The expected root of the tree after reconstruction.
+    ///
+    /// This primarily exists as a sanity check, taking little extra space but ensuring that we can
+    /// detect more possible cases of corruption.
+    pub root: Word,
+
+    /// The nodes that make up the tree itself.
+    ///
+    /// It maps the node depth to a vector containing all the nodes at that depth, ensuring that no
+    /// data that can be reasonably reconstructed is stored.
+    pub nodes: Map<u8, Vec<(u64, NodeValue)>>,
+
+    /// The leaves of the tree.
+    ///
+    /// It only stores the populated leaves, keyed on their index.
+    pub leaves: Vec<(u64, SmtLeaf)>,
+}
+
+impl UniqueNodes {
+    /// Creates an empty `UniqueNodes` with no nodes or leaves in it.
+    pub fn empty() -> Self {
+        Self {
+            root: *EmptySubtreeRoots::entry(SMT_DEPTH, 0),
+            nodes: Map::default(),
+            leaves: Vec::default(),
+        }
+    }
+}
+
+impl Default for UniqueNodes {
+    fn default() -> Self {
+        Self::empty()
+    }
+}
+
+impl Serializable for UniqueNodes {
+    fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        // First we write the expected root into the buffer.
+        self.root.write_into(target);
+
+        // We write the length as u64 to ensure portability.
+        let node_count = self.nodes.len() as u64;
+        target.write(node_count);
+
+        // We then write each of the pairs of (u8, Vec<...>) independently.
+        for (depth, nodes) in self.nodes.iter() {
+            target.write(depth);
+            let node_count = nodes.len() as u64;
+            target.write(node_count);
+            target.write_many(nodes.iter());
+        }
+
+        // The leaves themselves come last.
+        let leaf_count = self.leaves.len() as u64;
+        target.write(leaf_count);
+        target.write_many(self.leaves.iter());
+    }
+}
+
+impl Deserializable for UniqueNodes {
+    fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
+        // The first item is the 32 bytes containing the expected root of the tree after
+        // reconstruction.
+        let root = Word::read_from(source)?;
+
+        // We first have to read the count of levels.
+        let level_count = source.read_u64()?;
+        let mut nodes = Map::new();
+
+        // Next we have that many levels to read, but each is of a variable size.
+        for _ in 0..level_count {
+            let depth = source.read_u8()?;
+            let node_count = source.read_u64()?;
+            let level_nodes =
+                source.read_many_iter(node_count as usize)?.collect::<Result<Vec<_>, _>>()?;
+            nodes.insert(depth, level_nodes);
+        }
+
+        // Next we need the number of leaves.
+        let leaf_count = source.read_u64()?;
+        let mut leaves = Vec::with_capacity(leaf_count as usize);
+
+        // And then we have to read that many leaves.
+        for _ in 0..leaf_count {
+            leaves.push(source.read()?);
+        }
+
+        Ok(Self { root, nodes, leaves })
+    }
+}
+
+// NODE VALUE
+// ================================================================================================
+
+/// The value of a node in the serialized representation.
+///
+/// # Serialization
+///
+/// This enum can be in one of two cases: empty, or containing a Word. The naïve serialization would
+/// use a flag to indicate the variant, costing at least a byte to avoid the need for potentially
+/// expensive unaligned accesses.
+///
+/// [`Word`], however, consists of four `Felt`s, each of which occupies the Goldilocks field. This
+/// provides a niche in each of those `Felt`s that allows us to not require the extra byte when
+/// serializing a true value. As we assume that real values are more common than empty subtree roots
+/// by their very nature, making an empty root take 8 bytes instead of 1 is a smaller cost to pay
+/// than an extra byte for each populated node.
+///
+/// To that end, we encode the type as follows:
+///
+/// - For `Self::EmptySubtreeRoot` we encode the LE bytes for [`u64::MAX`], which exceeds the field
+///   order and hence serves as a sentinel value using the niche.
+/// - For `Self::Present` we simply encode the word as its four component felts. As none of the
+///   felts can take a value exceeding [`Felt::ORDER`], we can immediately disambiguate between this
+///   case and the one above.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum NodeValue {
+    /// The node is the head of an empty subtree at the depth given by the outer map in
+    /// [`UniqueNodes`].
+    EmptySubtreeRoot,
+
+    /// The node's value is the provided hash.
+    Present(Word),
+}
+
+impl Serializable for NodeValue {
+    fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        match self {
+            NodeValue::EmptySubtreeRoot => target.write_u64(u64::MAX),
+            NodeValue::Present(w) => w.write_into(target),
+        }
+    }
+}
+
+impl Deserializable for NodeValue {
+    fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
+        let first_value = source.read_u64()?;
+
+        let to_e = |e: FeltFromIntError| DeserializationError::InvalidValue(e.to_string());
+
+        if first_value == u64::MAX {
+            Ok(Self::EmptySubtreeRoot)
+        } else {
+            // We start by reading the rest of the bytes here to make sure that we have enough data
+            // before actually deserializing.
+            let remaining_values: [u64; Word::NUM_ELEMENTS - 1] = source.read()?;
+
+            let felts = [
+                Felt::new(first_value).map_err(to_e)?,
+                Felt::new(remaining_values[0]).map_err(to_e)?,
+                Felt::new(remaining_values[1]).map_err(to_e)?,
+                Felt::new(remaining_values[2]).map_err(to_e)?,
+            ];
+
+            Ok(Self::Present(Word::new(felts)))
+        }
+    }
+}

--- a/miden-crypto/src/merkle/smt/partial/serialization/property_tests.rs
+++ b/miden-crypto/src/merkle/smt/partial/serialization/property_tests.rs
@@ -1,0 +1,162 @@
+#![cfg(test)]
+//! Contains the property tests for the new serialization mechanism for the `PartialSmt` type.
+
+use alloc::vec::Vec;
+
+use miden_field::{Felt, Word};
+use miden_serde_utils::{Deserializable, Serializable};
+use proptest::prelude::*;
+
+use crate::{
+    Map,
+    merkle::smt::{LeafIndex, NodeValue, SmtLeaf, UniqueNodes},
+};
+// GENERATORS
+// ================================================================================================
+
+/// Generates an arbitrary [`Felt`] that is guaranteed to be valid.
+fn arbitrary_valid_felt() -> impl Strategy<Value = Felt> {
+    any::<u64>().prop_filter_map("Out of bounds for Felt", |e| Felt::new(e).ok())
+}
+
+/// Generates an arbitrary [`Word`] that is guaranteed to consist of only valid `Felt`s.
+pub fn arbitrary_valid_word() -> impl Strategy<Value = Word> {
+    prop::array::uniform4(arbitrary_valid_felt()).prop_map(Word::new)
+}
+
+impl Arbitrary for NodeValue {
+    type Parameters = ();
+
+    fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
+        prop_oneof![
+            Just(NodeValue::EmptySubtreeRoot),
+            arbitrary_valid_word().prop_map(NodeValue::Present)
+        ]
+        .boxed()
+    }
+
+    type Strategy = BoxedStrategy<Self>;
+}
+
+/// Generates an arbitrary node for the given `level` in the tree, ensuring that the index is in
+/// bounds.
+fn arbitrary_node_for_level(level: u8) -> impl Strategy<Value = (u64, NodeValue)> + Clone {
+    let limit = 2u64.pow(level as u32);
+
+    (0..limit).prop_flat_map(|i| (Just(i), any::<NodeValue>())).prop_filter_map(
+        "Invalid node index for level",
+        move |(i, v)| {
+            if i < 2u64.pow(level as u32) { Some((i, v)) } else { None }
+        },
+    )
+}
+
+/// Generates a set of arbitrary nodes for the given `level` in the tree, ensuring that the indices
+/// are in bounds.
+fn arbitrary_nodes_for_level(level: u8) -> impl Strategy<Value = Vec<(u64, NodeValue)>> + Clone {
+    prop::collection::vec(arbitrary_node_for_level(level), 0..=100)
+}
+
+/// Generates a set of arbitrary nodes for a random depth.
+fn arbitrary_nodes_for_depth(
+    level: u8,
+) -> impl Strategy<Value = (u8, Vec<(u64, NodeValue)>)> + Clone {
+    (Just(level), arbitrary_nodes_for_level(level))
+}
+
+/// Generates an arbitrary set of nodes.
+fn arbitrary_nodes() -> impl Strategy<Value = Map<u8, Vec<(u64, NodeValue)>>> {
+    prop::collection::vec(1u8..64, 0..=1000)
+        .prop_flat_map(|depths| {
+            depths.into_iter().map(arbitrary_nodes_for_depth).collect::<Vec<_>>()
+        })
+        .prop_map(|nodes| nodes.into_iter().collect::<Map<_, _>>())
+}
+
+/// Generates a leaf with a single, arbitrary entry.
+fn arbitrary_single_leaf() -> impl Strategy<Value = SmtLeaf> {
+    (arbitrary_valid_word(), arbitrary_valid_word())
+        .prop_map(|(key, value)| SmtLeaf::new_single(key, value))
+}
+
+/// Generates a leaf with multiple entries, all ensured to share the same leaf index.
+fn arbitrary_multi_leaf() -> impl Strategy<Value = SmtLeaf> {
+    prop::collection::vec((arbitrary_valid_word(), arbitrary_valid_word()), 2..=64).prop_map(
+        |pairs| {
+            let Some((first_key, _)) = pairs.first() else {
+                panic!("Minimum requested length is 2 but the pairs vec was empty.")
+            };
+
+            let index = LeafIndex::from(*first_key);
+            SmtLeaf::new_multiple(
+                pairs
+                    .into_iter()
+                    .map(|(mut key, value)| {
+                        key.d = Felt::new_unchecked(index.position());
+                        (key, value)
+                    })
+                    .collect::<Vec<_>>(),
+            )
+            .expect("All keys have the same leaf index by construction")
+        },
+    )
+}
+
+/// Generates an arbitrary `SmtLeaf`.
+fn arbitrary_leaf() -> impl Strategy<Value = SmtLeaf> {
+    prop_oneof![
+        any::<u64>().prop_map(|i| SmtLeaf::new_empty(LeafIndex::new_max_depth(i))),
+        arbitrary_single_leaf(),
+        arbitrary_multi_leaf(),
+    ]
+}
+
+/// Generates an arbitrary number of leaves.
+pub fn arbitrary_leaves() -> impl Strategy<Value = Vec<(u64, SmtLeaf)>> {
+    prop::collection::vec(arbitrary_leaf(), 0..100).prop_map(|leaves| {
+        leaves
+            .into_iter()
+            .map(|l| {
+                let index = l.index().position();
+                (index, l)
+            })
+            .collect::<Vec<_>>()
+    })
+}
+
+// UNIQUE NODES TESTS
+// ================================================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(50))]
+
+    #[test]
+    fn unique_nodes_serialization_always_roundtrips(
+        root in arbitrary_valid_word(),
+        nodes in arbitrary_nodes(),
+        leaves in arbitrary_leaves(),
+    ) {
+        let value = UniqueNodes { root, nodes, leaves };
+        let serialized = value.to_bytes();
+        let result = UniqueNodes::read_from_bytes(serialized.as_slice());
+
+        prop_assert_eq!(result, Ok(value));
+    }
+}
+
+// NODE VALUE TESTS
+// ================================================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(100_000))]
+
+    #[test]
+    fn node_value_serialization_always_roundtrips(
+        value in any::<NodeValue>()
+    ) {
+        let serialized = value.to_bytes();
+        let result = NodeValue::read_from_bytes(serialized.as_slice());
+
+        prop_assert_eq!(result, Ok(value));
+    }
+}

--- a/miden-crypto/src/merkle/smt/partial/serialization/tests.rs
+++ b/miden-crypto/src/merkle/smt/partial/serialization/tests.rs
@@ -1,0 +1,152 @@
+#![cfg(test)]
+//! The basic handwritten tests for the serialization functionality of the partial SMT.
+
+mod unique_nodes {
+    use miden_field::{Felt, Word};
+    use miden_serde_utils::{Deserializable, Serializable};
+
+    use crate::{
+        merkle::smt::{LeafIndex, NodeValue, SmtLeaf, UniqueNodes},
+        rand::test_utils::ContinuousRng,
+    };
+
+    #[test]
+    fn empty_unique_nodes_roundtrips() {
+        let value = UniqueNodes::empty();
+        assert_eq!(UniqueNodes::read_from_bytes(&value.to_bytes()), Ok(value))
+    }
+
+    #[test]
+    fn unique_nodes_roundtrips() {
+        let mut rng = ContinuousRng::new([0x67; 32]);
+
+        let level_1_depth = 6u8;
+        let level_1_nodes = vec![
+            (0u64, NodeValue::EmptySubtreeRoot),
+            (2u64.pow(3), NodeValue::Present(rng.value())),
+            (2u64.pow(6) - 1, NodeValue::Present(rng.value())),
+        ];
+
+        let level_2_depth = 61u8;
+        let level_2_nodes = vec![
+            (0u64, NodeValue::EmptySubtreeRoot),
+            (2u64.pow(12), NodeValue::Present(rng.value())),
+            (2u64.pow(14) - 1, NodeValue::Present(rng.value())),
+            (2u64.pow(58) + 31, NodeValue::Present(rng.value())),
+        ];
+
+        let leaf_1_index = u64::MAX;
+        let leaf_1_value = SmtLeaf::new_empty(LeafIndex::new_max_depth(leaf_1_index));
+
+        let leaf_2_index = 2u64.pow(32);
+        let leaf_2_value = SmtLeaf::new_single(rng.value(), rng.value());
+
+        let leaf_3_index = 12;
+        let leaf_index: Felt = rng.value();
+        let leaf_3_value = SmtLeaf::new_multiple(vec![
+            (Word::new([rng.value(), rng.value(), rng.value(), leaf_index]), rng.value()),
+            (Word::new([rng.value(), rng.value(), rng.value(), leaf_index]), rng.value()),
+            (Word::new([rng.value(), rng.value(), rng.value(), leaf_index]), rng.value()),
+        ])
+        .unwrap();
+
+        let mut value = UniqueNodes::empty();
+        value.root = rng.value();
+        value.nodes.insert(level_1_depth, level_1_nodes);
+        value.nodes.insert(level_2_depth, level_2_nodes);
+        value.leaves.push((leaf_1_index, leaf_1_value));
+        value.leaves.push((leaf_2_index, leaf_2_value));
+        value.leaves.push((leaf_3_index, leaf_3_value));
+
+        assert_eq!(UniqueNodes::read_from_bytes(&value.to_bytes()), Ok(value))
+    }
+}
+
+mod node_value {
+    use miden_field::{Felt, Word};
+    use miden_serde_utils::{Deserializable, Serializable};
+
+    use super::super::NodeValue;
+    use crate::rand::test_utils::ContinuousRng;
+
+    #[test]
+    fn empty_node_value_serializes_correctly() {
+        assert_eq!(NodeValue::EmptySubtreeRoot.to_bytes(), u64::MAX.to_le_bytes())
+    }
+
+    #[test]
+    fn word_node_value_serializes_correctly() {
+        // The limit values should both serialize to known values.
+        assert_eq!(NodeValue::Present(Word::empty()).to_bytes(), vec![0x00; 32]);
+        assert_eq!(
+            NodeValue::Present(Word::new([Felt::new_unchecked(Felt::ORDER - 1); 4])).to_bytes(),
+            vec![
+                0x00, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff, 0x00, 0x00, 0x00, 0x00, 0xff, 0xff,
+                0xff, 0xff, 0x00, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff, 0x00, 0x00, 0x00, 0x00,
+                0xff, 0xff, 0xff, 0xff,
+            ]
+        );
+
+        // It should always produce the same bytes as serializing the word directly.
+        let mut rng = ContinuousRng::new([0x42; 32]);
+        let rand_word: Word = rng.value();
+        assert_eq!(NodeValue::Present(rand_word).to_bytes(), rand_word.to_bytes());
+    }
+
+    #[test]
+    fn empty_node_value_deserializes_correctly() {
+        assert_eq!(
+            NodeValue::read_from_bytes(&u64::MAX.to_le_bytes()),
+            Ok(NodeValue::EmptySubtreeRoot)
+        );
+        assert_eq!(
+            NodeValue::read_from_bytes(&u64::MAX.to_le_bytes()),
+            Ok(NodeValue::EmptySubtreeRoot)
+        );
+    }
+
+    #[test]
+    fn word_node_value_deserializes_correctly() {
+        // The limit values should both deserialize from known values.
+        assert_eq!(NodeValue::read_from_bytes(&[0x00; 32]), Ok(NodeValue::Present(Word::empty())));
+        assert_eq!(
+            NodeValue::read_from_bytes(&[
+                0x00, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff, 0x00, 0x00, 0x00, 0x00, 0xff, 0xff,
+                0xff, 0xff, 0x00, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff, 0x00, 0x00, 0x00, 0x00,
+                0xff, 0xff, 0xff, 0xff,
+            ]),
+            Ok(NodeValue::Present(Word::new([Felt::new_unchecked(Felt::ORDER - 1); 4])))
+        );
+
+        // And a series of random valid word bytes should result in that same word being stored.
+        let mut rng = ContinuousRng::new([0x96; 32]);
+        let rand_word: Word = rng.value();
+        assert_eq!(
+            NodeValue::read_from_bytes(&rand_word.to_bytes()),
+            Ok(NodeValue::Present(rand_word))
+        );
+    }
+
+    #[test]
+    fn empty_node_value_roundtrips() {
+        let value = NodeValue::EmptySubtreeRoot;
+        assert_eq!(NodeValue::read_from_bytes(&value.to_bytes()), Ok(value));
+    }
+
+    #[test]
+    fn word_node_value_roundtrips() {
+        let mut rng = ContinuousRng::new([0x69; 32]);
+        let rand_word: Word = rng.value();
+        let value = NodeValue::Present(rand_word);
+        assert_eq!(NodeValue::read_from_bytes(&value.to_bytes()), Ok(value));
+
+        let failing_word = Word::new([
+            Felt::new_unchecked(3603862270821680383),
+            Felt::new_unchecked(0),
+            Felt::new_unchecked(0),
+            Felt::new_unchecked(0),
+        ]);
+        let value = NodeValue::Present(failing_word);
+        assert_eq!(NodeValue::read_from_bytes(&value.to_bytes()), Ok(value));
+    }
+}

--- a/miden-crypto/src/merkle/smt/partial/tests.rs
+++ b/miden-crypto/src/merkle/smt/partial/tests.rs
@@ -1,20 +1,24 @@
-use alloc::collections::{BTreeMap, BTreeSet};
+use alloc::{
+    collections::{BTreeMap, BTreeSet},
+    vec::Vec,
+};
 
 use assert_matches::assert_matches;
+use itertools::Itertools;
 use proptest::prelude::*;
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha20Rng;
 
-use super::{PartialSmt, SMT_DEPTH};
+use super::{PartialSmt, SMT_DEPTH, serialization::property_tests::arbitrary_valid_word};
 use crate::{
     EMPTY_WORD, Felt, ONE, Word, ZERO,
     merkle::{
         EmptySubtreeRoots, MerkleError,
         smt::{Smt, SmtLeaf},
     },
+    rand::test_utils::ContinuousRng,
     utils::{Deserializable, Serializable},
 };
-
 // Note: Word's Arbitrary implementation is in word/mod.rs, gated by cfg(any(test, feature =
 // "testing"))
 
@@ -29,7 +33,7 @@ fn random_word<R: Rng>(rng: &mut R) -> Word {
     ])
 }
 
-/// Tests that a partial SMT constructed from a root is well behaved and returns expected
+/// Tests that a partial SMT constructed from a root is well-behaved, and returns expected
 /// values.
 #[test]
 fn partial_smt_new_with_no_entries() {
@@ -417,6 +421,9 @@ fn partial_smt_serialization_roundtrip() {
     let bytes = partial_smt.to_bytes();
     let decoded = PartialSmt::read_from_bytes(&bytes).unwrap();
 
+    assert_eq!(partial_smt.num_entries, decoded.num_entries);
+    assert_eq!(partial_smt.root(), decoded.root());
+
     assert_eq!(partial_smt, decoded);
 }
 
@@ -723,11 +730,99 @@ fn partial_smt_deserialize_leaves_count_larger() {
     assert!(result.is_err());
 }
 
+// UNIQUE NODES TESTS
+// ================================================================================================
+
+#[test]
+fn unique_nodes_roundtrips() {
+    let mut rng = ContinuousRng::new([0x96; 32]);
+
+    // Set up our tree, starting as an empty tree root and then inserting a few values.
+    let mut tree = PartialSmt::new(*EmptySubtreeRoots::entry(SMT_DEPTH, 0));
+    for _ in 0..200 {
+        tree.insert(rng.value(), rng.value()).unwrap();
+    }
+
+    // We then convert it to its representation as unique nodes.
+    let uniques = tree.to_unique_nodes();
+
+    // The leaves in the unique representation should be exactly the same leaves as were stored by
+    // the original tree.
+    let original_leaves = tree
+        .leaves()
+        .sorted_by_key(|(k, _)| *k)
+        .map(|(k, v)| (k.position(), v.clone()))
+        .collect::<Vec<_>>();
+    let unique_leaves = uniques
+        .leaves
+        .iter()
+        .sorted_by_key(|(k, _)| *k)
+        .map(|(k, v)| (*k, v.clone()))
+        .collect::<Vec<_>>();
+    assert_eq!(unique_leaves, original_leaves);
+
+    // Finally, the unique representation should result in the same tree.
+    let reconstituted_tree =
+        PartialSmt::from_unique_nodes(uniques).expect("No data corruption has occurred in memory");
+    assert_eq!(reconstituted_tree, tree);
+}
+
+#[test]
+fn unique_nodes_of_exclusion_proofs_roundtrips() {}
+
+#[test]
+fn unique_nodes_serialization_roundtrips() {
+    let mut rng = ContinuousRng::new([0xab; 32]);
+
+    // Set up our tree, starting as an empty tree root and then inserting a few values.
+    let mut tree = PartialSmt::new(*EmptySubtreeRoots::entry(SMT_DEPTH, 0));
+    for _ in 0..200 {
+        tree.insert(rng.value(), rng.value()).unwrap();
+    }
+
+    // We then check that the serialization round-trips correctly.
+    assert_eq!(PartialSmt::read_from_bytes(&tree.to_bytes()), Ok(tree));
+}
+
 // PROPTEST-BASED TESTS
 // ================================================================================================
 // These tests use proptest's Arbitrary trait, which is no_std compatible with the `alloc` feature.
 
 proptest! {
+    /// Conversion to and from unique nodes should always round-trip to the same tree.
+    #[test]
+    fn prop_unique_nodes_roundtrips(
+        kv_pairs in prop::collection::vec((arbitrary_valid_word(), arbitrary_valid_word()), 0..100),
+    ) {
+        let mut smt = PartialSmt::new(*EmptySubtreeRoots::entry(SMT_DEPTH, 0));
+
+        for (k, v) in kv_pairs {
+            smt.insert(k, v)?;
+        }
+
+        let unique = smt.to_unique_nodes();
+        let result = PartialSmt::from_unique_nodes(unique)?;
+
+        prop_assert_eq!(result, smt);
+    }
+
+    /// Deserialization of the serialized blob should always result in the same value.
+    #[test]
+    fn prop_serde_roundtrips(
+        kv_pairs in prop::collection::vec((arbitrary_valid_word(), arbitrary_valid_word()), 0..100),
+    ) {
+        let mut smt = PartialSmt::new(*EmptySubtreeRoots::entry(SMT_DEPTH, 0));
+
+        for (k, v) in kv_pairs {
+            smt.insert(k, v)?;
+        }
+
+        let bytes = smt.to_bytes();
+        let result = PartialSmt::read_from_bytes(&bytes)?;
+
+        prop_assert_eq!(result, smt);
+    }
+
     /// Property test: inserting a value into an empty partial SMT and then reading it back
     /// should return the same value.
     #[test]

--- a/miden-crypto/src/merkle/smt/partial/tests.rs
+++ b/miden-crypto/src/merkle/smt/partial/tests.rs
@@ -2,6 +2,7 @@ use alloc::{
     collections::{BTreeMap, BTreeSet},
     vec::Vec,
 };
+use std::println;
 
 use assert_matches::assert_matches;
 use itertools::Itertools;
@@ -13,7 +14,7 @@ use super::{PartialSmt, SMT_DEPTH, serialization::property_tests::arbitrary_vali
 use crate::{
     EMPTY_WORD, Felt, ONE, Word, ZERO,
     merkle::{
-        EmptySubtreeRoots, MerkleError,
+        EmptySubtreeRoots, MerkleError, NodeIndex,
         smt::{Smt, SmtLeaf},
     },
     rand::test_utils::ContinuousRng,
@@ -768,7 +769,43 @@ fn unique_nodes_roundtrips() {
 }
 
 #[test]
-fn unique_nodes_of_exclusion_proofs_roundtrips() {}
+fn unique_nodes_of_exclusion_proofs_roundtrips() {
+    let mut rng = ChaCha20Rng::from_seed([10u8; 32]);
+    let key = random_word(&mut rng);
+    let val = random_word(&mut rng);
+    let key_1 = random_word(&mut rng);
+    let val_1 = random_word(&mut rng);
+    let key_2 = random_word(&mut rng);
+    let val_2 = random_word(&mut rng);
+    let missing_key = random_word(&mut rng);
+    let smt: Smt = Smt::with_entries([(key, val), (key_1, val_1), (key_2, val_2)]).unwrap();
+
+    let partial_smt = PartialSmt::from_proofs([smt.open(&missing_key)]).unwrap();
+
+    println!("Partial SMT:");
+    partial_smt
+        .inner_nodes
+        .iter()
+        .sorted_by_key(|(i, _)| **i)
+        .for_each(|(ix, v)| println!("{ix}: {v:?}"));
+
+    let unique_nodes = partial_smt.to_unique_nodes();
+    println!("Unique Nodes:");
+    unique_nodes
+        .nodes
+        .iter()
+        .sorted_by_key(|(depth, _)| *depth)
+        .for_each(|(d, nodes)| {
+            nodes.iter().sorted_by_key(|(depth, _)| *depth).for_each(|(p, v)| {
+                let ix = NodeIndex::new_unchecked(*d, *p);
+                println!("{ix}: {v:?}");
+            })
+        });
+
+    let decoded = PartialSmt::from_unique_nodes(unique_nodes).unwrap();
+
+    assert_eq!(partial_smt, decoded);
+}
 
 #[test]
 fn unique_nodes_serialization_roundtrips() {


### PR DESCRIPTION
This adds a `partial_smt` fuzz target for `PartialSmt::read_from_bytes`.

The target checks raw byte input, like the existing serde fuzz targets. It also builds valid `UniqueNodes` payloads from fuzz input, with varied roots, nodes, leaves, and missing node data. This gives the fuzzer a better path into `PartialSmt` reconstruction instead of failing early during byte parsing.

A focused missing-node case covers the panic path found where malformed compact input can reach missing reconstruction data.

The fuzz target is wired into the Makefile and the scheduled fuzz CI matrix.