### PR TITLE
feat(merkle): add Merkle frontier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [BREAKING] Reorganized `miden-lifted-stark` internals: consolidated `align`, `bitrev`, `horner`, and `packing` helpers under a new `util` module; removed the legacy `fri::*` re-export facade ([#1000](https://github.com/0xMiden/crypto/pull/1000)).
 - [BREAKING] Extracted `BackendReader`, allowing `LargeSmtForest<S>` to work with read-only storage backends ([#986](https://github.com/0xMiden/crypto/pull/986)).
 - [BREAKING] Refactored `miden-lifted-stark::domain` around a uniform `Coset` trait shared by `TwoAdicSubgroup` and `TwoAdicCoset`, slimmed the `LiftedDomain` surface (drops dead getters, removes silently-dispatched `points`/`bit_reversed_points`/`vanishing_at` in favour of explicit `trace_subgroup()` / `lde_coset()` access), made `LiftedDomain` constructors fallible, moved selector logic onto `LiftedDomain`, and changed `log_blowup` to return `u8` ([#993](https://github.com/0xMiden/crypto/pull/993)).
+- Added `MerkleFrontier` as append-only `len + peaks` state with a raw Merkle root, append support, legacy `MmrPeaks` conversion, and standard Merkle proof bridging that authenticates `(len, root)` during verification ([#984](https://github.com/0xMiden/crypto/pull/984)).
 
 ## 0.25.0 (2026-05-01)
 
@@ -16,7 +17,6 @@
 - Added `Signature::from_der()` for EdDSA signatures ([#979](https://github.com/0xMiden/crypto/pull/979)).
 - Fixed `SimpleSmt::set_subtree()` to clear stale leaves and inner nodes in the replaced subtree region ([#981](https://github.com/0xMiden/crypto/pull/981)).
 - Fixed `SliceReader` bounds checking to reject overflowing read lengths ([#987](https://github.com/0xMiden/crypto/pull/987)).
-- Added `MerkleFrontier` as append-only `len + peaks` state with a normal Merkle root commitment, append support, legacy `MmrPeaks` conversion, and standard Merkle proof bridging ([#984](https://github.com/0xMiden/crypto/pull/984)).
 
 ## 0.24.0 (2026-04-19)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Added `Signature::from_der()` for EdDSA signatures ([#979](https://github.com/0xMiden/crypto/pull/979)).
 - Fixed `SimpleSmt::set_subtree()` to clear stale leaves and inner nodes in the replaced subtree region ([#981](https://github.com/0xMiden/crypto/pull/981)).
 - Fixed `SliceReader` bounds checking to reject overflowing read lengths ([#987](https://github.com/0xMiden/crypto/pull/987)).
+- Added `MerkleFrontier` as append-only `len + peaks` state with a normal Merkle root commitment, append support, legacy `MmrPeaks` conversion, and standard Merkle proof bridging ([#984](https://github.com/0xMiden/crypto/pull/984)).
 
 ## 0.24.0 (2026-04-19)
 

--- a/miden-crypto/Cargo.toml
+++ b/miden-crypto/Cargo.toml
@@ -41,6 +41,11 @@ required-features = ["std"]
 
 [[bench]]
 harness           = false
+name              = "mmr"
+required-features = ["std"]
+
+[[bench]]
+harness           = false
 name              = "partial_mt"
 required-features = ["std"]
 

--- a/miden-crypto/benches/mmr.rs
+++ b/miden-crypto/benches/mmr.rs
@@ -1,0 +1,208 @@
+//! Merkle Mountain Range frontier benchmarks.
+//!
+//! These benchmarks compare the legacy peak-hash commitment API with the rooted frontier API.
+
+use std::hint;
+
+use criterion::{BatchSize, BenchmarkId, Criterion, criterion_group, criterion_main};
+use miden_crypto::{
+    Word,
+    merkle::mmr::{MerkleFrontier, Mmr, MmrPeaks},
+};
+
+mod common;
+use common::{
+    config::{DEFAULT_MEASUREMENT_TIME, DEFAULT_SAMPLE_SIZE},
+    data::{WordPattern, generate_word_pattern, generate_words_pattern},
+};
+
+// Includes mixed sizes plus 2^k - 1 / 2^k pairs to expose hamming-weight effects.
+const MMR_SIZES: &[usize] = &[1_000, 1_023, 1_024, 50_000, 65_535, 65_536];
+
+struct MmrBenchData {
+    mmr: Mmr,
+    peaks: MmrPeaks,
+    frontier: MerkleFrontier,
+    leaf_pos: usize,
+    leaf: Word,
+}
+
+fn build_mmr(size: usize) -> Mmr {
+    Mmr::try_from_iter(generate_words_pattern(size, WordPattern::Sequential)).unwrap()
+}
+
+fn build_data(size: usize) -> MmrBenchData {
+    let mmr = build_mmr(size);
+    let peaks = mmr.peaks();
+    let frontier = mmr.frontier();
+    let leaf_pos = 0;
+    let leaf = generate_word_pattern(leaf_pos as u64, WordPattern::Sequential);
+
+    MmrBenchData { mmr, peaks, frontier, leaf_pos, leaf }
+}
+
+// === MMR Commitment Benchmarks ===
+
+fn bench_mmr_commitments(c: &mut Criterion) {
+    let mut group = c.benchmark_group("mmr-commitment");
+    group.measurement_time(DEFAULT_MEASUREMENT_TIME);
+    group.sample_size(DEFAULT_SAMPLE_SIZE);
+
+    for &size in MMR_SIZES {
+        group.bench_with_input(BenchmarkId::new("legacy-hash-peaks", size), &size, |b, &size| {
+            let data = build_data(size);
+            b.iter(|| {
+                hint::black_box(data.peaks.hash_peaks());
+            });
+        });
+
+        group.bench_with_input(BenchmarkId::new("frontier-root", size), &size, |b, &size| {
+            let data = build_data(size);
+            b.iter(|| {
+                hint::black_box(data.frontier.root());
+            });
+        });
+    }
+
+    group.finish();
+}
+
+// === MMR Append Benchmarks ===
+
+fn bench_mmr_append(c: &mut Criterion) {
+    let mut group = c.benchmark_group("mmr-append");
+    group.measurement_time(DEFAULT_MEASUREMENT_TIME);
+    group.sample_size(DEFAULT_SAMPLE_SIZE);
+
+    for &size in MMR_SIZES {
+        group.bench_with_input(BenchmarkId::new("frontier-append", size), &size, |b, &size| {
+            let data = build_data(size);
+            let next_leaf = generate_word_pattern(size as u64, WordPattern::Sequential);
+
+            b.iter_batched(
+                || data.frontier.clone(),
+                |mut frontier| {
+                    frontier.append(hint::black_box(next_leaf)).unwrap();
+                    hint::black_box(frontier);
+                },
+                BatchSize::SmallInput,
+            );
+        });
+
+        group.bench_with_input(
+            BenchmarkId::new("frontier-append-and-root", size),
+            &size,
+            |b, &size| {
+                let data = build_data(size);
+                let next_leaf = generate_word_pattern(size as u64, WordPattern::Sequential);
+
+                b.iter_batched(
+                    || data.frontier.clone(),
+                    |mut frontier| {
+                        frontier.append(hint::black_box(next_leaf)).unwrap();
+                        hint::black_box(frontier.root());
+                    },
+                    BatchSize::SmallInput,
+                );
+            },
+        );
+    }
+
+    group.finish();
+}
+
+// === MMR Proof Opening Benchmarks ===
+
+fn bench_mmr_open(c: &mut Criterion) {
+    let mut group = c.benchmark_group("mmr-open");
+    group.measurement_time(DEFAULT_MEASUREMENT_TIME);
+    group.sample_size(DEFAULT_SAMPLE_SIZE);
+
+    for &size in MMR_SIZES {
+        group.bench_with_input(BenchmarkId::new("legacy-proof", size), &size, |b, &size| {
+            let data = build_data(size);
+
+            b.iter(|| {
+                hint::black_box(data.mmr.open(data.leaf_pos).unwrap());
+            });
+        });
+
+        group.bench_with_input(BenchmarkId::new("frontier-proof", size), &size, |b, &size| {
+            let data = build_data(size);
+
+            b.iter(|| {
+                hint::black_box(data.mmr.open_frontier(data.leaf_pos).unwrap());
+            });
+        });
+    }
+
+    group.finish();
+}
+
+// === MMR Proof Verification Benchmarks ===
+
+fn bench_mmr_verify(c: &mut Criterion) {
+    let mut group = c.benchmark_group("mmr-verify");
+    group.measurement_time(DEFAULT_MEASUREMENT_TIME);
+    group.sample_size(DEFAULT_SAMPLE_SIZE);
+
+    for &size in MMR_SIZES {
+        group.bench_with_input(BenchmarkId::new("legacy-peak-local", size), &size, |b, &size| {
+            let data = build_data(size);
+            let proof = data.mmr.open(data.leaf_pos).unwrap();
+
+            b.iter(|| {
+                data.peaks
+                    .verify(hint::black_box(data.leaf), hint::black_box(proof.clone()))
+                    .unwrap();
+            });
+        });
+
+        group.bench_with_input(
+            BenchmarkId::new("legacy-committed-peaks", size),
+            &size,
+            |b, &size| {
+                let data = build_data(size);
+                let commitment = data.peaks.hash_peaks();
+                let proof = data.mmr.open(data.leaf_pos).unwrap();
+
+                b.iter(|| {
+                    assert_eq!(data.peaks.hash_peaks(), hint::black_box(commitment));
+                    data.peaks
+                        .verify(hint::black_box(data.leaf), hint::black_box(proof.clone()))
+                        .unwrap();
+                });
+            },
+        );
+
+        group.bench_with_input(BenchmarkId::new("frontier-root", size), &size, |b, &size| {
+            let data = build_data(size);
+            let root = data.frontier.root();
+            let proof = data.mmr.open_frontier(data.leaf_pos).unwrap();
+
+            b.iter(|| {
+                proof
+                    .path
+                    .verify(
+                        data.leaf_pos as u64,
+                        hint::black_box(proof.value),
+                        hint::black_box(&root),
+                    )
+                    .unwrap();
+            });
+        });
+    }
+
+    group.finish();
+}
+
+// === Benchmark Group Definition ===
+
+criterion_group!(
+    mmr_benches,
+    bench_mmr_commitments,
+    bench_mmr_append,
+    bench_mmr_open,
+    bench_mmr_verify,
+);
+criterion_main!(mmr_benches);

--- a/miden-crypto/benches/mmr.rs
+++ b/miden-crypto/benches/mmr.rs
@@ -175,20 +175,21 @@ fn bench_mmr_verify(c: &mut Criterion) {
             },
         );
 
-        group.bench_with_input(BenchmarkId::new("frontier-root", size), &size, |b, &size| {
+        group.bench_with_input(BenchmarkId::new("frontier-len-root", size), &size, |b, &size| {
             let data = build_data(size);
+            let len = data.frontier.len();
             let root = data.frontier.root();
             let proof = data.mmr.open_frontier(data.leaf_pos).unwrap();
 
             b.iter(|| {
-                proof
-                    .path
-                    .verify(
-                        data.leaf_pos as u64,
-                        hint::black_box(proof.value),
-                        hint::black_box(&root),
-                    )
-                    .unwrap();
+                MerkleFrontier::verify_leaf(
+                    hint::black_box(len),
+                    hint::black_box(root),
+                    hint::black_box(data.leaf_pos),
+                    hint::black_box(proof.value),
+                    hint::black_box(&proof.path),
+                )
+                .unwrap();
             });
         });
     }

--- a/miden-crypto/src/merkle/mmr/error.rs
+++ b/miden-crypto/src/merkle/mmr/error.rs
@@ -12,6 +12,8 @@ pub enum MmrError {
     InvalidPeaks(String),
     #[error("mmr forest is out of bounds: requested {0} > current {1}")]
     ForestOutOfBounds(usize, usize),
+    #[error("mmr proof forest has {proof} leaves but frontier has {frontier} leaves")]
+    InconsistentProofForest { proof: usize, frontier: usize },
     #[error("mmr forest size {requested} exceeds maximum {max}")]
     ForestSizeExceeded { requested: usize, max: usize },
     #[error("mmr peak does not match the computed merkle root of the provided authentication path")]

--- a/miden-crypto/src/merkle/mmr/frontier.rs
+++ b/miden-crypto/src/merkle/mmr/frontier.rs
@@ -1,0 +1,305 @@
+//! A compact rooted frontier for append-only Merkle trees.
+//!
+//! A [`MerkleFrontier`] stores the next leaf index (`len`) and the full left subtrees (`peaks`) on
+//! the path to that next leaf. Empty right subtrees are implied, and the public commitment is the
+//! Merkle root obtained by folding this path.
+
+use alloc::vec::Vec;
+
+use super::{Forest, MmrError, MmrPeaks, MmrProof};
+use crate::{
+    Word,
+    hash::poseidon2::Poseidon2,
+    merkle::{EmptySubtreeRoots, MerkleError, MerklePath, MerkleProof},
+    utils::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable},
+};
+
+// MERKLE FRONTIER
+// ================================================================================================
+
+/// A compact rooted frontier for an append-only Merkle tree.
+///
+/// The peaks are ordered from largest subtree to smallest subtree, matching [`MmrPeaks`].
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
+pub struct MerkleFrontier {
+    /// The next leaf index in the append-only tree.
+    len: usize,
+
+    /// Full left subtrees on the path to `len`, ordered largest to smallest.
+    peaks: Vec<Word>,
+}
+
+impl MerkleFrontier {
+    // CONSTRUCTORS
+    // --------------------------------------------------------------------------------------------
+
+    /// Returns a new [`MerkleFrontier`] instantiated from the specified length and peaks.
+    ///
+    /// # Errors
+    /// Returns an error if the length exceeds the maximum supported forest size, or if the number
+    /// of peaks does not match the number of full subtrees encoded by `len`.
+    pub fn new(len: usize, peaks: Vec<Word>) -> Result<Self, MmrError> {
+        validate_frontier(len, peaks.len())?;
+        Ok(Self { len, peaks })
+    }
+
+    // ACCESSORS
+    // --------------------------------------------------------------------------------------------
+
+    /// Returns the next leaf index in the append-only tree.
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    /// Returns true if this frontier has no leaves.
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    /// Returns the number of leaves currently committed by this frontier.
+    pub fn num_leaves(&self) -> usize {
+        self.len
+    }
+
+    /// Returns the number of peaks in this frontier.
+    pub fn num_peaks(&self) -> usize {
+        self.peaks.len()
+    }
+
+    /// Returns the peaks in largest-to-smallest order.
+    pub fn peaks(&self) -> &[Word] {
+        &self.peaks
+    }
+
+    /// Converts this frontier into its components.
+    pub fn into_parts(self) -> (usize, Vec<Word>) {
+        (self.len, self.peaks)
+    }
+
+    /// Converts this frontier into legacy [`MmrPeaks`] state.
+    pub fn into_legacy_peaks(self) -> MmrPeaks {
+        let forest = Forest::new(self.len).expect("frontier length must be valid");
+        MmrPeaks::new(forest, self.peaks).expect("frontier peaks must be valid")
+    }
+
+    // FUNCTIONALITY
+    // --------------------------------------------------------------------------------------------
+
+    /// Returns the Merkle root of this frontier.
+    ///
+    /// The root is computed by folding the path to `len`: set bits consume peaks on the left and
+    /// unset bits imply empty subtrees on the right.
+    pub fn root(&self) -> Word {
+        if self.len == 0 {
+            return empty_subtree_root(0);
+        }
+
+        let mut bits = self.len;
+        let mut level = 0u8;
+        let mut peak_idx = self.peaks.len();
+        let mut acc = empty_subtree_root(0);
+
+        while bits != 0 {
+            if bits & 1 == 1 {
+                peak_idx -= 1;
+                acc = Poseidon2::merge(&[self.peaks[peak_idx], acc]);
+            } else {
+                acc = Poseidon2::merge(&[acc, empty_subtree_root(level)]);
+            }
+
+            bits >>= 1;
+            level += 1;
+        }
+
+        acc
+    }
+
+    /// Converts a peak-local MMR proof into a plain Merkle proof against this frontier's root.
+    ///
+    /// The input proof must be for the same forest length as this frontier. The returned path can
+    /// be verified with [`MerklePath::verify`] using the global leaf position and [`Self::root`].
+    pub fn to_merkle_proof(&self, opening: &MmrProof) -> Result<MerkleProof, MmrError> {
+        let proof_len = opening.forest().num_leaves();
+        if proof_len != self.len {
+            return Err(MmrError::InconsistentProofForest { proof: proof_len, frontier: self.len });
+        }
+
+        let peak_height = Forest::new(self.len)
+            .expect("frontier length must be valid")
+            .leaf_to_corresponding_tree(opening.position())
+            .ok_or(MmrError::PositionNotFound(opening.position()))? as u8;
+
+        if opening.merkle_path().depth() != peak_height {
+            return Err(MmrError::InvalidMerklePath(MerkleError::InvalidPathLength(
+                peak_height as usize,
+            )));
+        }
+
+        let mut nodes = opening.merkle_path().nodes().to_vec();
+        nodes.extend(self.path_from_peak_to_root(opening.peak_index())?);
+
+        Ok(MerkleProof::new(opening.leaf(), MerklePath::new(nodes)))
+    }
+
+    /// Appends a leaf to this frontier.
+    ///
+    /// # Errors
+    /// Returns an error if appending would exceed the maximum supported forest size.
+    pub fn append(&mut self, mut node: Word) -> Result<(), MmrError> {
+        if self.len >= Forest::MAX_LEAVES {
+            return Err(MmrError::ForestSizeExceeded {
+                requested: self.len.saturating_add(1),
+                max: Forest::MAX_LEAVES,
+            });
+        }
+
+        let mut n = self.len;
+        while n & 1 == 1 {
+            let left = self.peaks.pop().expect("peak must exist");
+            node = Poseidon2::merge(&[left, node]);
+            n >>= 1;
+        }
+        self.peaks.push(node);
+        self.len += 1;
+
+        Ok(())
+    }
+
+    // UTILITIES
+    // --------------------------------------------------------------------------------------------
+
+    fn path_from_peak_to_root(&self, target_peak_idx: usize) -> Result<Vec<Word>, MmrError> {
+        if target_peak_idx >= self.peaks.len() {
+            return Err(MmrError::PeakOutOfBounds {
+                peak_idx: target_peak_idx,
+                peaks_len: self.peaks.len(),
+            });
+        }
+
+        let frontier_depth = (usize::BITS - self.len.leading_zeros()) as u8;
+        let mut acc = empty_subtree_root(0);
+        let mut path = Vec::new();
+        let mut peak_cursor = self.peaks.len();
+        let mut contains_target = false;
+
+        for level in 0..frontier_depth {
+            if (self.len >> level) & 1 == 1 {
+                peak_cursor -= 1;
+                let peak = self.peaks[peak_cursor];
+                if peak_cursor == target_peak_idx {
+                    contains_target = true;
+                    path.push(acc);
+                } else if contains_target {
+                    path.push(peak);
+                }
+                acc = Poseidon2::merge(&[peak, acc]);
+            } else {
+                let empty = empty_subtree_root(level);
+                if contains_target {
+                    path.push(empty);
+                }
+                acc = Poseidon2::merge(&[acc, empty]);
+            }
+        }
+
+        Ok(path)
+    }
+}
+
+// CONVERSIONS
+// ================================================================================================
+
+impl From<MmrPeaks> for MerkleFrontier {
+    fn from(peaks: MmrPeaks) -> Self {
+        let (forest, peaks) = peaks.into_parts();
+        Self { len: forest.num_leaves(), peaks }
+    }
+}
+
+impl From<&MmrPeaks> for MerkleFrontier {
+    fn from(peaks: &MmrPeaks) -> Self {
+        Self {
+            len: peaks.num_leaves(),
+            peaks: peaks.peaks().to_vec(),
+        }
+    }
+}
+
+impl From<MerkleFrontier> for MmrPeaks {
+    fn from(frontier: MerkleFrontier) -> Self {
+        frontier.into_legacy_peaks()
+    }
+}
+
+// SERIALIZATION
+// ================================================================================================
+
+impl Serializable for MerkleFrontier {
+    fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        self.len.write_into(target);
+        self.peaks.write_into(target);
+    }
+}
+
+impl Deserializable for MerkleFrontier {
+    fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
+        let len = usize::read_from(source)?;
+        if !Forest::is_valid_size(len) {
+            return Err(DeserializationError::InvalidValue(format!(
+                "frontier length {len} exceeds maximum {}",
+                Forest::MAX_LEAVES
+            )));
+        }
+
+        let num_peaks = usize::read_from(source)?;
+        validate_frontier(len, num_peaks).map_err(|err| {
+            DeserializationError::InvalidValue(format!("invalid frontier: {err}"))
+        })?;
+
+        let peaks = source.read_many_iter(num_peaks)?.collect::<Result<_, _>>()?;
+        Self::new(len, peaks)
+            .map_err(|err| DeserializationError::InvalidValue(format!("invalid frontier: {err}")))
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for MerkleFrontier {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(serde::Deserialize)]
+        struct MerkleFrontierParts {
+            len: usize,
+            peaks: Vec<Word>,
+        }
+
+        let parts = MerkleFrontierParts::deserialize(deserializer)?;
+        MerkleFrontier::new(parts.len, parts.peaks).map_err(serde::de::Error::custom)
+    }
+}
+
+// HELPER FUNCTIONS
+// ================================================================================================
+
+fn validate_frontier(len: usize, num_peaks: usize) -> Result<(), MmrError> {
+    if !Forest::is_valid_size(len) {
+        return Err(MmrError::ForestSizeExceeded { requested: len, max: Forest::MAX_LEAVES });
+    }
+
+    let forest = Forest::new(len).expect("frontier length has been validated");
+    if forest.num_trees() != num_peaks {
+        return Err(MmrError::InvalidPeaks(format!(
+            "number of one bits in len is {} which does not equal peak length {}",
+            forest.num_trees(),
+            num_peaks
+        )));
+    }
+
+    Ok(())
+}
+
+fn empty_subtree_root(height: u8) -> Word {
+    *EmptySubtreeRoots::entry(height, 0)
+}

--- a/miden-crypto/src/merkle/mmr/frontier.rs
+++ b/miden-crypto/src/merkle/mmr/frontier.rs
@@ -128,7 +128,9 @@ impl MerkleFrontier {
         let peak_height = Forest::new(self.len)
             .expect("frontier length must be valid")
             .leaf_to_corresponding_tree(opening.position())
-            .ok_or(MmrError::PositionNotFound(opening.position()))? as u8;
+            .ok_or(MmrError::PositionNotFound(opening.position()))?;
+        let peak_height =
+            u8::try_from(peak_height).expect("peak height bounded by Forest::MAX_LEAVES");
 
         if opening.merkle_path().depth() != peak_height {
             return Err(MmrError::InvalidMerklePath(MerkleError::InvalidPathLength(
@@ -179,7 +181,7 @@ impl MerkleFrontier {
 
         let frontier_depth = (usize::BITS - self.len.leading_zeros()) as u8;
         let mut acc = empty_subtree_root(0);
-        let mut path = Vec::new();
+        let mut path = Vec::with_capacity(frontier_depth as usize);
         let mut peak_cursor = self.peaks.len();
         let mut contains_target = false;
 
@@ -258,8 +260,7 @@ impl Deserializable for MerkleFrontier {
         })?;
 
         let peaks = source.read_many_iter(num_peaks)?.collect::<Result<_, _>>()?;
-        Self::new(len, peaks)
-            .map_err(|err| DeserializationError::InvalidValue(format!("invalid frontier: {err}")))
+        Ok(Self { len, peaks })
     }
 }
 

--- a/miden-crypto/src/merkle/mmr/frontier.rs
+++ b/miden-crypto/src/merkle/mmr/frontier.rs
@@ -115,7 +115,7 @@ impl MerkleFrontier {
         acc
     }
 
-    /// Converts a peak-local MMR proof into a plain Merkle proof against this frontier's root.
+    /// Converts a peak-local MMR proof into a standard Merkle proof against this frontier's root.
     ///
     /// The input proof must be for the same forest length as this frontier. The returned path can
     /// be verified with [`MerklePath::verify`] using the global leaf position and [`Self::root`].

--- a/miden-crypto/src/merkle/mmr/frontier.rs
+++ b/miden-crypto/src/merkle/mmr/frontier.rs
@@ -1,8 +1,9 @@
 //! A compact rooted frontier for append-only Merkle trees.
 //!
 //! A [`MerkleFrontier`] stores the next leaf index (`len`) and the full left subtrees (`peaks`) on
-//! the path to that next leaf. Empty right subtrees are implied, and the public commitment is the
-//! Merkle root obtained by folding this path.
+//! the path to that next leaf. Empty right subtrees are implied, and the raw Merkle root is
+//! obtained by folding this path. The authenticated frontier state is the pair `(len, root)`: the
+//! root alone does not distinguish real leaves from implied empty padding.
 
 use alloc::vec::Vec;
 
@@ -86,10 +87,12 @@ impl MerkleFrontier {
     // FUNCTIONALITY
     // --------------------------------------------------------------------------------------------
 
-    /// Returns the Merkle root of this frontier.
+    /// Returns the raw Merkle root of this frontier.
     ///
     /// The root is computed by folding the path to `len`: set bits consume peaks on the left and
-    /// unset bits imply empty subtrees on the right.
+    /// unset bits imply empty subtrees on the right. This root should be authenticated together
+    /// with [`Self::len`]; by itself, it does not bind the number of real leaves before the implied
+    /// empty padding.
     pub fn root(&self) -> Word {
         if self.len == 0 {
             return empty_subtree_root(0);
@@ -115,10 +118,41 @@ impl MerkleFrontier {
         acc
     }
 
+    /// Verifies a Merkle proof against this frontier.
+    ///
+    /// This treats the frontier's authenticated state as `(len, root)`: the position must be below
+    /// [`Self::len`] before the proof is verified against [`Self::root`].
+    pub fn verify(&self, position: usize, proof: &MerkleProof) -> Result<(), MmrError> {
+        Self::verify_leaf(self.len, self.root(), position, proof.value, &proof.path)
+    }
+
+    /// Verifies a leaf opening against an authenticated `(len, root)` frontier pair.
+    ///
+    /// This is the safe public check to use when a verifier receives only the frontier length and
+    /// raw root rather than the full [`MerkleFrontier`] state.
+    pub fn verify_leaf(
+        len: usize,
+        root: Word,
+        position: usize,
+        leaf: Word,
+        path: &MerklePath,
+    ) -> Result<(), MmrError> {
+        if !Forest::is_valid_size(len) {
+            return Err(MmrError::ForestSizeExceeded { requested: len, max: Forest::MAX_LEAVES });
+        }
+        if position >= len {
+            return Err(MmrError::PositionNotFound(position));
+        }
+
+        path.verify(position as u64, leaf, &root).map_err(MmrError::InvalidMerklePath)
+    }
+
     /// Converts a peak-local MMR proof into a standard Merkle proof against this frontier's root.
     ///
     /// The input proof must be for the same forest length as this frontier. The returned path can
-    /// be verified with [`MerklePath::verify`] using the global leaf position and [`Self::root`].
+    /// be verified with [`Self::verify`] using the global leaf position. If only the frontier
+    /// length and raw root are available, use [`Self::verify_leaf`] so the position is checked
+    /// against the authenticated length before calling [`MerklePath::verify`].
     pub fn to_merkle_proof(&self, opening: &MmrProof) -> Result<MerkleProof, MmrError> {
         let proof_len = opening.forest().num_leaves();
         if proof_len != self.len {

--- a/miden-crypto/src/merkle/mmr/full.rs
+++ b/miden-crypto/src/merkle/mmr/full.rs
@@ -119,10 +119,10 @@ impl Mmr {
     }
 
     /// Returns a standard Merkle proof for the leaf at the specified position against the rooted
-    /// frontier commitment.
+    /// frontier.
     ///
-    /// The returned proof can be verified with `MerklePath::verify` using
-    /// `self.frontier().root()` as the expected root.
+    /// The returned proof can be verified with [`MerkleFrontier::verify`] using the authenticated
+    /// frontier state `(len, root)`.
     pub fn open_frontier(&self, pos: usize) -> Result<MerkleProof, MmrError> {
         let opening = self.open(pos)?;
         self.frontier().to_merkle_proof(&opening)

--- a/miden-crypto/src/merkle/mmr/full.rs
+++ b/miden-crypto/src/merkle/mmr/full.rs
@@ -14,13 +14,14 @@ use alloc::vec::Vec;
 
 use super::{
     super::{InnerNodeInfo, MerklePath},
-    MmrDelta, MmrError, MmrPath, MmrPeaks, MmrProof,
+    MerkleFrontier, MmrDelta, MmrError, MmrPath, MmrPeaks, MmrProof,
     forest::{Forest, TreeSizeIterator},
     nodes_from_mask,
 };
 use crate::{
     Word,
     hash::poseidon2::Poseidon2,
+    merkle::MerkleProof,
     utils::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable},
 };
 
@@ -117,6 +118,16 @@ impl Mmr {
         self.open_at(pos, self.forest)
     }
 
+    /// Returns a standard Merkle proof for the leaf at the specified position against the rooted
+    /// frontier commitment.
+    ///
+    /// The returned proof can be verified with `MerklePath::verify` using
+    /// `self.frontier().root()` as the expected root.
+    pub fn open_frontier(&self, pos: usize) -> Result<MerkleProof, MmrError> {
+        let opening = self.open(pos)?;
+        self.frontier().to_merkle_proof(&opening)
+    }
+
     /// Returns an [MmrProof] for the leaf at the specified position using the state of the MMR
     /// at the specified `forest`.
     ///
@@ -187,6 +198,11 @@ impl Mmr {
     /// Returns the current peaks of the MMR.
     pub fn peaks(&self) -> MmrPeaks {
         self.peaks_at(self.forest).expect("failed to get peaks at current forest")
+    }
+
+    /// Returns the current rooted frontier of the MMR.
+    pub fn frontier(&self) -> MerkleFrontier {
+        self.peaks().into()
     }
 
     /// Returns the peaks of the MMR at the state specified by `forest`.

--- a/miden-crypto/src/merkle/mmr/mod.rs
+++ b/miden-crypto/src/merkle/mmr/mod.rs
@@ -3,6 +3,7 @@
 mod delta;
 mod error;
 mod forest;
+mod frontier;
 mod full;
 mod inorder;
 mod partial;
@@ -25,6 +26,7 @@ fn nodes_from_mask(mask: usize) -> usize {
 pub use delta::MmrDelta;
 pub use error::MmrError;
 pub use forest::Forest;
+pub use frontier::MerkleFrontier;
 pub use full::Mmr;
 pub use inorder::InOrderIndex;
 pub use partial::PartialMmr;

--- a/miden-crypto/src/merkle/mmr/partial.rs
+++ b/miden-crypto/src/merkle/mmr/partial.rs
@@ -266,10 +266,10 @@ impl PartialMmr {
     }
 
     /// Returns a standard Merkle proof for a tracked leaf against this partial MMR's rooted
-    /// frontier commitment.
+    /// frontier.
     ///
-    /// The returned proof can be verified with `MerklePath::verify` using
-    /// `self.frontier().root()` as the expected root.
+    /// The returned proof can be verified with [`MerkleFrontier::verify`] using the authenticated
+    /// frontier state `(len, root)`.
     pub fn open_frontier(&self, pos: usize) -> Result<Option<MerkleProof>, MmrError> {
         let Some(opening) = self.open(pos)? else {
             return Ok(None);

--- a/miden-crypto/src/merkle/mmr/partial.rs
+++ b/miden-crypto/src/merkle/mmr/partial.rs
@@ -265,15 +265,17 @@ impl PartialMmr {
         Ok(Some(MmrProof::new(path, leaf)))
     }
 
-    /// Returns a standard Merkle proof for a tracked leaf against this partial MMR's rooted frontier
-    /// commitment.
+    /// Returns a standard Merkle proof for a tracked leaf against this partial MMR's rooted
+    /// frontier commitment.
     ///
     /// The returned proof can be verified with `MerklePath::verify` using
     /// `self.frontier().root()` as the expected root.
     pub fn open_frontier(&self, pos: usize) -> Result<Option<MerkleProof>, MmrError> {
-        self.open(pos)?
-            .map(|opening| self.frontier().to_merkle_proof(&opening))
-            .transpose()
+        let Some(opening) = self.open(pos)? else {
+            return Ok(None);
+        };
+        let proof = self.frontier().to_merkle_proof(&opening)?;
+        Ok(Some(proof))
     }
 
     // ITERATORS

--- a/miden-crypto/src/merkle/mmr/partial.rs
+++ b/miden-crypto/src/merkle/mmr/partial.rs
@@ -4,12 +4,12 @@ use alloc::{
     vec::Vec,
 };
 
-use super::{MmrDelta, MmrPath, MmrProof};
+use super::{MerkleFrontier, MmrDelta, MmrPath, MmrProof};
 use crate::{
     Word,
     hash::poseidon2::Poseidon2,
     merkle::{
-        InnerNodeInfo, MerklePath,
+        InnerNodeInfo, MerklePath, MerkleProof,
         mmr::{InOrderIndex, MmrError, MmrPeaks, forest::Forest},
     },
     utils::{ByteReader, ByteWriter, Deserializable, Serializable},
@@ -193,6 +193,11 @@ impl PartialMmr {
         MmrPeaks::new(self.forest, self.peaks.clone()).expect("invalid MMR peaks")
     }
 
+    /// Returns the current rooted frontier of this partial MMR.
+    pub fn frontier(&self) -> MerkleFrontier {
+        self.peaks().into()
+    }
+
     /// Returns true if this partial MMR tracks an authentication path for the leaf at the
     /// specified position.
     pub fn is_tracked(&self, pos: usize) -> bool {
@@ -258,6 +263,17 @@ impl PartialMmr {
 
         let path = MmrPath::new(self.forest, pos, MerklePath::new(nodes));
         Ok(Some(MmrProof::new(path, leaf)))
+    }
+
+    /// Returns a plain Merkle proof for a tracked leaf against this partial MMR's rooted frontier
+    /// commitment.
+    ///
+    /// The returned proof can be verified with `MerklePath::verify` using
+    /// `self.frontier().root()` as the expected root.
+    pub fn open_frontier(&self, pos: usize) -> Result<Option<MerkleProof>, MmrError> {
+        self.open(pos)?
+            .map(|opening| self.frontier().to_merkle_proof(&opening))
+            .transpose()
     }
 
     // ITERATORS

--- a/miden-crypto/src/merkle/mmr/partial.rs
+++ b/miden-crypto/src/merkle/mmr/partial.rs
@@ -265,7 +265,7 @@ impl PartialMmr {
         Ok(Some(MmrProof::new(path, leaf)))
     }
 
-    /// Returns a plain Merkle proof for a tracked leaf against this partial MMR's rooted frontier
+    /// Returns a standard Merkle proof for a tracked leaf against this partial MMR's rooted frontier
     /// commitment.
     ///
     /// The returned proof can be verified with `MerklePath::verify` using

--- a/miden-crypto/src/merkle/mmr/peaks.rs
+++ b/miden-crypto/src/merkle/mmr/peaks.rs
@@ -124,8 +124,8 @@ impl MmrPeaks {
 
     /// Hashes the peaks.
     ///
-    /// This is the legacy MMR commitment. New consumers should use [`MerkleFrontier::root`] to
-    /// commit to the rooted append-only frontier.
+    /// This is the legacy MMR commitment. New consumers can use [`MerkleFrontier::root`] as a raw
+    /// Merkle root, authenticated together with the frontier length.
     ///
     /// The procedure will:
     /// - Flatten and pad the peaks to a vector of Felts.

--- a/miden-crypto/src/merkle/mmr/peaks.rs
+++ b/miden-crypto/src/merkle/mmr/peaks.rs
@@ -3,14 +3,14 @@ use alloc::vec::Vec;
 use crate::{
     Felt, Word, ZERO,
     hash::poseidon2::Poseidon2,
-    merkle::mmr::{Forest, MmrError, MmrProof},
+    merkle::mmr::{Forest, MerkleFrontier, MmrError, MmrProof},
 };
 
 // MMR PEAKS
 // ================================================================================================
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
 pub struct MmrPeaks {
     /// The number of leaves (represented by [`Forest`]) is used to differentiate MMRs that have
     /// the same number of peaks. This happens because the number of peaks goes up-and-down as
@@ -117,7 +117,15 @@ impl MmrPeaks {
         (self.forest, self.peaks)
     }
 
+    /// Converts these peaks into a rooted [`MerkleFrontier`].
+    pub fn into_frontier(self) -> MerkleFrontier {
+        self.into()
+    }
+
     /// Hashes the peaks.
+    ///
+    /// This is the legacy MMR commitment. New consumers should use [`MerkleFrontier::root`] to
+    /// commit to the rooted append-only frontier.
     ///
     /// The procedure will:
     /// - Flatten and pad the peaks to a vector of Felts.
@@ -178,5 +186,22 @@ impl MmrPeaks {
 impl From<MmrPeaks> for Vec<Word> {
     fn from(peaks: MmrPeaks) -> Self {
         peaks.peaks
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for MmrPeaks {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(serde::Deserialize)]
+        struct MmrPeaksParts {
+            forest: Forest,
+            peaks: Vec<Word>,
+        }
+
+        let parts = MmrPeaksParts::deserialize(deserializer)?;
+        MmrPeaks::new(parts.forest, parts.peaks).map_err(serde::de::Error::custom)
     }
 }

--- a/miden-crypto/src/merkle/mmr/tests.rs
+++ b/miden-crypto/src/merkle/mmr/tests.rs
@@ -15,6 +15,7 @@ use crate::{
             forest::{Forest, TreeSizeIterator, high_bitmask},
         },
     },
+    utils::{Deserializable, DeserializationError, Serializable},
 };
 
 #[test]
@@ -693,6 +694,61 @@ fn test_partial_mmr_open_frontier_verifies_against_frontier_root() {
 fn test_merkle_frontier_rejects_invalid_peaks() {
     let err = MerkleFrontier::new(0b11, vec![LEAVES[0]]).unwrap_err();
     assert_matches!(err, MmrError::InvalidPeaks(_));
+}
+
+#[test]
+fn test_merkle_frontier_serialization_roundtrip() {
+    let mmr = Mmr::try_from_iter(LEAVES).unwrap();
+    let frontier = mmr.frontier();
+
+    let decoded = MerkleFrontier::read_from_bytes(&frontier.to_bytes()).unwrap();
+
+    assert_eq!(decoded, frontier);
+    assert_eq!(decoded.root(), frontier.root());
+}
+
+#[test]
+fn test_merkle_frontier_deserialization_rejects_large_len() {
+    let bytes = (Forest::MAX_LEAVES + 1).to_bytes();
+
+    let result = MerkleFrontier::read_from_bytes(&bytes);
+
+    assert!(matches!(result, Err(DeserializationError::InvalidValue(_))));
+}
+
+#[test]
+fn test_merkle_frontier_deserialization_rejects_invalid_peak_count() {
+    let mut bytes = 0b11usize.to_bytes();
+    bytes.extend_from_slice(&1usize.to_bytes());
+
+    let result = MerkleFrontier::read_from_bytes(&bytes);
+
+    assert!(matches!(result, Err(DeserializationError::InvalidValue(_))));
+}
+
+#[test]
+fn test_merkle_frontier_rejects_proof_from_different_forest() {
+    let mmr = Mmr::try_from_iter(LEAVES).unwrap();
+    let proof = mmr.open_at(0, Forest::new(4).unwrap()).unwrap();
+
+    let err = mmr.frontier().to_merkle_proof(&proof).unwrap_err();
+
+    assert_matches!(
+        err,
+        MmrError::InconsistentProofForest { proof, frontier }
+            if proof == 4 && frontier == LEAVES.len()
+    );
+}
+
+#[test]
+fn test_merkle_frontier_rejects_proof_with_wrong_peak_path_depth() {
+    let mmr = Mmr::try_from_iter(LEAVES).unwrap();
+    let path = MmrPath::new(mmr.forest(), 0, MerklePath::new(Vec::new()));
+    let proof = MmrProof::new(path, LEAVES[0]);
+
+    let err = mmr.frontier().to_merkle_proof(&proof).unwrap_err();
+
+    assert_matches!(err, MmrError::InvalidMerklePath(_));
 }
 
 #[test]

--- a/miden-crypto/src/merkle/mmr/tests.rs
+++ b/miden-crypto/src/merkle/mmr/tests.rs
@@ -9,7 +9,7 @@ use super::{
 use crate::{
     Felt,
     merkle::{
-        EmptySubtreeRoots, MerklePath, MerkleTree, NodeIndex, int_to_node,
+        EmptySubtreeRoots, MerklePath, MerkleProof, MerkleTree, NodeIndex, int_to_node,
         mmr::{
             InOrderIndex, MmrPath, MmrProof,
             forest::{Forest, TreeSizeIterator, high_bitmask},
@@ -662,13 +662,36 @@ fn test_mmr_open_frontier_verifies_against_frontier_root() {
         mmr.add(leaf).unwrap();
 
         let frontier = mmr.frontier();
-        let root = frontier.root();
 
         for pos in 0..=len {
             let proof = mmr.open_frontier(pos).unwrap();
-            proof.path.verify(pos as u64, proof.value, &root).unwrap();
+            frontier.verify(pos, &proof).unwrap();
         }
     }
+}
+
+#[test]
+fn test_merkle_frontier_verify_rejects_out_of_range_empty_padding() {
+    let empty_leaf = empty_subtree_root(0);
+    let mut mmr = Mmr::new();
+    mmr.add(empty_leaf).unwrap();
+    mmr.add(empty_leaf).unwrap();
+
+    let frontier_len2 = mmr.frontier();
+    let mut frontier_len3 = frontier_len2.clone();
+    frontier_len3.append(empty_leaf).unwrap();
+
+    assert_eq!(frontier_len2.len(), 2);
+    assert_eq!(frontier_len3.len(), 3);
+    assert_eq!(frontier_len2.root(), frontier_len3.root());
+
+    let out_of_range_path = MerklePath::new(vec![empty_leaf, frontier_len2.peaks()[0]]);
+    out_of_range_path.verify(2, empty_leaf, &frontier_len2.root()).unwrap();
+
+    let err = frontier_len2
+        .verify(2, &MerkleProof::new(empty_leaf, out_of_range_path))
+        .unwrap_err();
+    assert_matches!(err, MmrError::PositionNotFound(2));
 }
 
 #[test]
@@ -681,10 +704,10 @@ fn test_partial_mmr_open_frontier_verifies_against_frontier_root() {
         partial.track(pos, proof.leaf(), proof.merkle_path()).unwrap();
     }
 
-    let root = partial.frontier().root();
+    let frontier = partial.frontier();
     for pos in [0, 2, 5, 6] {
         let proof = partial.open_frontier(pos).unwrap().unwrap();
-        proof.path.verify(pos as u64, proof.value, &root).unwrap();
+        frontier.verify(pos, &proof).unwrap();
     }
 
     assert!(partial.open_frontier(1).unwrap().is_none());

--- a/miden-crypto/src/merkle/mmr/tests.rs
+++ b/miden-crypto/src/merkle/mmr/tests.rs
@@ -4,12 +4,12 @@ use assert_matches::assert_matches;
 
 use super::{
     super::{InnerNodeInfo, Poseidon2, Word},
-    Mmr, MmrError, MmrPeaks, PartialMmr, nodes_from_mask,
+    MerkleFrontier, Mmr, MmrError, MmrPeaks, PartialMmr, nodes_from_mask,
 };
 use crate::{
     Felt,
     merkle::{
-        MerklePath, MerkleTree, NodeIndex, int_to_node,
+        EmptySubtreeRoots, MerklePath, MerkleTree, NodeIndex, int_to_node,
         mmr::{
             InOrderIndex, MmrPath, MmrProof,
             forest::{Forest, TreeSizeIterator, high_bitmask},
@@ -22,6 +22,16 @@ fn tests_empty_mmr_peaks() {
     let peaks = MmrPeaks::default();
     assert_eq!(peaks.num_peaks(), 0);
     assert_eq!(peaks.num_leaves(), 0);
+}
+
+#[test]
+fn test_empty_merkle_frontier() {
+    let frontier = MerkleFrontier::default();
+    assert_eq!(frontier.len(), 0);
+    assert_eq!(frontier.num_leaves(), 0);
+    assert_eq!(frontier.num_peaks(), 0);
+    assert!(frontier.is_empty());
+    assert_eq!(frontier.root(), empty_subtree_root(0));
 }
 
 #[test]
@@ -573,6 +583,117 @@ const LEAVES: [Word; 7] = [
     int_to_node(5),
     int_to_node(6),
 ];
+
+#[test]
+fn test_merkle_frontier_root_small_forests() {
+    let peak_01 = merge(LEAVES[0], LEAVES[1]);
+    let peak_23 = merge(LEAVES[2], LEAVES[3]);
+    let peak_0123 = merge(peak_01, peak_23);
+    let peak_45 = merge(LEAVES[4], LEAVES[5]);
+
+    let cases = [
+        (0, vec![], empty_subtree_root(0)),
+        (1, vec![LEAVES[0]], merge(LEAVES[0], empty_subtree_root(0))),
+        (2, vec![peak_01], merge(peak_01, empty_subtree_root(1))),
+        (
+            3,
+            vec![peak_01, LEAVES[2]],
+            merge(peak_01, merge(LEAVES[2], empty_subtree_root(0))),
+        ),
+        (4, vec![peak_0123], merge(peak_0123, empty_subtree_root(2))),
+        (
+            5,
+            vec![peak_0123, LEAVES[4]],
+            merge(peak_0123, merge(merge(LEAVES[4], empty_subtree_root(0)), empty_subtree_root(1))),
+        ),
+        (
+            6,
+            vec![peak_0123, peak_45],
+            merge(peak_0123, merge(peak_45, empty_subtree_root(1))),
+        ),
+        (
+            7,
+            vec![peak_0123, peak_45, LEAVES[6]],
+            merge(peak_0123, merge(peak_45, merge(LEAVES[6], empty_subtree_root(0)))),
+        ),
+    ];
+
+    for (len, peaks, expected_root) in cases {
+        let frontier = MerkleFrontier::new(len, peaks).unwrap();
+        assert_eq!(frontier.root(), expected_root);
+    }
+}
+
+#[test]
+fn test_merkle_frontier_append_matches_mmr() {
+    let mut frontier = MerkleFrontier::default();
+    let mut mmr = Mmr::new();
+
+    for leaf in LEAVES {
+        frontier.append(leaf).unwrap();
+        mmr.add(leaf).unwrap();
+
+        let mmr_frontier = mmr.frontier();
+        assert_eq!(frontier, mmr_frontier);
+        assert_eq!(frontier.root(), mmr_frontier.root());
+        assert_eq!(MmrPeaks::from(frontier.clone()), mmr.peaks());
+    }
+}
+
+#[test]
+fn test_merkle_frontier_converts_from_mmr_peaks() {
+    let mmr = Mmr::try_from_iter(LEAVES).unwrap();
+    let peaks = mmr.peaks();
+    let frontier = MerkleFrontier::from(&peaks);
+
+    assert_eq!(frontier.len(), peaks.num_leaves());
+    assert_eq!(frontier.peaks(), peaks.peaks());
+    assert_eq!(frontier.clone().into_legacy_peaks(), peaks);
+    assert_eq!(frontier.root(), MerkleFrontier::from(mmr.peaks()).root());
+}
+
+#[test]
+fn test_mmr_open_frontier_verifies_against_frontier_root() {
+    let mut mmr = Mmr::new();
+
+    for len in 0..32 {
+        let leaf = int_to_node(len as u64);
+        mmr.add(leaf).unwrap();
+
+        let frontier = mmr.frontier();
+        let root = frontier.root();
+
+        for pos in 0..=len {
+            let proof = mmr.open_frontier(pos).unwrap();
+            proof.path.verify(pos as u64, proof.value, &root).unwrap();
+        }
+    }
+}
+
+#[test]
+fn test_partial_mmr_open_frontier_verifies_against_frontier_root() {
+    let mmr = Mmr::try_from_iter(LEAVES).unwrap();
+    let mut partial = PartialMmr::from_peaks(mmr.peaks());
+
+    for pos in [0, 2, 5, 6] {
+        let proof = mmr.open(pos).unwrap();
+        partial.track(pos, proof.leaf(), proof.merkle_path()).unwrap();
+    }
+
+    let root = partial.frontier().root();
+    for pos in [0, 2, 5, 6] {
+        let proof = partial.open_frontier(pos).unwrap().unwrap();
+        proof.path.verify(pos as u64, proof.value, &root).unwrap();
+    }
+
+    assert!(partial.open_frontier(1).unwrap().is_none());
+}
+
+#[test]
+fn test_merkle_frontier_rejects_invalid_peaks() {
+    let err = MerkleFrontier::new(0b11, vec![LEAVES[0]]).unwrap_err();
+    assert_matches!(err, MmrError::InvalidPeaks(_));
+}
 
 #[test]
 fn test_mmr_simple() {
@@ -1511,6 +1632,10 @@ fn digests_to_elements(digests: &[Word]) -> Vec<Felt> {
 // short hand for the Poseidon2 hash, used to make test code more concise and easy to read
 fn merge(l: Word, r: Word) -> Word {
     Poseidon2::merge(&[l, r])
+}
+
+fn empty_subtree_root(height: u8) -> Word {
+    *EmptySubtreeRoots::entry(height, 0)
 }
 
 /// Given a leaf index and the current forest, return the tree number responsible for


### PR DESCRIPTION
## Describe your changes

This adds `MerkleFrontier` as append-only `len + peaks` state with a normal Merkle root commitment, plus append support and conversions to/from legacy `MmrPeaks`.

It also adds `Mmr` / `PartialMmr` helpers for producing plain Merkle proofs against the frontier root, and documents `MmrPeaks::hash_peaks()` as the legacy commitment path.

Tests added for frontier root computation, append parity with `Mmr`, legacy conversion, and frontier proof verification.

Closes 0xMiden/miden-vm#3526.

## Checklist before requesting a review
- [X] Repo forked and branch created from `next` according to naming convention.
- [X] Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- [X] Relevant issues are linked in the PR description.
- [X] Tests added for new functionality.
- [X] Documentation/comments updated according to changes.
