### PR TITLE
fix(mmr): bind peak hash to forest leaf count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.26.0 (TBD)
 
 - [BREAKING] Upgraded direct `rand` dependencies to 0.10, updating RNG trait bounds and removing direct `rand_hc` usage ([#995](https://github.com/0xMiden/crypto/pull/995)).
+- [BREAKING] Bound `MmrPeaks::hash_peaks()` commitments to the forest leaf count, preventing structurally distinct MMRs with identical peak values from producing the same commitment ([#997](https://github.com/0xMiden/crypto/pull/997)).
 
 ## 0.25.0 (2026-05-01)
 

--- a/miden-crypto/src/merkle/mmr/peaks.rs
+++ b/miden-crypto/src/merkle/mmr/peaks.rs
@@ -117,13 +117,24 @@ impl MmrPeaks {
         (self.forest, self.peaks)
     }
 
-    /// Hashes the peaks.
+    /// Hashes the forest leaf count and peaks.
     ///
     /// The procedure will:
+    /// - Prefix the preimage with `[num_leaves, 0, 0, 0]` to bind the forest shape.
     /// - Flatten and pad the peaks to a vector of Felts.
     /// - Hash the vector of Felts.
     pub fn hash_peaks(&self) -> Word {
-        Poseidon2::hash_elements(&self.flatten_and_pad_peaks())
+        let padded_peaks = self.flatten_and_pad_peaks();
+        let mut elements = Vec::with_capacity(Word::NUM_ELEMENTS + padded_peaks.len());
+        elements.extend_from_slice(&[
+            Felt::new_unchecked(self.num_leaves() as u64),
+            ZERO,
+            ZERO,
+            ZERO,
+        ]);
+        elements.extend_from_slice(&padded_peaks);
+
+        Poseidon2::hash_elements(&elements)
     }
 
     /// Verifies the Merkle opening proof.

--- a/miden-crypto/src/merkle/mmr/tests.rs
+++ b/miden-crypto/src/merkle/mmr/tests.rs
@@ -1185,6 +1185,25 @@ fn test_mmr_peaks_hash_binds_num_leaves() {
 }
 
 #[test]
+fn test_empty_mmr_peaks_hash_includes_num_leaves() {
+    let peaks = MmrPeaks::default();
+
+    let expected_peaks = vec![Word::default(); 16];
+    assert_eq!(peaks.hash_peaks(), mmr_commitment(0, &expected_peaks));
+}
+
+#[test]
+fn test_mmr_peaks_hash_binds_multi_peak_forest_shape() {
+    let peaks = vec![int_to_node(0), int_to_node(1)];
+
+    let five_leaf_peaks = MmrPeaks::new(Forest::new(0b0101).unwrap(), peaks.clone()).unwrap();
+    let six_leaf_peaks = MmrPeaks::new(Forest::new(0b0110).unwrap(), peaks).unwrap();
+
+    assert_eq!(five_leaf_peaks.flatten_and_pad_peaks(), six_leaf_peaks.flatten_and_pad_peaks());
+    assert_ne!(five_leaf_peaks.hash_peaks(), six_leaf_peaks.hash_peaks());
+}
+
+#[test]
 fn test_mmr_delta() {
     let mmr = Mmr::try_from_iter(LEAVES.iter().copied()).unwrap();
     let acc = mmr.peaks();

--- a/miden-crypto/src/merkle/mmr/tests.rs
+++ b/miden-crypto/src/merkle/mmr/tests.rs
@@ -1134,10 +1134,7 @@ fn test_mmr_hash_peaks() {
     // minimum length is 16
     let mut expected_peaks = [first_peak, second_peak, third_peak].to_vec();
     expected_peaks.resize(16, Word::default());
-    assert_eq!(
-        peaks.hash_peaks(),
-        Poseidon2::hash_elements(&digests_to_elements(&expected_peaks))
-    );
+    assert_eq!(peaks.hash_peaks(), mmr_commitment(peaks.num_leaves() as u64, &expected_peaks));
 }
 
 #[test]
@@ -1155,7 +1152,7 @@ fn test_mmr_peaks_hash_less_than_16() {
         expected_peaks.resize(16, Word::default());
         assert_eq!(
             accumulator.hash_peaks(),
-            Poseidon2::hash_elements(&digests_to_elements(&expected_peaks))
+            mmr_commitment(accumulator.num_leaves() as u64, &expected_peaks)
         );
     }
 }
@@ -1172,8 +1169,19 @@ fn test_mmr_peaks_hash_odd() {
     expected_peaks.resize(18, Word::default());
     assert_eq!(
         accumulator.hash_peaks(),
-        Poseidon2::hash_elements(&digests_to_elements(&expected_peaks))
+        mmr_commitment(accumulator.num_leaves() as u64, &expected_peaks)
     );
+}
+
+#[test]
+fn test_mmr_peaks_hash_binds_num_leaves() {
+    let peak = int_to_node(0);
+
+    let one_leaf_peaks = MmrPeaks::new(Forest::new(1).unwrap(), vec![peak]).unwrap();
+    let two_leaf_peaks = MmrPeaks::new(Forest::new(2).unwrap(), vec![peak]).unwrap();
+
+    assert_eq!(one_leaf_peaks.flatten_and_pad_peaks(), two_leaf_peaks.flatten_and_pad_peaks());
+    assert_ne!(one_leaf_peaks.hash_peaks(), two_leaf_peaks.hash_peaks());
 }
 
 #[test]
@@ -1504,8 +1512,18 @@ mod property_tests {
 // HELPER FUNCTIONS
 // ================================================================================================
 
-fn digests_to_elements(digests: &[Word]) -> Vec<Felt> {
-    Word::words_as_elements(digests).to_vec()
+fn mmr_commitment(num_leaves: u64, padded_peaks: &[Word]) -> Word {
+    let padded_peak_elements = Word::words_as_elements(padded_peaks);
+    let mut elements = Vec::with_capacity(Word::NUM_ELEMENTS + padded_peak_elements.len());
+    elements.extend_from_slice(&[
+        Felt::new_unchecked(num_leaves),
+        Felt::ZERO,
+        Felt::ZERO,
+        Felt::ZERO,
+    ]);
+    elements.extend_from_slice(padded_peak_elements);
+
+    Poseidon2::hash_elements(&elements)
 }
 
 // short hand for the Poseidon2 hash, used to make test code more concise and easy to read


### PR DESCRIPTION
## Describe your changes

This PR updates `MmrPeaks::hash_peaks()` to bind the forest leaf count by hashing:

```rust
[num_leaves, 0, 0, 0] || padded_peaks
```

This matches the commitment format introduced in [miden-vm#3109 ](https://github.com/0xMiden/miden-vm/pull/3109)for MMR `pack`/`unpack`, and addresses 0xMiden/miden-vm#3512  by ensuring identical peak values under different forests produce different commitments.

## Checklist before requesting a review
- [x] Repo forked and branch created from `next` according to naming convention.
- [x] Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- [x] Relevant issues are linked in the PR description.
- [x] Tests added for new functionality.
- [x] Documentation/comments updated according to changes.
