### PR TITLE
fix: link fuzz targets in PR checks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,7 +67,9 @@ jobs:
       - name: Cleanup large tools for build space
         uses: ./.github/actions/cleanup-runner
       - name: Install Rust toolchain
-        run: rustup toolchain install --no-self-update
+        run: |
+          rustup toolchain install --no-self-update
+          rustup toolchain install --no-self-update nightly
       - uses: WarpBuilds/rust-cache@9d0cc3090d9c87de74ea67617b246e978735b1a1 # pin@v2
         with:
           # Fuzz crates are separate workspaces, so cache them explicitly.
@@ -75,5 +77,7 @@ jobs:
             .
             miden-crypto-fuzz
             miden-serde-utils/fuzz
+      - name: Install cargo-fuzz
+        run: cargo +nightly install cargo-fuzz --version 0.13.1
       - name: Check fuzz crates
         run: make check-fuzz

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,8 @@ help:
 
 ALL_FEATURES_EXCEPT_ROCKSDB="concurrent executable internal serde std"
 MIDEN_STARK_TEST_PACKAGES=-p miden-lifted-air -p miden-lifted-stark -p miden-stateful-hasher -p miden-stark-transcript
+MIDEN_CRYPTO_FUZZ_TARGETS=word merkle merkle_store smt_serde partial_smt mmr crypto aead signatures
+MIDEN_SERDE_UTILS_FUZZ_TARGETS=primitives collections string vint64 goldilocks budgeted
 WARNINGS=RUSTDOCFLAGS="-D warnings"
 
 # -- linting --------------------------------------------------------------------------------------
@@ -119,9 +121,15 @@ check-features: ## Check curated feature combinations across the integrated work
 	./scripts/check-features.sh
 
 .PHONY: check-fuzz
-check-fuzz: ## Check fuzz crate compilation
+check-fuzz: ## Check and link fuzz targets
 	cd miden-crypto-fuzz && cargo check --locked
 	cd miden-serde-utils/fuzz && cargo check --locked
+	for target in $(MIDEN_CRYPTO_FUZZ_TARGETS); do \
+		cargo +nightly fuzz build --fuzz-dir miden-crypto-fuzz $$target; \
+	done
+	for target in $(MIDEN_SERDE_UTILS_FUZZ_TARGETS); do \
+		(cd miden-serde-utils && cargo +nightly fuzz build $$target); \
+	done
 
 # --- building ------------------------------------------------------------------------------------
 

--- a/miden-crypto/Cargo.toml
+++ b/miden-crypto/Cargo.toml
@@ -88,7 +88,7 @@ internal          = ["concurrent"]
 persistent-forest = ["rocksdb", "serde"]
 rocksdb           = ["concurrent", "dep:rocksdb"]
 serde             = ["dep:serde", "serde?/alloc"]
-std               = ["blake3/std", "dep:cc", "miden-serde-utils/std", "rand/std", "rand/thread_rng", "serde?/std"]
+std               = ["blake3/std", "dep:cc", "miden-serde-utils/std", "once_cell/std", "rand/std", "rand/thread_rng", "serde?/std"]
 testing           = ["dep:proptest", "miden-field/testing"]
 
 [dependencies]


### PR DESCRIPTION
The rand 0.10 migration removed transitive feature unification that had been enabling `once_cell/std` for `miden-crypto`. The scheduled fuzz workflow caught the resulting critical-section undefined symbols because cargo-fuzz performs the final sanitizer link, but the PR fuzz check only ran cargo check, which type-checks metadata and does not link executables.

Enable `once_cell/std` from `miden-crypto`'s std feature directly, and make check-fuzz build every cargo-fuzz target with nightly. The build workflow now installs nightly and the pinned cargo-fuzz version so future link-only fuzz regressions fail during PR checks instead of waiting for the scheduled fuzz run.

