### PR TITLE
fix: correct format string in periodic.rs assert to avoid named argument

### DIFF
--- a/stark/miden-lifted-stark/src/prover/periodic.rs
+++ b/stark/miden-lifted-stark/src/prover/periodic.rs
@@ -55,7 +55,8 @@ impl<F: TwoAdicField> PeriodicLde<F> {
         let log_max_period = log2_strict_u8(max_period);
         assert!(
             coset.log_trace_height >= log_max_period,
-            "periodic column period ({max_period}) exceeds trace height ({})",
+            "periodic column period ({}) exceeds trace height ({})",
+            max_period,
             1 << coset.log_trace_height as usize,
         );
         let log_blowup = coset.log_blowup();


### PR DESCRIPTION
## Problem
The assert! in PeriodicLde::build uses a named format placeholder "{max_period}" but only a positional argument was provided, causing incorrect formatting or compilation issues when the assertion is evaluated.

## Fix
Replace the incorrect formatting with a standard positional format:
- Before: "periodic column period ({max_period}) exceeds trace height ({})", 1 << coset... 
- After: "periodic column period ({}) exceeds trace height ({})", max_period, 1 << coset...

## Why this is safe
- This changes only the formatting of an assertion message and does not alter any logic or data flow.
- It eliminates a potential compile-time formatting error and provides a correct, informative error message when the assertion fails.
- No public API changes; behavior remains the same aside from clearer error reporting.
