### PR TITLE
Migrate to rand 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 0.26.0 (TBD)
 
+- [BREAKING] Upgraded direct `rand` dependencies to 0.10, updating RNG trait bounds and removing direct `rand_hc` usage ([#995](https://github.com/0xMiden/crypto/pull/995)).
+
 ## 0.25.0 (2026-05-01)
 
 - [BREAKING] Changed the serialization format of `PartialSmt` to be more compact on the wire ([#957](https://github.com/0xMiden/crypto/pull/957)).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -251,13 +251,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chacha20poly1305"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
 dependencies = [
  "aead",
- "chacha20",
+ "chacha20 0.9.1",
  "cipher",
  "poly1305",
  "zeroize",
@@ -667,9 +678,6 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
 dependencies = [
- "futures-core",
- "futures-sink",
- "nanorand",
  "spin 0.9.8",
 ]
 
@@ -701,12 +709,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "futures-sink"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
@@ -751,10 +753,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -778,6 +778,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -1138,10 +1139,8 @@ dependencies = [
  "p3-symmetric",
  "p3-util",
  "proptest",
- "rand 0.9.4",
- "rand_chacha",
- "rand_core 0.9.5",
- "rand_hc",
+ "rand 0.10.1",
+ "rand_chacha 0.10.0",
  "rayon",
  "rocksdb",
  "seq-macro",
@@ -1258,15 +1257,6 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
-name = "nanorand"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
-dependencies = [
- "getrandom 0.2.17",
-]
 
 [[package]]
 name = "nom"
@@ -1941,7 +1931,7 @@ dependencies = [
  "bitflags",
  "num-traits",
  "rand 0.9.4",
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
  "unarray",
@@ -1974,7 +1964,7 @@ version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rand_core 0.9.5",
 ]
 
@@ -1984,6 +1974,8 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
+ "chacha20 0.10.0",
+ "getrandom 0.4.2",
  "rand_core 0.10.1",
 ]
 
@@ -1995,6 +1987,16 @@ checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e6af7f3e25ded52c41df4e0b1af2d047e45896c2f3281792ed68a1c243daedb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2020,15 +2022,6 @@ name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
-
-[[package]]
-name = "rand_hc"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b363d4f6370f88d62bf586c80405657bde0f0e1b8945d47d2ad59b906cb4f54"
-dependencies = [
- "rand_core 0.6.4",
-]
 
 [[package]]
 name = "rand_xorshift"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -748,17 +748,6 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
@@ -955,9 +944,7 @@ dependencies = [
  "cfg-if",
  "ecdsa",
  "elliptic-curve",
- "once_cell",
  "sha2",
- "signature",
 ]
 
 [[package]]
@@ -2004,9 +1991,6 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.17",
-]
 
 [[package]]
 name = "rand_core"
@@ -2631,12 +2615,6 @@ dependencies = [
  "same-file",
  "winapi-util",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.11.1+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ chacha20poly1305 = "0.10"
 curve25519-dalek = { default-features = false, version = "4" }
 der              = { default-features = false, version = "0.7" }
 ed25519-dalek    = "2"
-flume            = "0.11.1"
+flume            = { default-features = false, version = "0.11.1" }
 hex              = { default-features = false, version = "0.4" }
 hkdf             = { default-features = false, version = "0.12" }
 itertools        = "0.14"
@@ -75,9 +75,7 @@ num-complex      = { default-features = false, version = "0.4" }
 once_cell        = { default-features = false, version = "1.21" }
 proptest         = { default-features = false, version = "1.7" }
 quote            = "1.0"
-rand_chacha      = { default-features = false, version = "0.9" }
-rand_core        = { default-features = false, version = "0.9" }
-rand_hc          = "0.3"
+rand_chacha      = { default-features = false, version = "0.10" }
 rayon            = "1.10"
 rocksdb          = { default-features = false, version = "0.24" }
 rstest           = "0.26"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,15 +61,15 @@ p3-util          = { default-features = false, version = "0.5" }
 assert_matches   = { default-features = false, version = "1.5" }
 blake3           = { default-features = false, version = "1.8" }
 cc               = "1.2"
-chacha20poly1305 = "0.10"
+chacha20poly1305 = { default-features = false, version = "0.10" }
 curve25519-dalek = { default-features = false, version = "4" }
 der              = { default-features = false, version = "0.7" }
-ed25519-dalek    = "2"
+ed25519-dalek    = { default-features = false, version = "2" }
 flume            = { default-features = false, version = "0.11.1" }
 hex              = { default-features = false, version = "0.4" }
 hkdf             = { default-features = false, version = "0.12" }
 itertools        = "0.14"
-k256             = "0.13"
+k256             = { default-features = false, version = "0.13" }
 num              = { default-features = false, version = "0.4" }
 num-complex      = { default-features = false, version = "0.4" }
 once_cell        = { default-features = false, version = "1.21" }

--- a/deny.toml
+++ b/deny.toml
@@ -44,10 +44,9 @@ skip = [
   { name = "thiserror-impl" },
 ]
 skip-tree = [
-  # Stable crypto crates still depend on rand_core 0.6, getrandom 0.2, and chacha20 0.9.
+  # Stable crypto crates still depend on rand_core 0.6 and chacha20 0.9.
   { name = "chacha20", version = "=0.9.1" },
   { name = "cpufeatures", version = "0.2.17" },
-  { name = "getrandom", version = "=0.2.17" },
   { name = "rand_core", version = "=0.6.4" },
 
   # Dev/test-only proptest still depends on rand 0.9.

--- a/deny.toml
+++ b/deny.toml
@@ -44,12 +44,15 @@ skip = [
   { name = "thiserror-impl" },
 ]
 skip-tree = [
-  # miden-crypto uses rand 0.9 while Plonky3 0.5 uses rand 0.10,
-  # causing duplicate rand / rand_core / getrandom trees
+  # Stable crypto crates still depend on rand_core 0.6, getrandom 0.2, and chacha20 0.9.
+  { name = "chacha20", version = "=0.9.1" },
   { name = "cpufeatures", version = "0.2.17" },
   { name = "getrandom", version = "=0.2.17" },
-  { name = "rand", version = "=0.9.4" },
   { name = "rand_core", version = "=0.6.4" },
+
+  # Dev/test-only proptest still depends on rand 0.9.
+  { name = "rand", version = "=0.9.4" },
+  { name = "rand_chacha", version = "=0.9.0" },
   { name = "rand_core", version = "=0.9.5" },
 ]
 wildcards = "allow"

--- a/miden-crypto-fuzz/Cargo.lock
+++ b/miden-crypto-fuzz/Cargo.lock
@@ -13,6 +13,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
 name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -49,6 +55,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e050f626429857a27ddccb31e0aca21356bfa709c04041aefddac081a8f068a"
 
 [[package]]
+name = "bitflags"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
 name = "blake3"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -69,12 +81,6 @@ checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
-
-[[package]]
-name = "bumpalo"
-version = "3.19.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
 name = "cc"
@@ -102,7 +108,18 @@ checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.0",
 ]
 
 [[package]]
@@ -112,7 +129,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
 dependencies = [
  "aead",
- "chacha20",
+ "chacha20 0.9.1",
  "cipher",
  "poly1305",
  "zeroize",
@@ -146,6 +163,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -217,7 +243,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest",
  "fiat-crypto",
@@ -324,6 +350,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "ff"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -351,23 +383,14 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
 dependencies = [
- "futures-core",
- "futures-sink",
- "nanorand",
  "spin 0.9.8",
 ]
 
 [[package]]
-name = "futures-core"
-version = "0.3.31"
+name = "foldhash"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
-
-[[package]]
-name = "futures-sink"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "generic-array"
@@ -387,10 +410,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -401,8 +422,22 @@ checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "rand_core 0.10.0",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -415,6 +450,27 @@ dependencies = [
  "rand_core 0.6.4",
  "subtle",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hkdf"
@@ -432,6 +488,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest",
+]
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.0",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -453,6 +527,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
 name = "jobserver"
 version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -460,16 +540,6 @@ checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
 dependencies = [
  "getrandom 0.3.4",
  "libc",
-]
-
-[[package]]
-name = "js-sys"
-version = "0.3.83"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "464a3709c7f55f1f721e5389aa6ea4e3bc6aba669353300af094b29ffbdde1d8"
-dependencies = [
- "once_cell",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -492,8 +562,14 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -527,6 +603,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "memchr"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
 name = "miden-crypto"
 version = "0.26.0"
 dependencies = [
@@ -555,10 +643,8 @@ dependencies = [
  "p3-maybe-rayon",
  "p3-symmetric",
  "p3-util",
- "rand 0.9.3",
+ "rand",
  "rand_chacha",
- "rand_core 0.9.3",
- "rand_hc",
  "rayon",
  "serde",
  "sha2",
@@ -582,7 +668,7 @@ version = "0.0.0"
 dependencies = [
  "libfuzzer-sys",
  "miden-crypto",
- "rand 0.9.3",
+ "rand",
 ]
 
 [[package]]
@@ -596,7 +682,7 @@ dependencies = [
  "p3-goldilocks",
  "p3-util",
  "paste",
- "rand 0.10.1",
+ "rand",
  "serde",
  "subtle",
  "thiserror",
@@ -628,7 +714,7 @@ dependencies = [
  "p3-maybe-rayon",
  "p3-symmetric",
  "p3-util",
- "rand 0.10.1",
+ "rand",
  "serde",
  "thiserror",
  "tracing",
@@ -658,15 +744,6 @@ version = "0.26.0"
 dependencies = [
  "p3-field",
  "p3-symmetric",
-]
-
-[[package]]
-name = "nanorand"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
-dependencies = [
- "getrandom 0.2.16",
 ]
 
 [[package]]
@@ -821,7 +898,7 @@ dependencies = [
  "p3-maybe-rayon",
  "p3-util",
  "paste",
- "rand 0.10.1",
+ "rand",
  "serde",
  "tracing",
 ]
@@ -842,7 +919,7 @@ dependencies = [
  "p3-symmetric",
  "p3-util",
  "paste",
- "rand 0.10.1",
+ "rand",
  "serde",
 ]
 
@@ -867,7 +944,7 @@ dependencies = [
  "p3-field",
  "p3-maybe-rayon",
  "p3-util",
- "rand 0.10.1",
+ "rand",
  "serde",
  "tracing",
 ]
@@ -891,7 +968,7 @@ dependencies = [
  "p3-field",
  "p3-symmetric",
  "p3-util",
- "rand 0.10.1",
+ "rand",
 ]
 
 [[package]]
@@ -912,7 +989,7 @@ dependencies = [
  "p3-symmetric",
  "p3-util",
  "paste",
- "rand 0.10.1",
+ "rand",
  "serde",
  "spin 0.10.0",
  "tracing",
@@ -926,7 +1003,7 @@ checksum = "6a018b618e3fa0aec8be933b1d8e404edd23f46991f6bf3f5c2f3f95e9413fe9"
 dependencies = [
  "p3-field",
  "p3-symmetric",
- "rand 0.10.1",
+ "rand",
 ]
 
 [[package]]
@@ -939,7 +1016,7 @@ dependencies = [
  "p3-mds",
  "p3-symmetric",
  "p3-util",
- "rand 0.10.1",
+ "rand",
 ]
 
 [[package]]
@@ -993,7 +1070,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -1011,6 +1088,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
 ]
 
 [[package]]
@@ -1038,14 +1125,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
-name = "rand"
-version = "0.9.3"
+name = "r-efi"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
-dependencies = [
- "rand_chacha",
- "rand_core 0.9.3",
-]
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
@@ -1053,17 +1136,19 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
+ "chacha20 0.10.0",
+ "getrandom 0.4.2",
  "rand_core 0.10.0",
 ]
 
 [[package]]
 name = "rand_chacha"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+checksum = "3e6af7f3e25ded52c41df4e0b1af2d047e45896c2f3281792ed68a1c243daedb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.3",
+ "rand_core 0.10.0",
 ]
 
 [[package]]
@@ -1077,27 +1162,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
-dependencies = [
- "getrandom 0.3.4",
-]
-
-[[package]]
-name = "rand_core"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
-
-[[package]]
-name = "rand_hc"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b363d4f6370f88d62bf586c80405657bde0f0e1b8945d47d2ad59b906cb4f54"
-dependencies = [
- "rand_core 0.6.4",
-]
 
 [[package]]
 name = "rayon"
@@ -1137,12 +1204,6 @@ checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
 ]
-
-[[package]]
-name = "rustversion"
-version = "1.0.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "scopeguard"
@@ -1201,13 +1262,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -1368,6 +1442,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "universal-hash"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1395,52 +1475,50 @@ version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.46.0",
 ]
 
 [[package]]
-name = "wasm-bindgen"
-version = "0.2.106"
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d759f433fa64a2d763d1340820e46e111a7a5ab75f993d1852d70b03dbb80fd"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "cfg-if",
- "once_cell",
- "rustversion",
- "wasm-bindgen-macro",
- "wasm-bindgen-shared",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
-name = "wasm-bindgen-macro"
-version = "0.2.106"
+name = "wasm-encoder"
+version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48cb0d2638f8baedbc542ed444afc0644a29166f1595371af4fecf8ce1e7eeb3"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
 dependencies = [
- "quote",
- "wasm-bindgen-macro-support",
+ "leb128fmt",
+ "wasmparser",
 ]
 
 [[package]]
-name = "wasm-bindgen-macro-support"
-version = "0.2.106"
+name = "wasm-metadata"
+version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cefb59d5cd5f92d9dcf80e4683949f15ca4b511f4ac0a6e14d4e1ac60c6ecd40"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
- "bumpalo",
- "proc-macro2",
- "quote",
- "syn",
- "wasm-bindgen-shared",
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
 ]
 
 [[package]]
-name = "wasm-bindgen-shared"
-version = "0.2.106"
+name = "wasmparser"
+version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "unicode-ident",
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
 ]
 
 [[package]]
@@ -1448,6 +1526,94 @@ name = "wit-bindgen"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "x25519-dalek"
@@ -1484,3 +1650,9 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/miden-crypto-fuzz/Cargo.lock
+++ b/miden-crypto-fuzz/Cargo.lock
@@ -405,17 +405,6 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
@@ -551,9 +540,7 @@ dependencies = [
  "cfg-if",
  "ecdsa",
  "elliptic-curve",
- "once_cell",
  "sha2",
- "signature",
 ]
 
 [[package]]
@@ -1156,9 +1143,6 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.16",
-]
 
 [[package]]
 name = "rand_core"
@@ -1462,12 +1446,6 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
-name = "wasi"
-version = "0.11.1+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"

--- a/miden-crypto-fuzz/Cargo.toml
+++ b/miden-crypto-fuzz/Cargo.toml
@@ -10,7 +10,7 @@ cargo-fuzz = true
 [dependencies]
 libfuzzer-sys = "0.4"
 miden-crypto  = { features = ["concurrent", "fuzzing"], path = "../miden-crypto" }
-rand          = { default-features = false, version = "0.9" }
+rand          = { default-features = false, version = "0.10" }
 
 # Existing SMT fuzz target (for sequential vs parallel consistency)
 [[bin]]

--- a/miden-crypto-fuzz/fuzz_targets/smt.rs
+++ b/miden-crypto-fuzz/fuzz_targets/smt.rs
@@ -2,7 +2,7 @@
 
 use libfuzzer_sys::fuzz_target;
 use miden_crypto::{merkle::smt::Smt, Felt, Word, ONE};
-use rand::Rng; // Needed for randomizing the split percentage
+use rand::RngExt; // Needed for randomizing the split percentage
 
 struct FuzzInput {
     entries: Vec<(Word, Word)>,

--- a/miden-crypto/Cargo.toml
+++ b/miden-crypto/Cargo.toml
@@ -112,10 +112,8 @@ num              = { features = ["alloc", "libm"], workspace = true }
 num-complex      = { workspace = true }
 once_cell        = { features = ["alloc", "critical-section"], workspace = true }
 proptest         = { features = ["alloc"], optional = true, workspace = true }
-rand             = { default-features = false, version = "0.9" }
+rand             = { workspace = true }
 rand_chacha      = { workspace = true }
-rand_core        = { workspace = true }
-rand_hc          = { workspace = true }
 rayon            = { optional = true, workspace = true }
 rocksdb          = { features = ["bindgen-runtime", "lz4"], optional = true, workspace = true }
 serde            = { features = ["derive"], optional = true, workspace = true }

--- a/miden-crypto/Cargo.toml
+++ b/miden-crypto/Cargo.toml
@@ -100,14 +100,14 @@ miden-serde-utils   = { workspace = true }
 
 # External dependencies
 blake3           = { workspace = true }
-chacha20poly1305 = { features = ["alloc", "stream"], workspace = true }
+chacha20poly1305 = { features = ["alloc", "rand_core", "stream"], workspace = true }
 clap             = { features = ["derive"], optional = true, workspace = true }
 curve25519-dalek = { workspace = true }
 der              = { workspace = true }
-ed25519-dalek    = { features = ["zeroize"], workspace = true }
+ed25519-dalek    = { features = ["alloc", "zeroize"], workspace = true }
 flume            = { workspace = true }
 hkdf             = { workspace = true }
-k256             = { features = ["ecdh", "ecdsa", "pkcs8"], workspace = true }
+k256             = { features = ["alloc", "ecdh", "ecdsa", "pkcs8"], workspace = true }
 num              = { features = ["alloc", "libm"], workspace = true }
 num-complex      = { workspace = true }
 once_cell        = { features = ["alloc", "critical-section"], workspace = true }

--- a/miden-crypto/benches/common/macros.rs
+++ b/miden-crypto/benches/common/macros.rs
@@ -961,8 +961,8 @@ macro_rules! benchmark_aead_bytes {
         /// Benchmark AEAD operations on byte arrays
         fn $bytes_fn(c: &mut Criterion) {
             use miden_crypto::aead::$aead_module::{Nonce, SecretKey};
+            use rand::SeedableRng;
             use rand_chacha::ChaCha20Rng;
-            use rand_core::SeedableRng;
 
             let group_name = format!("{} - Byte Arrays", $group_prefix);
             let mut group = c.benchmark_group(&group_name);
@@ -1044,8 +1044,8 @@ macro_rules! benchmark_aead_field {
         /// Benchmark AEAD operations on field elements
         fn $felts_fn(c: &mut Criterion) {
             use miden_crypto::aead::$aead_module::{Nonce, SecretKey};
+            use rand::SeedableRng;
             use rand_chacha::ChaCha20Rng;
-            use rand_core::SeedableRng;
 
             let group_name = format!("{} - Field Elements", $group_prefix);
             let mut group = c.benchmark_group(&group_name);

--- a/miden-crypto/src/aead/aead_poseidon2/mod.rs
+++ b/miden-crypto/src/aead/aead_poseidon2/mod.rs
@@ -13,7 +13,7 @@ use core::ops::Range;
 use miden_crypto_derive::{SilentDebug, SilentDisplay};
 use num::Integer;
 use rand::{
-    Rng,
+    Rng, RngExt,
     distr::{Distribution, StandardUniform, Uniform},
 };
 use subtle::ConstantTimeEq;
@@ -772,7 +772,7 @@ impl AeadScheme for AeadPoseidon2 {
             .map_err(|_| EncryptionError::FailedOperation)
     }
 
-    fn encrypt_bytes<R: rand::CryptoRng + rand::RngCore>(
+    fn encrypt_bytes<R: rand::CryptoRng>(
         key: &Self::Key,
         rng: &mut R,
         plaintext: &[u8],
@@ -801,7 +801,7 @@ impl AeadScheme for AeadPoseidon2 {
     // OPTIMIZED FELT METHODS
     // --------------------------------------------------------------------------------------------
 
-    fn encrypt_elements<R: rand::CryptoRng + rand::RngCore>(
+    fn encrypt_elements<R: rand::CryptoRng>(
         key: &Self::Key,
         rng: &mut R,
         plaintext: &[Felt],

--- a/miden-crypto/src/aead/aead_poseidon2/test.rs
+++ b/miden-crypto/src/aead/aead_poseidon2/test.rs
@@ -2,7 +2,7 @@ use proptest::{
     prelude::{any, prop},
     prop_assert_eq, prop_assert_ne, prop_assume, proptest,
 };
-use rand::{RngCore, SeedableRng};
+use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha20Rng;
 
 use super::*;

--- a/miden-crypto/src/aead/mod.rs
+++ b/miden-crypto/src/aead/mod.rs
@@ -52,7 +52,7 @@ pub(crate) trait AeadScheme {
     // BYTE METHODS
     // ================================================================================================
 
-    fn encrypt_bytes<R: rand::CryptoRng + rand::RngCore>(
+    fn encrypt_bytes<R: rand::CryptoRng>(
         key: &Self::Key,
         rng: &mut R,
         plaintext: &[u8],
@@ -69,7 +69,7 @@ pub(crate) trait AeadScheme {
     // ================================================================================================
 
     /// Encrypts field elements with associated data. Default implementation converts to bytes.
-    fn encrypt_elements<R: rand::CryptoRng + rand::RngCore>(
+    fn encrypt_elements<R: rand::CryptoRng>(
         key: &Self::Key,
         rng: &mut R,
         plaintext: &[Felt],

--- a/miden-crypto/src/aead/xchacha/mod.rs
+++ b/miden-crypto/src/aead/xchacha/mod.rs
@@ -16,13 +16,14 @@ use chacha20poly1305::{
     XChaCha20Poly1305,
     aead::{Aead, AeadCore, KeyInit},
 };
-use rand::{CryptoRng, RngCore};
+use rand::CryptoRng;
 #[cfg(any(test, feature = "testing"))]
 use subtle::ConstantTimeEq;
 
 use crate::{
     Felt,
     aead::{AeadScheme, DataType, EncryptionError},
+    rand::compat::RandCore06,
     utils::{
         ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable,
         bytes_to_elements_exact, elements_to_bytes,
@@ -65,19 +66,10 @@ pub struct Nonce {
 
 impl Nonce {
     /// Creates a new random nonce using the provided random number generator
-    pub fn with_rng<R: RngCore + CryptoRng>(rng: &mut R) -> Self {
-        // we use a seedable CSPRNG and seed it with `rng`
-        // this is a work around the fact that the version of the `rand` dependency in our crate
-        // is different than the one used in the `chacha20poly1305`. This solution will
-        // no longer be needed once `chacha20poly1305` gets a new release with a version of
-        // the `rand` dependency matching ours
-        use chacha20poly1305::aead::rand_core::SeedableRng;
-        let mut seed = [0_u8; 32];
-        RngCore::fill_bytes(rng, &mut seed);
-        let rng = rand_hc::Hc128Rng::from_seed(seed);
-
+    pub fn with_rng<R: CryptoRng>(rng: &mut R) -> Self {
+        let mut compat_rng = RandCore06::new(rng);
         Nonce {
-            inner: XChaCha20Poly1305::generate_nonce(rng),
+            inner: XChaCha20Poly1305::generate_nonce(&mut compat_rng),
         }
     }
 
@@ -115,18 +107,9 @@ impl SecretKey {
     }
 
     /// Creates a new random secret key using the provided random number generator
-    pub fn with_rng<R: RngCore + CryptoRng>(rng: &mut R) -> Self {
-        // we use a seedable CSPRNG and seed it with `rng`
-        // this is a work around the fact that the version of the `rand` dependency in our crate
-        // is different than the one used in the `chacha20poly1305`. This solution will
-        // no longer be needed once `chacha20poly1305` gets a new release with a version of
-        // the `rand` dependency matching ours
-        use chacha20poly1305::aead::rand_core::SeedableRng;
-        let mut seed = [0_u8; 32];
-        RngCore::fill_bytes(rng, &mut seed);
-        let rng = rand_hc::Hc128Rng::from_seed(seed);
-
-        let key = XChaCha20Poly1305::generate_key(rng);
+    pub fn with_rng<R: CryptoRng>(rng: &mut R) -> Self {
+        let mut compat_rng = RandCore06::new(rng);
+        let key = XChaCha20Poly1305::generate_key(&mut compat_rng);
         Self(key.into())
     }
 
@@ -348,7 +331,7 @@ impl AeadScheme for XChaCha {
             .map_err(|_| EncryptionError::FailedOperation)
     }
 
-    fn encrypt_bytes<R: CryptoRng + RngCore>(
+    fn encrypt_bytes<R: CryptoRng>(
         key: &Self::Key,
         rng: &mut R,
         plaintext: &[u8],

--- a/miden-crypto/src/aead/xchacha/test.rs
+++ b/miden-crypto/src/aead/xchacha/test.rs
@@ -2,7 +2,7 @@ use proptest::{
     prelude::{any, prop},
     prop_assert_eq, prop_assert_ne, proptest,
 };
-use rand::{Rng, SeedableRng};
+use rand::{RngExt, SeedableRng};
 use rand_chacha::ChaCha20Rng;
 
 use super::*;

--- a/miden-crypto/src/dsa/ecdsa_k256_keccak/mod.rs
+++ b/miden-crypto/src/dsa/ecdsa_k256_keccak/mod.rs
@@ -10,12 +10,13 @@ use k256::{
     pkcs8::DecodePublicKey,
 };
 use miden_crypto_derive::{SilentDebug, SilentDisplay};
-use rand::{CryptoRng, RngCore};
+use rand::CryptoRng;
 use thiserror::Error;
 
 use crate::{
     Felt, SequentialCommit, Word,
     ecdh::k256::{EphemeralPublicKey, SharedSecret},
+    rand::compat::RandCore06,
     utils::{
         ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable,
         bytes_to_packed_u32_elements,
@@ -50,20 +51,9 @@ struct SecretKey {
 
 impl SecretKey {
     /// Generates a new secret key using the provided random number generator.
-    fn with_rng<R: CryptoRng + RngCore>(rng: &mut R) -> Self {
-        // we use a seedable CSPRNG and seed it with `rng`
-        // this is a work around the fact that the version of the `rand` dependency in our crate
-        // is different than the one used in the `k256` one. This solution will no longer be needed
-        // once `k256` gets a new release with a version of the `rand` dependency matching ours
-        use k256::elliptic_curve::rand_core::SeedableRng;
-        let mut seed = [0_u8; 32];
-        RngCore::fill_bytes(rng, &mut seed);
-        let mut rng = rand_hc::Hc128Rng::from_seed(seed);
-
-        let signing_key = ecdsa::SigningKey::random(&mut rng);
-
-        // Zeroize the seed to prevent leaking secret material
-        seed.zeroize();
+    fn with_rng<R: CryptoRng>(rng: &mut R) -> Self {
+        let mut compat_rng = RandCore06::new(rng);
+        let signing_key = ecdsa::SigningKey::random(&mut compat_rng);
 
         Self { inner: signing_key }
     }
@@ -137,7 +127,7 @@ impl SigningKey {
     }
 
     /// Generates a new signing key using the provided random number generator.
-    pub fn with_rng<R: CryptoRng + RngCore>(rng: &mut R) -> Self {
+    pub fn with_rng<R: CryptoRng>(rng: &mut R) -> Self {
         Self(SecretKey::with_rng(rng))
     }
 
@@ -198,7 +188,7 @@ impl KeyExchangeKey {
     }
 
     /// Generates a new signing key using the provided random number generator.
-    pub fn with_rng<R: CryptoRng + RngCore>(rng: &mut R) -> Self {
+    pub fn with_rng<R: CryptoRng>(rng: &mut R) -> Self {
         Self(SecretKey::with_rng(rng))
     }
 

--- a/miden-crypto/src/dsa/eddsa_25519_sha512/mod.rs
+++ b/miden-crypto/src/dsa/eddsa_25519_sha512/mod.rs
@@ -6,7 +6,7 @@ use alloc::{string::ToString, vec::Vec};
 use der::{Decode, asn1::BitStringRef};
 use ed25519_dalek::{Signer, Verifier};
 use miden_crypto_derive::{SilentDebug, SilentDisplay};
-use rand::{CryptoRng, RngCore};
+use rand::CryptoRng;
 use thiserror::Error;
 
 use crate::{
@@ -42,9 +42,9 @@ struct SecretKey {
 
 impl SecretKey {
     /// Generates a new secret key using RNG.
-    fn with_rng<R: CryptoRng + RngCore>(rng: &mut R) -> Self {
+    fn with_rng<R: CryptoRng>(rng: &mut R) -> Self {
         let mut seed = [0u8; SECRET_KEY_BYTES];
-        RngCore::fill_bytes(rng, &mut seed);
+        rng.fill_bytes(&mut seed);
 
         let inner = ed25519_dalek::SigningKey::from_bytes(&seed);
 
@@ -122,7 +122,7 @@ impl SigningKey {
     }
 
     /// Generates a new secret key using RNG.
-    pub fn with_rng<R: CryptoRng + RngCore>(rng: &mut R) -> Self {
+    pub fn with_rng<R: CryptoRng>(rng: &mut R) -> Self {
         Self(SecretKey::with_rng(rng))
     }
 
@@ -178,7 +178,7 @@ impl KeyExchangeKey {
     }
 
     /// Generates a new secret key using RNG.
-    pub fn with_rng<R: CryptoRng + RngCore>(rng: &mut R) -> Self {
+    pub fn with_rng<R: CryptoRng>(rng: &mut R) -> Self {
         Self(SecretKey::with_rng(rng))
     }
 

--- a/miden-crypto/src/dsa/falcon512_poseidon2/math/ffsampling.rs
+++ b/miden-crypto/src/dsa/falcon512_poseidon2/math/ffsampling.rs
@@ -199,7 +199,7 @@ pub fn ffsampling<R: Rng>(
 #[cfg(test)]
 mod tests {
     use num_complex::Complex64;
-    use rand::{Rng, SeedableRng};
+    use rand::{Rng, RngExt, SeedableRng};
     use rand_chacha::ChaCha20Rng;
 
     use super::*;

--- a/miden-crypto/src/dsa/falcon512_poseidon2/tests/mod.rs
+++ b/miden-crypto/src/dsa/falcon512_poseidon2/tests/mod.rs
@@ -3,7 +3,7 @@ use data::{
     SYNC_DATA_FOR_TEST_VECTOR,
 };
 use prng::Shake256Testing;
-use rand::{RngCore, SeedableRng};
+use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha20Rng;
 
 use super::{Serializable, math::Polynomial};

--- a/miden-crypto/src/dsa/falcon512_poseidon2/tests/prng.rs
+++ b/miden-crypto/src/dsa/falcon512_poseidon2/tests/prng.rs
@@ -1,7 +1,9 @@
 use alloc::vec::Vec;
 
-use rand::{Rng, RngCore};
-use rand_core::impls;
+use rand::{
+    Rng,
+    rand_core::{Infallible, TryRng, utils},
+};
 use sha3::{
     Shake256, Shake256ReaderCore,
     digest::{ExtendableOutput, Update, XofReader, core_api::XofReaderCoreWrapper},
@@ -49,17 +51,20 @@ impl Shake256Testing {
     }
 }
 
-impl RngCore for Shake256Testing {
-    fn next_u32(&mut self) -> u32 {
-        impls::next_u32_via_fill(self)
+impl TryRng for Shake256Testing {
+    type Error = Infallible;
+
+    fn try_next_u32(&mut self) -> Result<u32, Self::Error> {
+        utils::next_word_via_fill::<u32, _>(self)
     }
 
-    fn next_u64(&mut self) -> u64 {
-        impls::next_u64_via_u32(self)
+    fn try_next_u64(&mut self) -> Result<u64, Self::Error> {
+        utils::next_u64_via_u32(self)
     }
 
-    fn fill_bytes(&mut self, dest: &mut [u8]) {
-        self.fill_bytes(dest)
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Self::Error> {
+        Shake256Testing::fill_bytes(self, dest);
+        Ok(())
     }
 }
 
@@ -176,18 +181,21 @@ impl ChaCha {
     }
 }
 
-impl RngCore for ChaCha {
-    fn next_u32(&mut self) -> u32 {
-        impls::next_u32_via_fill(self)
+impl TryRng for ChaCha {
+    type Error = Infallible;
+
+    fn try_next_u32(&mut self) -> Result<u32, Self::Error> {
+        utils::next_word_via_fill::<u32, _>(self)
     }
 
-    fn next_u64(&mut self) -> u64 {
-        impls::next_u64_via_u32(self)
+    fn try_next_u64(&mut self) -> Result<u64, Self::Error> {
+        utils::next_u64_via_u32(self)
     }
 
-    fn fill_bytes(&mut self, dest: &mut [u8]) {
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Self::Error> {
         let len = dest.len();
         let buffer = self.random_bytes(len);
-        dest.iter_mut().enumerate().for_each(|(i, d)| *d = buffer[i])
+        dest.iter_mut().enumerate().for_each(|(i, d)| *d = buffer[i]);
+        Ok(())
     }
 }

--- a/miden-crypto/src/ecdh/k256.rs
+++ b/miden-crypto/src/ecdh/k256.rs
@@ -16,14 +16,15 @@ use alloc::{string::ToString, vec::Vec};
 
 use hkdf::{Hkdf, hmac::SimpleHmac};
 use k256::{AffinePoint, elliptic_curve::sec1::ToEncodedPoint, sha2::Sha256};
-use rand::{CryptoRng, RngCore};
+use rand::CryptoRng;
 
 use crate::{
     dsa::ecdsa_k256_keccak::{KeyExchangeKey, PUBLIC_KEY_BYTES, PublicKey},
     ecdh::KeyAgreementScheme,
+    rand::compat::RandCore06,
     utils::{
         ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable,
-        zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing},
+        zeroize::{Zeroize, ZeroizeOnDrop},
     },
 };
 // SHARED SECRET
@@ -109,17 +110,9 @@ impl EphemeralSecretKey {
     }
 
     /// Generates a new ephemeral secret key using the provided random number generator.
-    pub fn with_rng<R: CryptoRng + RngCore>(rng: &mut R) -> Self {
-        // we use a seedable CSPRNG and seed it with `rng`
-        // this is a work around the fact that the version of the `rand` dependency in our crate
-        // is different than the one used in the `k256` one. This solution will no longer be needed
-        // once `k256` gets a new release with a version of the `rand` dependency matching ours
-        use k256::elliptic_curve::rand_core::SeedableRng;
-        let mut seed = Zeroizing::new([0_u8; 32]);
-        RngCore::fill_bytes(rng, &mut *seed);
-        let mut rng = rand_hc::Hc128Rng::from_seed(*seed);
-
-        let sk_e = k256::ecdh::EphemeralSecret::random(&mut rng);
+    pub fn with_rng<R: CryptoRng>(rng: &mut R) -> Self {
+        let mut compat_rng = RandCore06::new(rng);
+        let sk_e = k256::ecdh::EphemeralSecret::random(&mut compat_rng);
         Self { inner: sk_e }
     }
 
@@ -191,7 +184,7 @@ impl KeyAgreementScheme for K256 {
 
     type SharedSecret = SharedSecret;
 
-    fn generate_ephemeral_keypair<R: CryptoRng + RngCore>(
+    fn generate_ephemeral_keypair<R: CryptoRng>(
         rng: &mut R,
     ) -> (Self::EphemeralSecretKey, Self::EphemeralPublicKey) {
         let sk = EphemeralSecretKey::with_rng(rng);

--- a/miden-crypto/src/ecdh/mod.rs
+++ b/miden-crypto/src/ecdh/mod.rs
@@ -2,7 +2,7 @@
 
 use alloc::vec::Vec;
 
-use rand::{CryptoRng, RngCore};
+use rand::CryptoRng;
 use thiserror::Error;
 
 use crate::utils::{
@@ -26,7 +26,7 @@ pub(crate) trait KeyAgreementScheme {
     type SharedSecret: AsRef<[u8]> + Zeroize + ZeroizeOnDrop;
 
     /// Returns an ephemeral key pair generated from the provided RNG.
-    fn generate_ephemeral_keypair<R: CryptoRng + RngCore>(
+    fn generate_ephemeral_keypair<R: CryptoRng>(
         rng: &mut R,
     ) -> (Self::EphemeralSecretKey, Self::EphemeralPublicKey);
 

--- a/miden-crypto/src/ecdh/x25519.rs
+++ b/miden-crypto/src/ecdh/x25519.rs
@@ -16,15 +16,16 @@ use alloc::vec::Vec;
 
 use hkdf::{Hkdf, hmac::SimpleHmac};
 use k256::sha2::Sha256;
-use rand::{CryptoRng, RngCore};
+use rand::CryptoRng;
 use subtle::ConstantTimeEq;
 
 use crate::{
     dsa::eddsa_25519_sha512::{KeyExchangeKey, PublicKey},
     ecdh::KeyAgreementScheme,
+    rand::compat::RandCore06,
     utils::{
         ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable,
-        zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing},
+        zeroize::{Zeroize, ZeroizeOnDrop},
     },
 };
 // SHARED SECRETE
@@ -107,18 +108,9 @@ impl EphemeralSecretKey {
     }
 
     /// Generates a new random ephemeral secret key using the provided RNG.
-    pub fn with_rng<R: CryptoRng + RngCore>(rng: &mut R) -> Self {
-        // we use a seedable CSPRNG and seed it with `rng`
-        // this is a work around the fact that the version of the `rand` dependency in our crate
-        // is different than the one used in the `x25519_dalek` one. This solution will no longer be
-        // needed once `x25519_dalek` gets a new release with a version of the `rand`
-        // dependency matching ours
-        use k256::elliptic_curve::rand_core::SeedableRng;
-        let mut seed = Zeroizing::new([0_u8; 32]);
-        RngCore::fill_bytes(rng, &mut *seed);
-        let rng = rand_hc::Hc128Rng::from_seed(*seed);
-
-        let sk = x25519_dalek::EphemeralSecret::random_from_rng(rng);
+    pub fn with_rng<R: CryptoRng>(rng: &mut R) -> Self {
+        let mut compat_rng = RandCore06::new(rng);
+        let sk = x25519_dalek::EphemeralSecret::random_from_rng(&mut compat_rng);
         Self { inner: sk }
     }
 
@@ -186,7 +178,7 @@ impl KeyAgreementScheme for X25519 {
 
     type SharedSecret = SharedSecret;
 
-    fn generate_ephemeral_keypair<R: CryptoRng + RngCore>(
+    fn generate_ephemeral_keypair<R: CryptoRng>(
         rng: &mut R,
     ) -> (Self::EphemeralSecretKey, Self::EphemeralPublicKey) {
         let sk = EphemeralSecretKey::with_rng(rng);

--- a/miden-crypto/src/ies/crypto_box.rs
+++ b/miden-crypto/src/ies/crypto_box.rs
@@ -6,7 +6,7 @@
 
 use alloc::vec::Vec;
 
-use rand::{CryptoRng, RngCore};
+use rand::CryptoRng;
 
 use super::{IesError, IesScheme};
 use crate::{
@@ -42,7 +42,7 @@ impl<K: KeyAgreementScheme, A: AeadScheme> CryptoBox<K, A> {
     // BYTE-SPECIFIC METHODS
     // --------------------------------------------------------------------------------------------
 
-    pub fn seal_bytes_with_associated_data<R: CryptoRng + RngCore>(
+    pub fn seal_bytes_with_associated_data<R: CryptoRng>(
         rng: &mut R,
         recipient_public_key: &K::PublicKey,
         scheme: IesScheme,
@@ -103,7 +103,7 @@ impl<K: KeyAgreementScheme, A: AeadScheme> CryptoBox<K, A> {
     // ELEMENT-SPECIFIC METHODS
     // --------------------------------------------------------------------------------------------
 
-    pub fn seal_elements_with_associated_data<R: CryptoRng + RngCore>(
+    pub fn seal_elements_with_associated_data<R: CryptoRng>(
         rng: &mut R,
         recipient_public_key: &K::PublicKey,
         scheme: IesScheme,

--- a/miden-crypto/src/ies/keys.rs
+++ b/miden-crypto/src/ies/keys.rs
@@ -1,7 +1,7 @@
 use alloc::vec::Vec;
 use core::fmt;
 
-use rand::{CryptoRng, RngCore};
+use rand::CryptoRng;
 
 use super::{IesError, IesScheme, crypto_box::CryptoBox, message::SealedMessage};
 use crate::{
@@ -38,7 +38,7 @@ macro_rules! impl_seal_bytes_with_associated_data {
         ///
         /// The returned message can be unsealed with the [UnsealingKey] associated with this
         /// sealing key.
-        pub fn seal_bytes_with_associated_data<R: CryptoRng + RngCore>(
+        pub fn seal_bytes_with_associated_data<R: CryptoRng>(
             &self,
             rng: &mut R,
             plaintext: &[u8],
@@ -75,7 +75,7 @@ macro_rules! impl_seal_elements_with_associated_data {
         ///
         /// The returned message can be unsealed with the [UnsealingKey] associated with this
         /// sealing key.
-        pub fn seal_elements_with_associated_data<R: CryptoRng + RngCore>(
+        pub fn seal_elements_with_associated_data<R: CryptoRng>(
             &self,
             rng: &mut R,
             plaintext: &[Felt],
@@ -221,7 +221,7 @@ impl SealingKey {
     ///
     /// The returned message can be unsealed with the [UnsealingKey] associated with this sealing
     /// key.
-    pub fn seal_bytes<R: CryptoRng + RngCore>(
+    pub fn seal_bytes<R: CryptoRng>(
         &self,
         rng: &mut R,
         plaintext: &[u8],
@@ -240,7 +240,7 @@ impl SealingKey {
     ///
     /// The returned message can be unsealed with the [UnsealingKey] associated with this sealing
     /// key.
-    pub fn seal_elements<R: CryptoRng + RngCore>(
+    pub fn seal_elements<R: CryptoRng>(
         &self,
         rng: &mut R,
         plaintext: &[Felt],

--- a/miden-crypto/src/ies/tests.rs
+++ b/miden-crypto/src/ies/tests.rs
@@ -3,7 +3,7 @@
 use alloc::vec::Vec;
 
 use proptest::prelude::*;
-use rand::{RngCore, SeedableRng};
+use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha20Rng;
 
 use crate::{

--- a/miden-crypto/src/main.rs
+++ b/miden-crypto/src/main.rs
@@ -9,7 +9,7 @@ use miden_crypto::{
     merkle::smt::{LargeSmt, LargeSmtError, MemoryStorage},
     rand::test_utils::rand_value,
 };
-use rand::{Rng, prelude::IteratorRandom, rng};
+use rand::{RngExt, prelude::IteratorRandom, rng};
 
 #[cfg(feature = "executable")]
 mod boxed_storage;
@@ -204,16 +204,15 @@ pub fn batched_update(
     let size = tree.num_leaves();
     let mut rng = rng();
 
-    let new_pairs =
-        entries.iter().choose_multiple(&mut rng, updates).into_iter().map(|&(key, _)| {
-            let value = if rng.random_bool(REMOVAL_PROBABILITY) {
-                EMPTY_WORD
-            } else {
-                Word::new([ONE, ONE, ONE, Felt::new_unchecked(rng.random())])
-            };
+    let new_pairs = entries.iter().sample(&mut rng, updates).into_iter().map(|&(key, _)| {
+        let value = if rng.random_bool(REMOVAL_PROBABILITY) {
+            EMPTY_WORD
+        } else {
+            Word::new([ONE, ONE, ONE, Felt::new_unchecked(rng.random())])
+        };
 
-            (key, value)
-        });
+        (key, value)
+    });
 
     assert_eq!(new_pairs.len(), updates);
 

--- a/miden-crypto/src/merkle/smt/full/concurrent/tests.rs
+++ b/miden-crypto/src/merkle/smt/full/concurrent/tests.rs
@@ -7,7 +7,7 @@ use alloc::{
 
 use assert_matches::assert_matches;
 use proptest::prelude::*;
-use rand::{Rng, SeedableRng, prelude::IteratorRandom};
+use rand::{RngExt, SeedableRng, prelude::IteratorRandom};
 use rand_chacha::ChaCha20Rng;
 
 use super::{
@@ -132,7 +132,7 @@ fn generate_updates(entries: Vec<(Word, Word)>, updates: usize) -> Vec<(Word, Wo
     );
     let mut sorted_entries: Vec<(Word, Word)> = entries
         .into_iter()
-        .choose_multiple(&mut rng, updates)
+        .sample(&mut rng, updates)
         .into_iter()
         .map(|(key, _)| {
             let value = if rng.random_bool(REMOVAL_PROBABILITY) {

--- a/miden-crypto/src/merkle/smt/large/tests.rs
+++ b/miden-crypto/src/merkle/smt/large/tests.rs
@@ -1,6 +1,6 @@
 use alloc::{collections::BTreeSet, vec::Vec};
 
-use rand::{Rng, prelude::IteratorRandom, rng};
+use rand::{RngExt, prelude::IteratorRandom, rng};
 
 use super::{IN_MEMORY_DEPTH, MemoryStorage, SmtStorage, SmtStorageReader};
 use crate::{
@@ -35,7 +35,7 @@ fn generate_updates(entries: Vec<(Word, Word)>, updates: usize) -> Vec<(Word, Wo
     );
     let mut sorted_entries: Vec<(Word, Word)> = entries
         .into_iter()
-        .choose_multiple(&mut rng, updates)
+        .sample(&mut rng, updates)
         .into_iter()
         .map(|(key, _)| {
             let value = if rng.random_bool(REMOVAL_PROBABILITY) {

--- a/miden-crypto/src/merkle/smt/partial/tests.rs
+++ b/miden-crypto/src/merkle/smt/partial/tests.rs
@@ -6,7 +6,7 @@ use alloc::{
 use assert_matches::assert_matches;
 use itertools::Itertools;
 use proptest::prelude::*;
-use rand::{Rng, SeedableRng};
+use rand::{Rng, RngExt, SeedableRng};
 use rand_chacha::ChaCha20Rng;
 
 use super::{PartialSmt, SMT_DEPTH, serialization::property_tests::arbitrary_valid_word};

--- a/miden-crypto/src/rand/coin.rs
+++ b/miden-crypto/src/rand/coin.rs
@@ -1,8 +1,11 @@
 use alloc::string::ToString;
 
-use rand_core::impls;
+use rand::{
+    Rng,
+    rand_core::{Infallible, TryRng, utils},
+};
 
-use super::{Felt, FeltRng, RngCore};
+use super::{Felt, FeltRng};
 use crate::{
     Word, ZERO,
     field::ExtensionField,
@@ -68,7 +71,7 @@ impl RandomCoin {
 
     /// Fills `dest` with random data.
     pub fn fill_bytes(&mut self, dest: &mut [u8]) {
-        <Self as RngCore>::fill_bytes(self, dest)
+        <Self as Rng>::fill_bytes(self, dest)
     }
 
     /// Draws a random base field element from the random coin.
@@ -142,20 +145,22 @@ impl FeltRng for RandomCoin {
     }
 }
 
-// RNGCORE IMPLEMENTATION
+// RNG IMPLEMENTATION
 // ------------------------------------------------------------------------------------------------
 
-impl RngCore for RandomCoin {
-    fn next_u32(&mut self) -> u32 {
-        self.draw_basefield().as_canonical_u64() as u32
+impl TryRng for RandomCoin {
+    type Error = Infallible;
+
+    fn try_next_u32(&mut self) -> Result<u32, Self::Error> {
+        Ok(self.draw_basefield().as_canonical_u64() as u32)
     }
 
-    fn next_u64(&mut self) -> u64 {
-        impls::next_u64_via_u32(self)
+    fn try_next_u64(&mut self) -> Result<u64, Self::Error> {
+        utils::next_u64_via_u32(self)
     }
 
-    fn fill_bytes(&mut self, dest: &mut [u8]) {
-        impls::fill_bytes_via_next(self, dest)
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Self::Error> {
+        utils::fill_bytes_via_next_word(dest, || self.try_next_u32())
     }
 }
 

--- a/miden-crypto/src/rand/compat.rs
+++ b/miden-crypto/src/rand/compat.rs
@@ -1,0 +1,34 @@
+use rand::{CryptoRng, Rng};
+
+/// Adapts rand 0.10 RNGs for stable crypto crates that still use rand_core 0.6.
+pub(crate) struct RandCore06<'a, R: ?Sized>(&'a mut R);
+
+impl<'a, R: ?Sized> RandCore06<'a, R> {
+    pub(crate) fn new(rng: &'a mut R) -> Self {
+        Self(rng)
+    }
+}
+
+impl<R: Rng + ?Sized> k256::elliptic_curve::rand_core::RngCore for RandCore06<'_, R> {
+    fn next_u32(&mut self) -> u32 {
+        self.0.next_u32()
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        self.0.next_u64()
+    }
+
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
+        self.0.fill_bytes(dest);
+    }
+
+    fn try_fill_bytes(
+        &mut self,
+        dest: &mut [u8],
+    ) -> Result<(), k256::elliptic_curve::rand_core::Error> {
+        self.0.fill_bytes(dest);
+        Ok(())
+    }
+}
+
+impl<R: CryptoRng + ?Sized> k256::elliptic_curve::rand_core::CryptoRng for RandCore06<'_, R> {}

--- a/miden-crypto/src/rand/mod.rs
+++ b/miden-crypto/src/rand/mod.rs
@@ -1,11 +1,12 @@
 //! Pseudo-random element generation.
 
-use rand::RngCore;
+use rand::Rng;
 
 use crate::{Felt, Word};
 
 mod coin;
 pub use coin::RandomCoin;
+pub(crate) mod compat;
 
 // Test utilities for generating random data (used in tests and benchmarks)
 #[cfg(any(test, feature = "std"))]
@@ -127,7 +128,7 @@ impl<const N: usize> Randomizable for [u8; N] {
 /// Pseudo-random element generator.
 ///
 /// An instance can be used to draw, uniformly at random, base field elements as well as [Word]s.
-pub trait FeltRng: RngCore {
+pub trait FeltRng: Rng {
     /// Draw, uniformly at random, a base field element.
     fn draw_element(&mut self) -> Felt;
 
@@ -143,7 +144,7 @@ pub trait FeltRng: RngCore {
 /// This function is only available with the `std` feature.
 #[cfg(feature = "std")]
 pub fn random_felt() -> Felt {
-    use rand::Rng;
+    use rand::RngExt;
     let mut rng = rand::rng();
     // We use the `Felt::new` constructor to do rejection sampling here. It should effectively
     // never repeat, but nevertheless gives us the correct distribution.

--- a/miden-crypto/src/rand/test_utils.rs
+++ b/miden-crypto/src/rand/test_utils.rs
@@ -18,7 +18,7 @@
 
 use alloc::{vec, vec::Vec};
 
-use rand::{Rng, SeedableRng};
+use rand::{Rng, RngExt, SeedableRng};
 use rand_chacha::ChaCha20Rng;
 
 use crate::rand::Randomizable;
@@ -32,7 +32,7 @@ use crate::rand::Randomizable;
 /// ```
 /// # use miden_crypto::rand::test_utils::seeded_rng;
 /// let mut rng = seeded_rng([0u8; 32]);
-/// // Use rng with any function that accepts impl RngCore
+/// // Use rng with any function that accepts impl Rng
 /// ```
 pub fn seeded_rng(seed: [u8; 32]) -> ChaCha20Rng {
     ChaCha20Rng::from_seed(seed)


### PR DESCRIPTION
Closes #893, closes #927  — proptest uses rand 0.9 but is behind the testing feature.

Needed only because `cargo-deny` sees dev/test deps:
      - rand =0.9.4
      - rand_chacha =0.9.0
      - rand_core =0.9.5

Those dev-only ones come from `proptest`, not from `miden-crypto`’s normal dependency graph. So: consumers without testing do not need the `proptest`/`rand 0.9` exceptions,