### PR TITLE
refactor(smt/large_forest): introduce a two-phase mutation API

### DIFF
--- a/miden-crypto/src/merkle/smt/large_forest/backend/memory/mod.rs
+++ b/miden-crypto/src/merkle/smt/large_forest/backend/memory/mod.rs
@@ -13,9 +13,10 @@ use crate::{
         LeafIndex, SMT_DEPTH, Smt, SmtLeaf, SmtProof, VersionId,
         large_forest::{
             Backend, BackendReader,
-            backend::{BackendError, MutationSet, Result},
+            backend::{BackendError, Result},
             operation::{SmtForestUpdateBatch, SmtUpdateBatch},
             root::{LineageId, TreeEntry, TreeWithRoot},
+            utils::{AppliedLineageMutation, LineageMutation, LineageMutationKind, MutationSet},
         },
     },
 };
@@ -76,6 +77,29 @@ pub struct InMemoryBackend {
     trees: Map<LineageId, TreeData>,
 }
 
+/// Prepared mutations for [`InMemoryBackend`].
+///
+/// This is the in-memory backend's concrete [`Backend::PreparedMutations`] type. It stores the
+/// forward SMT mutation sets that were computed during the first phase of a forest update. Applying
+/// it mutates the in-memory trees directly without recomputing the update batches.
+///
+/// The fields are private because callers should treat prepared mutation data as opaque and pass it
+/// back through
+/// [`LargeSmtForest::apply_mutations`](crate::merkle::smt::LargeSmtForest::apply_mutations).
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct InMemoryPreparedMutations {
+    entries: Vec<InMemoryPreparedLineageMutation>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct InMemoryPreparedLineageMutation {
+    lineage: LineageId,
+    old_version: Option<VersionId>,
+    version: VersionId,
+    forward: MutationSet,
+    kind: LineageMutationKind,
+}
+
 impl InMemoryBackend {
     /// Constructs a new instance of the in-memory backend.
     pub fn new() -> Self {
@@ -86,6 +110,29 @@ impl InMemoryBackend {
     /// Converts this backend into a read-only snapshot.
     pub fn into_snapshot(self) -> InMemoryBackendSnapshot {
         InMemoryBackendSnapshot(self)
+    }
+
+    fn mutation_from_tree(
+        lineage: LineageId,
+        old_version: Option<VersionId>,
+        new_version: VersionId,
+        kind: LineageMutationKind,
+        forward: MutationSet,
+    ) -> (LineageMutation, InMemoryPreparedLineageMutation) {
+        let old_root = forward.old_root();
+        let new_root = forward.root();
+
+        let mutation =
+            LineageMutation::new(lineage, old_version, new_version, old_root, new_root, kind);
+        let prepared = InMemoryPreparedLineageMutation {
+            lineage,
+            old_version,
+            version: new_version,
+            forward,
+            kind,
+        };
+
+        (mutation, prepared)
     }
 }
 
@@ -191,11 +238,204 @@ impl BackendReader for InMemoryBackend {
 
 impl Backend for InMemoryBackend {
     type Reader = InMemoryBackendSnapshot;
+    type PreparedMutations = InMemoryPreparedMutations;
 
     fn reader(&self) -> Result<Self::Reader> {
         Ok(self.clone().into_snapshot())
     }
 
+    fn compute_add_lineage_mutations(
+        &self,
+        lineage: LineageId,
+        version: VersionId,
+        updates: SmtUpdateBatch,
+    ) -> Result<(Vec<LineageMutation>, Self::PreparedMutations)> {
+        if self.trees.contains_key(&lineage) {
+            return Err(BackendError::DuplicateLineage(lineage));
+        }
+
+        let tree = Smt::new();
+        let forward = tree.compute_mutations(updates.into_iter().map(Into::into))?;
+        let (mutation, prepared) = Self::mutation_from_tree(
+            lineage,
+            None,
+            version,
+            LineageMutationKind::AddLineage,
+            forward,
+        );
+
+        Ok((vec![mutation], InMemoryPreparedMutations { entries: vec![prepared] }))
+    }
+
+    fn compute_update_tree_mutations(
+        &self,
+        lineage: LineageId,
+        new_version: VersionId,
+        updates: SmtUpdateBatch,
+    ) -> Result<(Vec<LineageMutation>, Self::PreparedMutations)> {
+        let tree_data = self.trees.get(&lineage).ok_or(BackendError::UnknownLineage(lineage))?;
+        let forward = tree_data.tree.compute_mutations(updates.into_iter().map(Into::into))?;
+        let (mutation, prepared) = Self::mutation_from_tree(
+            lineage,
+            Some(tree_data.version),
+            new_version,
+            LineageMutationKind::UpdateTree,
+            forward,
+        );
+
+        Ok((vec![mutation], InMemoryPreparedMutations { entries: vec![prepared] }))
+    }
+
+    fn compute_add_lineages_mutations(
+        &self,
+        version: VersionId,
+        lineages: SmtForestUpdateBatch,
+    ) -> Result<(Vec<LineageMutation>, Self::PreparedMutations)> {
+        let updates = lineages
+            .into_iter()
+            .map(|(lineage, ops)| {
+                if self.trees.contains_key(&lineage) {
+                    return Err(BackendError::DuplicateLineage(lineage));
+                }
+                Ok((lineage, ops))
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        let mut mutations = Vec::with_capacity(updates.len());
+        let mut prepared = Vec::with_capacity(updates.len());
+        for (lineage, ops) in updates {
+            let tree = Smt::new();
+            let forward = tree.compute_mutations(ops.into_iter().map(Into::into))?;
+            let (mutation, prepared_entry) = Self::mutation_from_tree(
+                lineage,
+                None,
+                version,
+                LineageMutationKind::AddLineage,
+                forward,
+            );
+            mutations.push(mutation);
+            prepared.push(prepared_entry);
+        }
+
+        Ok((mutations, InMemoryPreparedMutations { entries: prepared }))
+    }
+
+    fn compute_update_forest_mutations(
+        &self,
+        new_version: VersionId,
+        updates: SmtForestUpdateBatch,
+    ) -> Result<(Vec<LineageMutation>, Self::PreparedMutations)> {
+        let updates = updates
+            .into_iter()
+            .map(|(lineage, ops)| {
+                if !self.trees.contains_key(&lineage) {
+                    return Err(BackendError::UnknownLineage(lineage));
+                }
+
+                Ok((lineage, ops))
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        let mut mutations = Vec::with_capacity(updates.len());
+        let mut prepared = Vec::with_capacity(updates.len());
+        for (lineage, ops) in updates {
+            let tree_data = self.trees.get(&lineage).expect("Tree known to be present was not");
+            let forward = tree_data.tree.compute_mutations(ops.into_iter().map(Into::into))?;
+            let (mutation, prepared_entry) = Self::mutation_from_tree(
+                lineage,
+                Some(tree_data.version),
+                new_version,
+                LineageMutationKind::UpdateTree,
+                forward,
+            );
+            mutations.push(mutation);
+            prepared.push(prepared_entry);
+        }
+
+        Ok((mutations, InMemoryPreparedMutations { entries: prepared }))
+    }
+
+    fn apply_mutations(
+        &mut self,
+        mutations: Self::PreparedMutations,
+    ) -> Result<Vec<AppliedLineageMutation>> {
+        for mutation in &mutations.entries {
+            match mutation.kind {
+                LineageMutationKind::AddLineage => {
+                    if self.trees.contains_key(&mutation.lineage) {
+                        return Err(BackendError::DuplicateLineage(mutation.lineage));
+                    }
+                },
+                LineageMutationKind::UpdateTree => {
+                    if !self.trees.contains_key(&mutation.lineage) {
+                        return Err(BackendError::UnknownLineage(mutation.lineage));
+                    }
+                },
+            }
+        }
+
+        let mut applied = Vec::with_capacity(mutations.entries.len());
+
+        for mutation in mutations.entries {
+            let old_root = mutation.forward.old_root();
+            let new_root = mutation.forward.root();
+            match mutation.kind {
+                LineageMutationKind::AddLineage => {
+                    let mut tree = Smt::new();
+                    let reverse = MutationSet::default();
+                    if !mutation.forward.is_empty() {
+                        tree.apply_mutations(mutation.forward)
+                            .map_err(BackendError::internal_from)?;
+                    }
+                    applied.push(AppliedLineageMutation::new(
+                        mutation.lineage,
+                        mutation.old_version,
+                        mutation.version,
+                        old_root,
+                        new_root,
+                        0,
+                        reverse,
+                        mutation.kind,
+                    ));
+                    self.trees
+                        .insert(mutation.lineage, TreeData { version: mutation.version, tree });
+                },
+                LineageMutationKind::UpdateTree => {
+                    let tree_data = self
+                        .trees
+                        .get_mut(&mutation.lineage)
+                        .ok_or(BackendError::UnknownLineage(mutation.lineage))?;
+                    let old_entry_count = tree_data.tree.num_entries();
+                    let reverse = if mutation.forward.is_empty() {
+                        mutation.forward
+                    } else {
+                        let reverse = tree_data
+                            .tree
+                            .apply_mutations_with_reversion(mutation.forward)
+                            .map_err(BackendError::internal_from)?;
+                        tree_data.version = mutation.version;
+                        reverse
+                    };
+                    applied.push(AppliedLineageMutation::new(
+                        mutation.lineage,
+                        mutation.old_version,
+                        mutation.version,
+                        old_root,
+                        new_root,
+                        old_entry_count,
+                        reverse,
+                        mutation.kind,
+                    ));
+                },
+            }
+        }
+
+        Ok(applied)
+    }
+}
+
+#[cfg(test)]
+impl InMemoryBackend {
     /// Adds the provided `lineage` to the forest.
     ///
     /// # Errors
@@ -203,14 +443,13 @@ impl Backend for InMemoryBackend {
     /// - [`BackendError::DuplicateLineage`] if the provided `lineage` is the same as an
     ///   already-known lineage. No data is changed in this case.
     /// - [`BackendError::Merkle`] if the provided `updates` cannot be applied to the empty tree.
-    fn add_lineage(
+    pub(crate) fn add_lineage(
         &mut self,
         lineage: LineageId,
         version: VersionId,
         updates: SmtUpdateBatch,
     ) -> Result<TreeWithRoot> {
-        // Returning this in the case of a duplicate lineage is required by the method contract on
-        // the `Backend` trait.
+        // Match the forest-level behavior expected by the backend tests.
         if self.trees.contains_key(&lineage) {
             return Err(BackendError::DuplicateLineage(lineage));
         }
@@ -244,14 +483,13 @@ impl Backend for InMemoryBackend {
     /// - [`BackendError::Merkle`] if the application of `updates` to the tree fails for any reason.
     /// - [`BackendError::UnknownLineage`] If the provided `lineage` is one not known by this
     ///   backend.
-    fn update_tree(
+    pub(crate) fn update_tree(
         &mut self,
         lineage: LineageId,
         new_version: VersionId,
         updates: SmtUpdateBatch,
     ) -> Result<MutationSet> {
-        // The method contract requires raising this error in the case that `lineage` is unknown to
-        // the backend.
+        // Unknown lineages must be rejected before any state changes.
         let tree_data =
             self.trees.get_mut(&lineage).ok_or(BackendError::UnknownLineage(lineage))?;
         let tree = &mut tree_data.tree;
@@ -261,9 +499,8 @@ impl Backend for InMemoryBackend {
         // user-input and hence is forwarded as-is.
         let mutations = tree.compute_mutations(updates.into_iter().map(Into::into))?;
 
-        // The invariants on this method given by the `Backend` trait states that no new allocations
-        // should be performed if the updates do not change the tree. As a result, we can
-        // short-circuit even trying.
+        // Preserve the existing no-op behavior: if the updates do not change the tree, do not
+        // allocate a new version.
         if mutations.is_empty() {
             // As the reverse of an empty mutations is also empty mutations, we can just return
             // that.
@@ -295,7 +532,7 @@ impl Backend for InMemoryBackend {
     ///   lineage. No data is changed in this case.
     /// - [`BackendError::Merkle`] if any of the provided updates cannot be applied on top of the
     ///   empty tree.
-    fn add_lineages(
+    pub(crate) fn add_lineages(
         &mut self,
         version: VersionId,
         lineages: SmtForestUpdateBatch,
@@ -362,7 +599,7 @@ impl Backend for InMemoryBackend {
     /// # Panics
     ///
     /// - If a tree that has been checked to be present is not present upon later access.
-    fn update_forest(
+    pub(crate) fn update_forest(
         &mut self,
         new_version: VersionId,
         updates: SmtForestUpdateBatch,

--- a/miden-crypto/src/merkle/smt/large_forest/backend/memory/property_tests.rs
+++ b/miden-crypto/src/merkle/smt/large_forest/backend/memory/property_tests.rs
@@ -9,7 +9,7 @@ use proptest::prelude::*;
 use crate::{
     EMPTY_WORD,
     merkle::smt::{
-        Backend, BackendReader, Smt, SmtForestUpdateBatch, SmtUpdateBatch, TreeWithRoot,
+        BackendReader, Smt, SmtForestUpdateBatch, SmtUpdateBatch, TreeWithRoot,
         large_forest::{
             InMemoryBackend,
             test_utils::{

--- a/miden-crypto/src/merkle/smt/large_forest/backend/memory/tests.rs
+++ b/miden-crypto/src/merkle/smt/large_forest/backend/memory/tests.rs
@@ -623,6 +623,48 @@ fn update_tree() -> Result<()> {
 }
 
 #[test]
+fn apply_mutations_returns_reversion_data() -> Result<()> {
+    let mut backend = InMemoryBackend::new();
+    let mut rng = ContinuousRng::new([0x77; 32]);
+
+    let lineage: LineageId = rng.value();
+    let version_1: VersionId = rng.value();
+    let version_2: VersionId = rng.value();
+    let key_1: Word = rng.value();
+    let value_1: Word = rng.value();
+    let key_2: Word = rng.value();
+    let value_2: Word = rng.value();
+    let value_3: Word = rng.value();
+
+    let mut initial = SmtUpdateBatch::default();
+    initial.add_insert(key_1, value_1);
+    initial.add_insert(key_2, value_2);
+    backend.add_lineage(lineage, version_1, initial)?;
+
+    let mut reference = Smt::new();
+    reference.insert(key_1, value_1)?;
+    reference.insert(key_2, value_2)?;
+    let old_entry_count = reference.num_entries();
+
+    let mut updates = SmtUpdateBatch::default();
+    updates.add_insert(key_2, value_3);
+    let expected_forward = reference.compute_mutations([(key_2, value_3)])?;
+    let expected_reverse = reference.apply_mutations_with_reversion(expected_forward)?;
+
+    let (_, prepared) = backend.compute_update_tree_mutations(lineage, version_2, updates)?;
+    let applied = backend.apply_mutations(prepared)?;
+
+    assert_eq!(applied.len(), 1);
+    assert_eq!(applied[0].lineage(), lineage);
+    assert_eq!(applied[0].old_entry_count(), old_entry_count);
+    assert_eq!(applied[0].reverse(), &expected_reverse);
+    assert_eq!(backend.version(lineage)?, version_2);
+    assert!(backend.trees()?.any(|tree| tree.root() == reference.root()));
+
+    Ok(())
+}
+
+#[test]
 fn update_forest() -> Result<()> {
     let mut backend = InMemoryBackend::new();
     let mut rng = ContinuousRng::new([0x76; 32]);

--- a/miden-crypto/src/merkle/smt/large_forest/backend/mod.rs
+++ b/miden-crypto/src/merkle/smt/large_forest/backend/mod.rs
@@ -19,7 +19,7 @@ use crate::{
             large_forest::{
                 operation::{SmtForestUpdateBatch, SmtUpdateBatch},
                 root::{LineageId, TreeEntry, TreeWithRoot, VersionId},
-                utils::MutationSet,
+                utils::{AppliedLineageMutation, LineageMutation},
             },
         },
     },
@@ -163,82 +163,139 @@ pub trait Backend: BackendReader {
     /// reader must not block writes in any way.
     type Reader: BackendReader;
 
+    /// Backend-specific data prepared during mutation computation and consumed during application.
+    ///
+    /// This type is intentionally opaque to forest users. Implementations should store enough
+    /// information here to apply the already-computed mutations without repeating the expensive
+    /// tree update computation.
+    ///
+    /// The prepared value must represent only prospective changes. Computing it must not change
+    /// the backend's committed state. It may contain ordinary SMT mutation sets, storage-level
+    /// updates, serialized values, or any other implementation-specific data needed to apply the
+    /// mutation efficiently later.
+    type PreparedMutations;
+
     /// Returns a read-only view of this backend that observes its current state.
     fn reader(&self) -> Result<Self::Reader>;
 
-    // SINGLE-TREE MODIFIERS
+    // TWO-PHASE MODIFIERS
     // ============================================================================================
 
-    /// Adds a new `lineage` to the forest with the provided `version` and sets the associated SMT
-    /// to have the value created by applying `updates` to the empty tree, returning the new root of
-    /// that tree.
+    /// Computes the backend data required to add one lineage, without applying it.
+    ///
+    /// The returned [`LineageMutation`] entries describe the visible root/version effects of the
+    /// prospective addition, while [`Self::PreparedMutations`] contains the backend-specific data
+    /// needed to commit those effects later via [`Self::apply_mutations`].
     ///
     /// # Expected Behavior
     ///
     /// Implementations must guarantee the following behavior in addition to the global invariants:
     ///
-    /// - If the provided `lineage` conflicts with an already-existing lineage in the backend, it
-    ///   must return [`BackendError::DuplicateLineage`].
-    fn add_lineage(
-        &mut self,
+    /// - The backend's committed state must not change.
+    /// - If the provided `lineage` conflicts with an already-existing lineage in the backend, this
+    ///   method must return [`BackendError::DuplicateLineage`].
+    /// - The returned prepared mutations must be sufficient for [`Self::apply_mutations`] to apply
+    ///   the addition without recomputing the Merkle update from `updates`.
+    /// - Empty `updates` must still prepare a new empty lineage.
+    fn compute_add_lineage_mutations(
+        &self,
         lineage: LineageId,
         version: VersionId,
         updates: SmtUpdateBatch,
-    ) -> Result<TreeWithRoot>;
+    ) -> Result<(Vec<LineageMutation>, Self::PreparedMutations)>;
 
-    /// Performs the provided `updates` on the tree with the specified `lineage`, returning the
-    /// mutation set that will revert the changes made to the tree.
+    /// Computes the backend data required to update one lineage, without applying it.
+    ///
+    /// The returned [`LineageMutation`] describes the visible root/version effect. The
+    /// backend-specific prepared payload is consumed by [`Self::apply_mutations`] to commit the
+    /// forward changes and return the reverse mutation data needed for history construction.
     ///
     /// # Expected Behavior
     ///
     /// Implementations must guarantee the following behavior in addition to the global invariants:
     ///
-    /// - At most one new root must be added to the forest for the entire batch.
-    /// - If applying the provided `updates` results in no changes to the tree, no new tree must be
-    ///   allocated.
-    fn update_tree(
-        &mut self,
+    /// - The backend's committed state must not change.
+    /// - If `lineage` is unknown to the backend, this method must return
+    ///   [`BackendError::UnknownLineage`].
+    /// - If applying `updates` would not change the tree, the returned lineage mutation must
+    ///   describe a no-op and the prepared data must not allocate a new backend tree version when
+    ///   applied.
+    /// - The returned prepared mutations must be sufficient for [`Self::apply_mutations`] to apply
+    ///   the update without recomputing the Merkle update from `updates`.
+    fn compute_update_tree_mutations(
+        &self,
         lineage: LineageId,
         new_version: VersionId,
         updates: SmtUpdateBatch,
-    ) -> Result<MutationSet>;
+    ) -> Result<(Vec<LineageMutation>, Self::PreparedMutations)>;
 
-    // MULTI-TREE MODIFIERS
-    // ============================================================================================
-
-    /// Adds multiple new `lineages` to the backend with the provided `version` and sets the
-    /// associated SMTs to have the value created by applying the provided updates to the empty
-    /// tree, returning the new root of that tree.
+    /// Computes the backend data required to add multiple lineages, without applying it.
+    ///
+    /// This is the batched equivalent of [`Self::compute_add_lineage_mutations`]. Backends may use
+    /// this method to prepare the additions in parallel or to build a more efficient batched apply
+    /// representation.
     ///
     /// # Expected Behavior
     ///
     /// Implementations must guarantee the following behavior in addition to the global invariants:
     ///
-    /// - If any provided lineage conflicts with an already-existing lineage in the backend, it must
-    ///   return [`BackendError::DuplicateLineage`].
-    fn add_lineages(
-        &mut self,
+    /// - The backend's committed state must not change.
+    /// - If any provided lineage conflicts with an already-existing lineage, this method must
+    ///   return [`BackendError::DuplicateLineage`] and prepare no partial committed state.
+    /// - Each lineage in `lineages` must produce at most one [`LineageMutation`].
+    /// - The prepared mutations must be applicable atomically by [`Self::apply_mutations`] where
+    ///   the backend supports atomic writes.
+    fn compute_add_lineages_mutations(
+        &self,
         version: VersionId,
         lineages: SmtForestUpdateBatch,
-    ) -> Result<Vec<(LineageId, TreeWithRoot)>>;
+    ) -> Result<(Vec<LineageMutation>, Self::PreparedMutations)>;
 
-    /// Performs the provided `updates` on the forest, setting all new tree states to have the
-    /// provided `new_version` and returning a vector of the mutation sets that reverse the changes
-    /// to each changed tree.
+    /// Computes the backend data required to update multiple lineages, without applying it.
+    ///
+    /// This is the batched equivalent of [`Self::compute_update_tree_mutations`]. Backends may use
+    /// this method to exploit parallelism across lineages and to prepare a single batched commit.
     ///
     /// # Expected Behavior
     ///
     /// Implementations must guarantee the following behavior in addition to the global invariants:
     ///
-    /// - At most one new root must be added to the forest for each target root in the provided
-    ///   `updates`.
-    /// - If applying the provided `updates` results in no changes to a given lineage of trees in
-    ///   the forest, then no new tree must be allocated in that lineage.
-    fn update_forest(
-        &mut self,
+    /// - The backend's committed state must not change.
+    /// - If any target lineage is unknown, this method must return [`BackendError::UnknownLineage`]
+    ///   and prepare no partial committed state.
+    /// - Each lineage in `updates` must produce at most one [`LineageMutation`].
+    /// - No-op lineage updates must not allocate new backend tree versions when applied.
+    /// - The prepared mutations must be applicable atomically by [`Self::apply_mutations`] where
+    ///   the backend supports atomic writes.
+    fn compute_update_forest_mutations(
+        &self,
         new_version: VersionId,
         updates: SmtForestUpdateBatch,
-    ) -> Result<Vec<(LineageId, MutationSet)>>;
+    ) -> Result<(Vec<LineageMutation>, Self::PreparedMutations)>;
+
+    /// Applies previously-computed backend mutations.
+    ///
+    /// This method consumes the opaque prepared data returned by one of the backend compute
+    /// methods. It commits the backend's latest-tree state and returns the applied lineage data
+    /// needed by [`crate::merkle::smt::LargeSmtForest`] to update forest-level lineage metadata and
+    /// history.
+    ///
+    /// # Expected Behavior
+    ///
+    /// Implementations must guarantee the following behavior in addition to the global invariants:
+    ///
+    /// - User-derived errors must leave the backend in a consistent committed state.
+    /// - If the prepared data contains multiple lineage updates, they should be committed
+    ///   atomically when the backend's storage engine supports atomic batched writes.
+    /// - The method must not recompute Merkle mutations from the original user updates; that work
+    ///   belongs to the compute methods.
+    /// - On success, the returned [`AppliedLineageMutation`] values must correspond to the applied
+    ///   prepared mutations in the same lineage set, including reverse mutations and old entry
+    ///   counts for update history.
+    fn apply_mutations(
+        &mut self,
+        mutations: Self::PreparedMutations,
+    ) -> Result<Vec<AppliedLineageMutation>>;
 }
 
 // BACKEND ERROR

--- a/miden-crypto/src/merkle/smt/large_forest/backend/persistent/mod.rs
+++ b/miden-crypto/src/merkle/smt/large_forest/backend/persistent/mod.rs
@@ -39,7 +39,6 @@ use alloc::{string::ToString, sync::Arc, vec::Vec};
 use core::ffi::c_int;
 use std::{
     collections::HashMap,
-    iter::once,
     mem::{self, ManuallyDrop},
 };
 
@@ -71,7 +70,9 @@ use crate::{
                     keys::{LeafKey, SubtreeKey},
                     tree_metadata::TreeMetadata,
                 },
-                utils::MutationSet,
+                utils::{
+                    AppliedLineageMutation, LineageMutation, LineageMutationKind, MutationSet,
+                },
             },
         },
     },
@@ -85,6 +86,33 @@ type DB = db::DB;
 
 /// The type of a write batch in the database associated with a transaction.
 type WriteBatch = db::WriteBatch;
+
+/// Prepared mutations for [`PersistentBackend`].
+///
+/// This is the persistent backend's concrete [`Backend::PreparedMutations`] type. It stores
+/// storage-level updates and the resulting metadata computed during the first phase of a forest
+/// update. Applying it builds and commits a RocksDB [`WriteBatch`] without recomputing the Merkle
+/// update batches.
+///
+/// The fields are private because callers should treat prepared mutation data as opaque and pass it
+/// back through
+/// [`LargeSmtForest::apply_mutations`](crate::merkle::smt::LargeSmtForest::apply_mutations).
+#[derive(Debug)]
+pub struct PersistentPreparedMutations {
+    entries: Vec<PersistentPreparedLineageMutation>,
+}
+
+#[derive(Debug)]
+struct PersistentPreparedLineageMutation {
+    lineage: LineageId,
+    old_version: Option<VersionId>,
+    old_root: Word,
+    old_entry_count: usize,
+    reverse: MutationSet,
+    metadata: TreeMetadata,
+    storage_updates: StorageUpdates,
+    kind: LineageMutationKind,
+}
 
 // CONSTANTS / COLUMN FAMILY NAMES
 // ================================================================================================
@@ -525,6 +553,7 @@ impl BackendReader for PersistentBackend {
 
 impl Backend for PersistentBackend {
     type Reader = PersistentBackendReader;
+    type PreparedMutations = PersistentPreparedMutations;
 
     fn reader(&self) -> Result<Self::Reader> {
         let snapshot = self.db.snapshot();
@@ -541,6 +570,186 @@ impl Backend for PersistentBackend {
         })
     }
 
+    fn compute_add_lineage_mutations(
+        &self,
+        lineage: LineageId,
+        version: VersionId,
+        updates: SmtUpdateBatch,
+    ) -> Result<(Vec<LineageMutation>, Self::PreparedMutations)> {
+        if self.lineages.contains_key(&lineage) {
+            return Err(BackendError::DuplicateLineage(lineage));
+        }
+
+        let metadata = TreeMetadata {
+            version,
+            root_value: *EmptySubtreeRoots::entry(SMT_DEPTH, 0),
+            entry_count: 0,
+        };
+        let (mutation, prepared) = self.prepare_tree_update(
+            lineage,
+            metadata,
+            version,
+            updates.into(),
+            LineageMutationKind::AddLineage,
+        )?;
+
+        Ok((vec![mutation], PersistentPreparedMutations { entries: vec![prepared] }))
+    }
+
+    fn compute_update_tree_mutations(
+        &self,
+        lineage: LineageId,
+        new_version: VersionId,
+        updates: SmtUpdateBatch,
+    ) -> Result<(Vec<LineageMutation>, Self::PreparedMutations)> {
+        let metadata = self
+            .lineages
+            .get(&lineage)
+            .ok_or(BackendError::UnknownLineage(lineage))?
+            .clone();
+        let (mutation, prepared) = self.prepare_tree_update(
+            lineage,
+            metadata,
+            new_version,
+            updates.into(),
+            LineageMutationKind::UpdateTree,
+        )?;
+
+        Ok((vec![mutation], PersistentPreparedMutations { entries: vec![prepared] }))
+    }
+
+    fn compute_add_lineages_mutations(
+        &self,
+        version: VersionId,
+        lineages: SmtForestUpdateBatch,
+    ) -> Result<(Vec<LineageMutation>, Self::PreparedMutations)> {
+        let updates = lineages
+            .into_iter()
+            .map(|(lineage, ops)| {
+                if self.lineages.contains_key(&lineage) {
+                    return Err(BackendError::DuplicateLineage(lineage));
+                }
+                Ok((lineage, ops))
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        let lineage_data = updates
+            .into_par_iter()
+            .map(|(lineage, ops)| {
+                let metadata = TreeMetadata {
+                    version,
+                    root_value: *EmptySubtreeRoots::entry(SMT_DEPTH, 0),
+                    entry_count: 0,
+                };
+                self.prepare_tree_update(
+                    lineage,
+                    metadata,
+                    version,
+                    ops.into_iter().map(Into::into).collect(),
+                    LineageMutationKind::AddLineage,
+                )
+            })
+            .collect::<Result<Vec<_>>>()?;
+        let (mutations, prepared): (Vec<_>, Vec<_>) = lineage_data.into_iter().unzip();
+
+        Ok((mutations, PersistentPreparedMutations { entries: prepared }))
+    }
+
+    fn compute_update_forest_mutations(
+        &self,
+        new_version: VersionId,
+        updates: SmtForestUpdateBatch,
+    ) -> Result<(Vec<LineageMutation>, Self::PreparedMutations)> {
+        let updates = updates
+            .into_iter()
+            .map(|(lineage, ops)| {
+                let metadata = self
+                    .lineages
+                    .get(&lineage)
+                    .ok_or(BackendError::UnknownLineage(lineage))?
+                    .clone();
+                Ok((lineage, ops, metadata))
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        let lineage_data = updates
+            .into_par_iter()
+            .map(|(lineage, ops, metadata)| {
+                self.prepare_tree_update(
+                    lineage,
+                    metadata,
+                    new_version,
+                    ops.into_iter().map(Into::into).collect(),
+                    LineageMutationKind::UpdateTree,
+                )
+            })
+            .collect::<Result<Vec<_>>>()?;
+        let (mutations, prepared): (Vec<_>, Vec<_>) = lineage_data.into_iter().unzip();
+
+        Ok((mutations, PersistentPreparedMutations { entries: prepared }))
+    }
+
+    fn apply_mutations(
+        &mut self,
+        mutations: Self::PreparedMutations,
+    ) -> Result<Vec<AppliedLineageMutation>> {
+        let lineage_count = mutations.entries.len();
+        let mut batches = Vec::with_capacity(lineage_count);
+        let mut metadata = Vec::with_capacity(lineage_count);
+        let mut applied = Vec::with_capacity(lineage_count);
+
+        for entry in mutations.entries {
+            match entry.kind {
+                LineageMutationKind::AddLineage => {
+                    if self.lineages.contains_key(&entry.lineage) {
+                        return Err(BackendError::DuplicateLineage(entry.lineage));
+                    }
+                },
+                LineageMutationKind::UpdateTree => {
+                    if !self.lineages.contains_key(&entry.lineage) {
+                        return Err(BackendError::UnknownLineage(entry.lineage));
+                    }
+                },
+            }
+
+            let applied_entry = AppliedLineageMutation::new(
+                entry.lineage,
+                entry.old_version,
+                entry.metadata.version,
+                entry.old_root,
+                entry.metadata.root_value,
+                entry.old_entry_count,
+                entry.reverse,
+                entry.kind,
+            );
+            let batch = self.apply_updates_to_lineage(
+                WriteBatch::default(),
+                entry.lineage,
+                entry.storage_updates,
+            )?;
+            let batch = self.write_metadata(batch, entry.lineage, &entry.metadata)?;
+            metadata.push((entry.lineage, entry.metadata, MutationSet::default()));
+            batches.push(batch);
+            applied.push(applied_entry);
+        }
+
+        let final_batch = if lineage_count > MIN_LINEAGES_IN_BATCH_TO_PARALLELIZE {
+            batches
+                .into_par_iter()
+                .fold(WriteBatch::new, |l, r| merge_batches(l, &r))
+                .reduce(WriteBatch::new, |l, r| merge_batches(l, &r))
+        } else {
+            batches.into_iter().fold(WriteBatch::new(), |l, r| merge_batches(l, &r))
+        };
+
+        self.finalize_update(final_batch, metadata.into_iter())?;
+
+        Ok(applied)
+    }
+}
+
+#[cfg(test)]
+impl PersistentBackend {
     /// Adds the provided `lineage` to the forest with the provided `version` and sets the
     /// associated tree to have the value created by applying `updates` to the empty tree, returning
     /// the root of this new tree.
@@ -551,14 +760,14 @@ impl Backend for PersistentBackend {
     ///   backend.
     /// - [`BackendError::Internal`] if the database cannot be accessed at any point.
     /// - [`BackendError::Merkle`] if an error occurs with the merkle tree semantics.
-    fn add_lineage(
+    pub(crate) fn add_lineage(
         &mut self,
         lineage: LineageId,
         version: VersionId,
         updates: SmtUpdateBatch,
     ) -> Result<TreeWithRoot> {
-        // We start by checking if the lineage already exists, as we are expected by contract to
-        // error if it is a duplicate.
+        // We start by checking if the lineage already exists, preserving the behavior expected by
+        // the backend tests.
         if self.lineages.contains_key(&lineage) {
             return Err(BackendError::DuplicateLineage(lineage));
         }
@@ -592,7 +801,7 @@ impl Backend for PersistentBackend {
         // Only when the batch has been successfully written to disk do we write to the in-memory
         // metadata, ensuring that the state remains consistent.
         let new_root = tree_metadata.root_value;
-        self.finalize_update(batch, once((lineage, tree_metadata, reversion_set)))?;
+        self.finalize_update(batch, std::iter::once((lineage, tree_metadata, reversion_set)))?;
 
         // Finally we just return the necessary metadata.
         Ok(TreeWithRoot::new(lineage, version, new_root))
@@ -608,7 +817,7 @@ impl Backend for PersistentBackend {
     /// - [`BackendError::Internal`] if the database cannot be accessed at any point.
     /// - [`BackendError::Merkle`] if an error occurs with the merkle tree semantics.
     /// - [`BackendError::UnknownLineage`] if the provided `lineage` is not known by this backend.
-    fn update_tree(
+    pub(crate) fn update_tree(
         &mut self,
         lineage: LineageId,
         new_version: VersionId,
@@ -642,7 +851,8 @@ impl Backend for PersistentBackend {
 
         // Writing the batch may fail, so we only write to the in-memory metadata once it is
         // successful to ensure the in-memory state cache remains consistent with the database.
-        let mut res = self.finalize_update(batch, once((lineage, tree_metadata, reversion_set)))?;
+        let mut res =
+            self.finalize_update(batch, std::iter::once((lineage, tree_metadata, reversion_set)))?;
         let Some((_, reversion_set)) = res.pop() else {
             unreachable!("finalize_update did not return the same number of output elements")
         };
@@ -663,7 +873,7 @@ impl Backend for PersistentBackend {
     ///   backend.
     /// - [`BackendError::Internal`] if the database cannot be accessed at any point.
     /// - [`BackendError::Merkle`] if an error occurs with the merkle tree semantics.
-    fn add_lineages(
+    pub(crate) fn add_lineages(
         &mut self,
         version: VersionId,
         lineages: SmtForestUpdateBatch,
@@ -762,7 +972,7 @@ impl Backend for PersistentBackend {
     /// - [`BackendError::Internal`] if the database cannot be accessed at any point.
     /// - [`BackendError::Merkle`] if an error occurs with the merkle tree semantics.
     /// - [`BackendError::UnknownLineage`] if the provided `lineage` is not known by this backend.
-    fn update_forest(
+    pub(crate) fn update_forest(
         &mut self,
         new_version: VersionId,
         updates: SmtForestUpdateBatch,
@@ -901,6 +1111,7 @@ impl PersistentBackend {
     ///
     /// - [`BackendError::Internal`] if the backend fails to read to or write from storage.
     /// - [`BackendError::Merkle`] if an error occurs with the merkle tree semantics in the backend.
+    #[cfg(test)]
     fn update_tree_in_write_batch(
         &self,
         batch: WriteBatch,
@@ -1049,6 +1260,172 @@ impl PersistentBackend {
         };
 
         Ok((batch, mutation_set, tree_metadata))
+    }
+
+    fn prepare_tree_update(
+        &self,
+        lineage: LineageId,
+        mut tree_metadata: TreeMetadata,
+        new_version: VersionId,
+        mut updates: Vec<(Word, Word)>,
+        kind: LineageMutationKind,
+    ) -> Result<(LineageMutation, PersistentPreparedLineageMutation)> {
+        updates.sort_by_key(|(k, _)| LeafIndex::from(*k).position());
+
+        let leaf_map = if tree_metadata.entry_count == 0 {
+            HashMap::new()
+        } else {
+            self.get_leaves_for_keys(lineage, &updates.iter().map(|(k, _)| *k).collect::<Vec<_>>())?
+        };
+
+        let LeafMutations {
+            mut leaves,
+            leaf_updates,
+            leaf_count_delta,
+            entry_count_delta,
+            reversion_pairs,
+        } = self.sorted_pairs_to_mutated_leaves(updates, &leaf_map)?;
+
+        let old_version = tree_metadata.version;
+        let old_root = tree_metadata.root_value;
+        let old_entry_count = tree_metadata
+            .entry_count
+            .try_into()
+            .expect("Count of entries should fit into usize");
+
+        if leaves.is_empty() {
+            let empty = MutationSet {
+                old_root,
+                node_mutations: NodeMutations::default(),
+                new_pairs: Map::default(),
+                new_root: old_root,
+            };
+            let mutation = LineageMutation::new(
+                lineage,
+                (kind == LineageMutationKind::UpdateTree).then_some(old_version),
+                new_version,
+                old_root,
+                old_root,
+                kind,
+            );
+            let prepared = PersistentPreparedLineageMutation {
+                lineage,
+                old_version: (kind == LineageMutationKind::UpdateTree).then_some(old_version),
+                old_root,
+                old_entry_count,
+                reverse: empty,
+                metadata: tree_metadata,
+                storage_updates: StorageUpdates::default(),
+                kind,
+            };
+            return Ok((mutation, prepared));
+        }
+
+        let mut subtree_updates: Vec<SubtreeUpdate> = Vec::with_capacity(leaves.len());
+        let mut global_node_reversions = Map::new();
+
+        for subtree_root_depth in
+            (0..=SMT_DEPTH - SUBTREE_DEPTH).step_by(SUBTREE_DEPTH as usize).rev()
+        {
+            let subtree_count = leaves.len();
+
+            let (mut subtree_roots, modified_subtrees, node_reversions) = leaves
+                .into_par_iter()
+                .map(|subtree_leaves| {
+                    self.process_subtree_for_depth(lineage, subtree_leaves, subtree_root_depth)
+                })
+                .fold(
+                    || {
+                        Ok((
+                            Vec::with_capacity(subtree_count),
+                            Vec::with_capacity(subtree_count),
+                            Map::new(),
+                        ))
+                    },
+                    |result, processed_tree| match (result, processed_tree) {
+                        (Ok((mut roots, mut subtrees, mut reversions)), Ok(tree)) => {
+                            roots.push(tree.subtree_root);
+                            reversions.extend(tree.reversion_nodes);
+                            if let Some(action) = tree.storage_action {
+                                subtrees.push(action);
+                            }
+
+                            Ok((roots, subtrees, reversions))
+                        },
+                        (Err(e), _) | (_, Err(e)) => Err(e),
+                    },
+                )
+                .reduce(
+                    || Ok((Vec::new(), Vec::new(), Map::new())),
+                    |data1, data2| match (data1, data2) {
+                        (
+                            Ok((mut roots1, mut trees1, mut reversions1)),
+                            Ok((roots2, trees2, reversions2)),
+                        ) => {
+                            roots1.extend(roots2);
+                            trees1.extend(trees2);
+                            reversions1.extend(reversions2);
+                            Ok((roots1, trees1, reversions1))
+                        },
+                        (Err(e), _) | (_, Err(e)) => Err(e),
+                    },
+                )?;
+
+            subtree_updates.extend(modified_subtrees);
+            global_node_reversions.extend(node_reversions);
+            leaves = SubtreeLeavesIter::from_leaves(&mut subtree_roots).collect();
+
+            debug_assert!(!leaves.is_empty());
+        }
+
+        let mut leaf_update_map = leaf_map;
+        for (idx, mutated_leaf) in leaf_updates {
+            let leaf_opt = match mutated_leaf {
+                SmtLeaf::Empty(_) => None,
+                _ => Some(mutated_leaf),
+            };
+            leaf_update_map.insert(idx, leaf_opt);
+        }
+
+        let storage_updates = StorageUpdates::from_parts(
+            leaf_update_map,
+            subtree_updates,
+            leaf_count_delta,
+            entry_count_delta,
+        );
+
+        let new_root = leaves[0][0].hash;
+        tree_metadata.entry_count = tree_metadata.entry_count.saturating_add_signed(
+            entry_count_delta.try_into().expect("Delta should always fit into i64"),
+        );
+        tree_metadata.root_value = new_root;
+        tree_metadata.version = new_version;
+        let reverse = MutationSet {
+            old_root: new_root,
+            node_mutations: global_node_reversions,
+            new_pairs: reversion_pairs.into_iter().collect(),
+            new_root: old_root,
+        };
+        let mutation = LineageMutation::new(
+            lineage,
+            (kind == LineageMutationKind::UpdateTree).then_some(old_version),
+            new_version,
+            old_root,
+            new_root,
+            kind,
+        );
+        let prepared = PersistentPreparedLineageMutation {
+            lineage,
+            old_version: (kind == LineageMutationKind::UpdateTree).then_some(old_version),
+            old_root,
+            old_entry_count,
+            reverse,
+            metadata: tree_metadata,
+            storage_updates,
+            kind,
+        };
+
+        Ok((mutation, prepared))
     }
 
     /// Applies the `updates` to the specified `lineage` in the context of the provided `batch`.

--- a/miden-crypto/src/merkle/smt/large_forest/backend/persistent/property_tests.rs
+++ b/miden-crypto/src/merkle/smt/large_forest/backend/persistent/property_tests.rs
@@ -10,7 +10,7 @@ use super::tests::default_backend;
 use crate::{
     EMPTY_WORD,
     merkle::smt::{
-        Backend, BackendReader, Smt, SmtForestUpdateBatch, SmtUpdateBatch, TreeWithRoot,
+        BackendReader, Smt, SmtForestUpdateBatch, SmtUpdateBatch, TreeWithRoot,
         large_forest::test_utils::{
             arbitrary_batch, arbitrary_lineage, arbitrary_version, arbitrary_word,
         },

--- a/miden-crypto/src/merkle/smt/large_forest/mod.rs
+++ b/miden-crypto/src/merkle/smt/large_forest/mod.rs
@@ -327,11 +327,12 @@ pub use config::{Config, DEFAULT_MAX_HISTORY_VERSIONS, MIN_HISTORY_VERSIONS};
 pub use error::{LargeSmtForestError, Result};
 pub use operation::{ForestOperation, SmtForestUpdateBatch, SmtUpdateBatch};
 pub use root::{LineageId, RootInfo, TreeEntry, TreeId, TreeWithRoot, VersionId};
+pub use utils::{AppliedLineageMutation, ForestMutationSet, LineageMutation, LineageMutationKind};
 
 use crate::{
     EMPTY_WORD, Map, Set, Word,
     merkle::{
-        NodeIndex, SparseMerklePath,
+        MerkleError, NodeIndex, SparseMerklePath,
         smt::{
             LeafIndex, SMT_DEPTH, SmtLeaf, SmtProof,
             large_forest::{
@@ -802,8 +803,105 @@ impl<B: BackendReader> LargeSmtForest<B> {
 /// Where anything more specific can be said about performance, the method documentation will
 /// contain more detail.
 impl<B: Backend> LargeSmtForest<B> {
-    /// Adds a new `lineage` to the tree, creating an empty tree and modifying it as specified by
+    /// Computes the mutations required to add a new `lineage`, without applying them.
+    ///
+    /// This is the first phase of [`Self::add_lineage`]. It creates a [`ForestMutationSet`] that
+    /// contains the proposed root commitment for the new lineage and backend-specific prepared
+    /// data that can later be committed with [`Self::apply_mutations`].
+    ///
+    /// The forest and backend are not modified by this method. Callers can inspect the returned
+    /// mutation set, especially via [`ForestMutationSet::roots`] or
+    /// [`ForestMutationSet::lineage_mutations`], before deciding whether to commit it.
+    ///
+    /// If the provided `updates` batch is empty, the returned mutation set still represents adding
+    /// the empty tree as the first version of the lineage.
+    ///
+    /// # Errors
+    ///
+    /// - [`LargeSmtForestError::DuplicateLineage`] if `lineage` is already known by the forest.
+    /// - [`LargeSmtForestError::Fatal`] if the backend fails while computing prepared data.
+    /// - [`LargeSmtForestError::Merkle`] if the provided `updates` cannot be applied to the empty
+    ///   tree.
+    ///
+    /// # Applying the Result
+    ///
+    /// The returned mutation set is valid only for the forest state against which it was computed.
+    /// Passing it to [`Self::apply_mutations`] after the same lineage has been added by another
+    /// operation will return an error.
+    pub fn compute_add_lineage_mutations(
+        &self,
+        lineage: LineageId,
+        new_version: VersionId,
+        updates: SmtUpdateBatch,
+    ) -> Result<ForestMutationSet<B>> {
+        if self.lineage_data.contains_key(&lineage) {
+            return Err(LargeSmtForestError::DuplicateLineage(lineage));
+        }
+
+        let (entries, prepared) =
+            self.backend.compute_add_lineage_mutations(lineage, new_version, updates)?;
+        Ok(ForestMutationSet::new(entries, prepared))
+    }
+
+    /// Computes the mutations required to update the latest tree in `lineage`, without applying
+    /// them.
+    ///
+    /// This is the first phase of [`Self::update_tree`]. It computes the proposed new root for the
+    /// lineage and the backend-specific data needed to commit the update later via
+    /// [`Self::apply_mutations`]. Reverse mutations needed for history are returned by the backend
+    /// during the apply phase.
+    ///
+    /// The forest and backend are not modified by this method. Callers can inspect the returned
+    /// mutation set before committing it, which is useful when root commitments must be published,
+    /// checked, or combined with other data before the backend write occurs.
+    ///
+    /// If applying `updates` would not change the tree, the returned mutation set represents a
+    /// no-op. Applying it will not advance the lineage version or allocate a new tree version, and
+    /// [`ForestMutationSet::roots`] will report the current latest version/root.
+    ///
+    /// # Errors
+    ///
+    /// - [`LargeSmtForestError::UnknownLineage`] if `lineage` is not known by the forest.
+    /// - [`LargeSmtForestError::BadVersion`] if `new_version` is not newer than the latest version
+    ///   for `lineage`.
+    /// - [`LargeSmtForestError::Fatal`] if the backend fails while computing prepared data.
+    /// - [`LargeSmtForestError::Merkle`] if the provided `updates` cannot be applied to the latest
+    ///   tree.
+    ///
+    /// # Applying the Result
+    ///
+    /// The returned mutation set is valid only while the lineage remains at the same latest
+    /// version and root. [`Self::apply_mutations`] rejects stale mutation sets if the lineage has
+    /// changed since this method was called.
+    pub fn compute_update_tree_mutations(
+        &self,
+        lineage: LineageId,
+        new_version: VersionId,
+        updates: SmtUpdateBatch,
+    ) -> Result<ForestMutationSet<B>> {
+        let Some(lineage_data) = self.lineage_data.get(&lineage) else {
+            return Err(LargeSmtForestError::UnknownLineage(lineage));
+        };
+
+        if lineage_data.latest_version >= new_version {
+            return Err(LargeSmtForestError::BadVersion {
+                provided: new_version,
+                latest: lineage_data.latest_version,
+            });
+        }
+
+        let (entries, prepared) =
+            self.backend.compute_update_tree_mutations(lineage, new_version, updates)?;
+        Ok(ForestMutationSet::new(entries, prepared))
+    }
+
+    /// Adds a new `lineage` to the forest, creating an empty tree and modifying it as specified by
     /// `updates`, with the result taking the provided `new_version`.
+    ///
+    /// This is the one-phase convenience API. It is equivalent to calling
+    /// [`Self::compute_add_lineage_mutations`] followed immediately by [`Self::apply_mutations`].
+    /// Use the two-phase API directly when the proposed root commitment must be inspected before
+    /// committing the backend changes.
     ///
     /// If the provided `updates` batch is empty, then the **empty tree will be added** as the first
     /// version in the lineage.
@@ -812,35 +910,29 @@ impl<B: Backend> LargeSmtForest<B> {
     ///
     /// - [`LargeSmtForestError::DuplicateLineage`] if the provided `lineage` is the same as an
     ///   already-known lineage.
-    /// - [`LargeSmtForestError::Fatal`] if the backend fails while being accessed.
-    /// - [`BackendError::Merkle`] if the provided `updates` cannot be applied to the empty tree.
+    /// - [`LargeSmtForestError::Fatal`] if the backend fails while computing or applying the
+    ///   mutation.
+    /// - [`LargeSmtForestError::Merkle`] if the provided `updates` cannot be applied to the empty
+    ///   tree.
     pub fn add_lineage(
         &mut self,
         lineage: LineageId,
         new_version: VersionId,
         updates: SmtUpdateBatch,
     ) -> Result<TreeWithRoot> {
-        // We can immediately add lineage in the backend, as by its contract it should return
-        // `DuplicateLineage` if the new lineage is a duplicate. We forward that, and any other
-        // errors, as this is the correct behavior for correctly-implemented backends.
-        let tree_info = self.backend.add_lineage(lineage, new_version, updates)?;
-
-        // We then construct the lineage tracking data and shove it into the corresponding map. The
-        // history is guaranteed to be empty here, so we do not need to put an entry in the
-        // non-empty histories set.
-        let lineage_data = LineageData {
-            history: History::empty(self.config.max_history_versions()),
-            latest_version: tree_info.version(),
-            latest_root: tree_info.root(),
-        };
-        self.lineage_data.insert(lineage, lineage_data);
-
-        Ok(tree_info)
+        let mutations = self.compute_add_lineage_mutations(lineage, new_version, updates)?;
+        let mut roots = self.apply_mutations(mutations)?;
+        Ok(roots.pop().expect("single lineage mutation returns one root"))
     }
 
     /// Performs the provided `updates` on the latest tree in the specified `lineage`, adding a
     /// single new root to the forest (corresponding to `new_version`) for the entire batch, and
     /// returning the data for the new root of the tree.
+    ///
+    /// This is the one-phase convenience API. It is equivalent to calling
+    /// [`Self::compute_update_tree_mutations`] followed immediately by
+    /// [`Self::apply_mutations`]. Use the two-phase API directly when the proposed root commitment
+    /// must be inspected before committing the backend changes.
     ///
     /// If applying the provided `operations` results in no changes to the tree, then the root data
     /// will be returned unchanged and no new tree will be allocated. It will retain its original
@@ -848,84 +940,22 @@ impl<B: Backend> LargeSmtForest<B> {
     ///
     /// # Errors
     ///
-    /// - [`LargeSmtForestError::BadVersion`] if the `new_version` is older than the latest version
+    /// - [`LargeSmtForestError::BadVersion`] if `new_version` is not newer than the latest version
     ///   for the provided `lineage`.
-    /// - [`LargeSmtForestError::Fatal`] if the backend fails while being accessed.
-    /// - [`LargeSmtForestError::UnknownLineage`] if the provided `tree` specifies a lineage that is
-    ///   not one known by the forest.
+    /// - [`LargeSmtForestError::Fatal`] if the backend fails while computing or applying the
+    ///   mutation.
+    /// - [`LargeSmtForestError::Merkle`] if the provided `updates` cannot be applied to the latest
+    ///   tree.
+    /// - [`LargeSmtForestError::UnknownLineage`] if `lineage` is not known by the forest.
     pub fn update_tree(
         &mut self,
         lineage: LineageId,
         new_version: VersionId,
         updates: SmtUpdateBatch,
     ) -> Result<TreeWithRoot> {
-        // We initially check that the lineage is known and that the version is greater than the
-        // last known version for that lineage.
-        let lineage_data = if let Some(lineage_data) = self.lineage_data.get_mut(&lineage) {
-            if lineage_data.latest_version < new_version {
-                lineage_data
-            } else {
-                return Err(LargeSmtForestError::BadVersion {
-                    provided: new_version,
-                    latest: lineage_data.latest_version,
-                });
-            }
-        } else {
-            return Err(LargeSmtForestError::UnknownLineage(lineage));
-        };
-
-        // We capture the entry count before the backend update, as this is the count for the
-        // version being pushed into history. This must precede `update_tree` because the backend
-        // entry count changes after that call.
-        //
-        // By the contract of the `Backend` trait, `entry_count` is expected to be extremely cheap,
-        // and only fail if the lineage in question is missing. Versions of this method that are
-        // expensive to call, or that can fail due to I/O or other such reasons, are considered
-        // non-conformant.
-        let old_entry_count = self.backend.entry_count(lineage)?;
-
-        // We now know that we have a valid lineage and a valid version, so we perform the update in
-        // the backend.
-        let reversion_set = self.backend.update_tree(lineage, new_version, updates)?;
-
-        // We do not want to actually change anything if the tree would not change.
-        if reversion_set.is_empty() {
-            return Ok(TreeWithRoot::new(
-                lineage,
-                lineage_data.latest_version,
-                lineage_data.latest_root,
-            ));
-        }
-
-        // The new root of the latest tree is actually given by the **old root** in our reverse
-        // mutation set.
-        let updated_root = reversion_set.old_root;
-
-        // The call to `add_version_from_mutation_set` should only yield an error if the
-        // provided version does not pass the version check. This check has already been
-        // performed as a precondition for reaching this point of the tree update, and
-        // hence should only ever fail due to a programmer bug so we panic if it does fail.
-        lineage_data
-            .history
-            .add_version_from_mutation_set(
-                lineage_data.latest_version,
-                reversion_set,
-                old_entry_count,
-            )
-            .unwrap_or_else(|_| {
-                panic!("Unable to add valid version {} to history", lineage_data.latest_version)
-            });
-
-        // At this point we now have a historical version added, so we track that the lineage has a
-        // non-empty history.
-        self.non_empty_histories.insert(lineage);
-
-        // Now we just have to update the other portions of the lineage data in place...
-        lineage_data.latest_root = updated_root;
-        lineage_data.latest_version = new_version;
-
-        // ...and return the correct value.
-        Ok(TreeWithRoot::new(lineage, new_version, updated_root))
+        let mutations = self.compute_update_tree_mutations(lineage, new_version, updates)?;
+        let mut roots = self.apply_mutations(mutations)?;
+        Ok(roots.pop().expect("single lineage mutation returns one root"))
     }
 }
 
@@ -944,10 +974,15 @@ impl<B: Backend> LargeSmtForest<B> {
 /// Where anything more specific can be said about performance, the method documentation will
 /// contain more detail.
 impl<B: Backend> LargeSmtForest<B> {
-    /// Adds multiple new `lineages` to the tree, creating an empty tree for each and applying the
+    /// Adds multiple new `lineages` to the forest, creating an empty tree for each and applying the
     /// provided modifications to it, with the result being given the specified `version`.
     ///
-    /// If the provide batch of modifications is empty for any given lineage, then the **empty tree
+    /// This is the one-phase convenience API. It is equivalent to calling
+    /// [`Self::compute_add_lineages_mutations`] followed immediately by
+    /// [`Self::apply_mutations`]. Use the two-phase API directly when the proposed root
+    /// commitments must be inspected before committing the backend changes.
+    ///
+    /// If the provided batch of modifications is empty for any given lineage, then the **empty tree
     /// will be added** as the first version in that lineage.
     ///
     /// # Performance
@@ -957,51 +992,72 @@ impl<B: Backend> LargeSmtForest<B> {
     /// [`Self::add_lineage`] in a loop, but in some cases it may be significantly more performant.
     ///
     /// The exact scope of any speed-up is determined by the backend in use, so it is worth reading
-    /// the documentation for the Backend's `add_lineages` method.
+    /// the documentation for the backend's [`Backend::compute_add_lineages_mutations`] method.
     ///
     /// # Errors
     ///
     /// - [`LargeSmtForestError::DuplicateLineage`] if any of the provided lineages share an ID with
     ///   an already-known lineage.
-    /// - [`LargeSmtForestError::Fatal`] if the backend fails while being accessed.
-    /// - [`BackendError::Merkle`] if the provided `updates` cannot be applied to the empty tree.
+    /// - [`LargeSmtForestError::Fatal`] if the backend fails while computing or applying the
+    ///   mutations.
+    /// - [`LargeSmtForestError::Merkle`] if any provided updates cannot be applied to an empty
+    ///   tree.
     pub fn add_lineages(
         &mut self,
         version: VersionId,
         lineages: SmtForestUpdateBatch,
     ) -> Result<Vec<TreeWithRoot>> {
-        // We start by performing our precondition checks: none of the lineages in the batch should
-        // already exist in the forest.
+        let mutations = self.compute_add_lineages_mutations(version, lineages)?;
+        self.apply_mutations(mutations)
+    }
+
+    /// Computes mutations that would add multiple new lineages without applying them.
+    ///
+    /// This is the first phase of [`Self::add_lineages`]. It returns a [`ForestMutationSet`]
+    /// containing one proposed result per lineage in `lineages`, plus backend-specific prepared
+    /// data that can later be committed with [`Self::apply_mutations`].
+    ///
+    /// The forest and backend are not modified by this method. Callers can inspect the returned
+    /// roots before committing the batch. This is useful when a higher-level transaction must know
+    /// all new root commitments before the forest backend is updated.
+    ///
+    /// Empty per-lineage operation batches still produce new empty lineages in the mutation set.
+    ///
+    /// # Performance
+    ///
+    /// Backends may compute the per-lineage mutations in parallel and may prepare a batched apply
+    /// representation. This method should generally be preferred over repeated
+    /// [`Self::compute_add_lineage_mutations`] calls when adding multiple lineages.
+    ///
+    /// # Errors
+    ///
+    /// - [`LargeSmtForestError::DuplicateLineage`] if any provided lineage is already known by the
+    ///   forest.
+    /// - [`LargeSmtForestError::Fatal`] if the backend fails while computing prepared data.
+    /// - [`LargeSmtForestError::Merkle`] if any provided updates cannot be applied to an empty
+    ///   tree.
+    pub fn compute_add_lineages_mutations(
+        &self,
+        version: VersionId,
+        lineages: SmtForestUpdateBatch,
+    ) -> Result<ForestMutationSet<B>> {
         for lineage in lineages.lineages() {
             if self.lineage_data.contains_key(lineage) {
                 return Err(LargeSmtForestError::DuplicateLineage(*lineage));
             }
         }
 
-        // With the preconditions checked we can call into the backend to perform the additions, and
-        // we forward all errors as this will be correct for conformant backend implementations.
-        let results = self.backend.add_lineages(version, lineages)?;
-
-        // Now we have to update the lineage data for each newly-added lineage. New lineages have
-        // empty histories, so we do not need to insert into `non_empty_histories`.
-        results
-            .into_iter()
-            .map(|(lineage, tree_info)| {
-                let lineage_data = LineageData {
-                    history: History::empty(self.config.max_history_versions()),
-                    latest_version: tree_info.version(),
-                    latest_root: tree_info.root(),
-                };
-                self.lineage_data.insert(lineage, lineage_data);
-
-                Ok(tree_info)
-            })
-            .collect()
+        let (entries, prepared) = self.backend.compute_add_lineages_mutations(version, lineages)?;
+        Ok(ForestMutationSet::new(entries, prepared))
     }
 
     /// Performs the provided `updates` on the forest, adding at most one new root with version
-    /// `new_version` to the forest for each target root in `updates` and returning a mapping
-    /// from old root to the new root data.
+    /// `new_version` for each targeted lineage and returning the resulting root data.
+    ///
+    /// This is the one-phase convenience API. It is equivalent to calling
+    /// [`Self::compute_update_forest_mutations`] followed immediately by
+    /// [`Self::apply_mutations`]. Use the two-phase API directly when the proposed root
+    /// commitments must be inspected before committing the backend changes.
     ///
     /// If applying the associated batch to any given lineage in the forest results in no changes to
     /// that tree, the initial root for that lineage will be returned and no new tree will be
@@ -1009,20 +1065,58 @@ impl<B: Backend> LargeSmtForest<B> {
     ///
     /// # Errors
     ///
-    /// - [`LargeSmtForestError::UnknownLineage`] If any lineage in the batch of modifications is
+    /// - [`LargeSmtForestError::UnknownLineage`] if any lineage in the batch of modifications is
     ///   one that is not known by the forest.
-    /// - [`LargeSmtForestError::Fatal`] if any error occurs to leave the forest in an inconsistent
-    ///   state.
-    /// - [`LargeSmtForestError::BadVersion`] if the `new_version` is older than the latest version
-    ///   for the provided `lineage`.
+    /// - [`LargeSmtForestError::Fatal`] if the backend fails while computing or applying the
+    ///   mutations.
+    /// - [`LargeSmtForestError::BadVersion`] if `new_version` is not newer than the latest version
+    ///   for any targeted lineage.
+    /// - [`LargeSmtForestError::Merkle`] if any provided updates cannot be applied to the relevant
+    ///   latest tree.
     pub fn update_forest(
         &mut self,
         new_version: VersionId,
         updates: SmtForestUpdateBatch,
     ) -> Result<Vec<TreeWithRoot>> {
-        // We start by performing our precondition checks on the lineages and versions. We have to
-        // ensure both that all the lineages exist, and that the specified version transition is
-        // valid for all of those lineages.
+        let mutations = self.compute_update_forest_mutations(new_version, updates)?;
+        self.apply_mutations(mutations)
+    }
+
+    /// Computes mutations that would update multiple existing lineages without applying them.
+    ///
+    /// This is the first phase of [`Self::update_forest`]. It returns a [`ForestMutationSet`]
+    /// containing one proposed result per lineage in `updates`, plus backend-specific prepared data
+    /// that can later be committed with [`Self::apply_mutations`].
+    ///
+    /// The forest and backend are not modified by this method. Callers can inspect all proposed
+    /// root commitments before committing the batch. This is useful when the forest update is only
+    /// one part of a larger transaction or when root commitments must be signed, checked, or stored
+    /// elsewhere before the backend write occurs.
+    ///
+    /// If a per-lineage update would not change the tree, the corresponding mutation is a no-op.
+    /// Applying the mutation set will not advance that lineage's version or allocate a new tree
+    /// version for it.
+    ///
+    /// # Performance
+    ///
+    /// Backends may compute per-lineage mutations in parallel and may prepare a batched apply
+    /// representation. This method should generally be preferred over repeated
+    /// [`Self::compute_update_tree_mutations`] calls when updating multiple lineages.
+    ///
+    /// # Errors
+    ///
+    /// - [`LargeSmtForestError::UnknownLineage`] if any targeted lineage is not known by the
+    ///   forest.
+    /// - [`LargeSmtForestError::BadVersion`] if `new_version` is not newer than the latest version
+    ///   for any targeted lineage.
+    /// - [`LargeSmtForestError::Fatal`] if the backend fails while computing prepared data.
+    /// - [`LargeSmtForestError::Merkle`] if any provided updates cannot be applied to the relevant
+    ///   latest tree.
+    pub fn compute_update_forest_mutations(
+        &self,
+        new_version: VersionId,
+        updates: SmtForestUpdateBatch,
+    ) -> Result<ForestMutationSet<B>> {
         updates
             .lineages()
             .map(|lineage| {
@@ -1041,77 +1135,137 @@ impl<B: Backend> LargeSmtForest<B> {
             })
             .collect::<Result<Vec<_>>>()?;
 
-        // We capture the entry counts before the backend update, as these are the counts for the
-        // versions being pushed into history. This must precede `update_forest` because the
-        // backend entry counts change after that call. We capture for all lineages eagerly
-        // (including those that may produce no-op updates) to keep the logic simple and consistent
-        // with `update_tree`, and use a map to eliminate any accidental dependencies on iteration
-        // order.
-        //
-        // By the contract of the `Backend` trait, `entry_count` is expected to be extremely cheap,
-        // and only fail if the lineage in question is missing. Versions of this method that are
-        // expensive to call, or that can fail due to I/O or other such reasons, are considered
-        // non-conformant.
-        let old_entry_counts: Map<LineageId, usize> = updates
-            .lineages()
-            .map(|lineage| Ok((*lineage, self.backend.entry_count(*lineage)?)))
-            .collect::<Result<_>>()?;
+        let (entries, prepared) =
+            self.backend.compute_update_forest_mutations(new_version, updates)?;
+        Ok(ForestMutationSet::new(entries, prepared))
+    }
 
-        // With the preconditions checked we can call into the backend to perform the updates, and
-        // we forward all errors as this will be correct for conformant backend implementations.
-        let reversion_sets = self.backend.update_forest(new_version, updates)?;
+    /// Applies mutations previously computed by one of the forest compute methods.
+    ///
+    /// This is the second phase of the two-phase update API. It consumes a [`ForestMutationSet`]
+    /// returned by one of:
+    ///
+    /// - [`Self::compute_add_lineage_mutations`],
+    /// - [`Self::compute_update_tree_mutations`],
+    /// - [`Self::compute_add_lineages_mutations`], or
+    /// - [`Self::compute_update_forest_mutations`].
+    ///
+    /// Before committing anything, this method validates that the mutation set is still applicable
+    /// to the current forest state. For update mutations, the latest version and root of every
+    /// affected lineage must still match the version/root captured during the compute phase. For
+    /// new-lineage mutations, the lineage must still be absent. These checks prevent stale
+    /// mutation sets from being applied after intervening forest changes.
+    ///
+    /// If validation succeeds, the opaque backend-prepared data is committed first. Only after the
+    /// backend apply succeeds does the forest update its in-memory lineage metadata and history.
+    /// This ordering keeps the forest consistent if the backend reports an error.
+    ///
+    /// The returned roots match [`ForestMutationSet::roots`] for the applied mutation set. No-op
+    /// update mutations return the existing latest version/root for their lineages.
+    ///
+    /// # Errors
+    ///
+    /// - [`LargeSmtForestError::DuplicateLineage`] if a mutation set attempts to add a lineage that
+    ///   is now already known.
+    /// - [`LargeSmtForestError::UnknownLineage`] if a mutation set attempts to update a lineage
+    ///   that is no longer known.
+    /// - [`LargeSmtForestError::BadVersion`] if an update mutation was computed against a version
+    ///   that is no longer the latest version.
+    /// - [`LargeSmtForestError::Merkle`] if an update mutation was computed against a root that is
+    ///   no longer the latest root.
+    /// - [`LargeSmtForestError::Fatal`] if the backend fails while applying its prepared data.
+    pub fn apply_mutations(
+        &mut self,
+        mutations: ForestMutationSet<B>,
+    ) -> Result<Vec<TreeWithRoot>> {
+        let (entries, prepared) = mutations.into_parts();
 
-        // Now we have to update the lineage data (including the history) to ensure that the state
-        // remains consistent, and we build our return values while doing so.
-        reversion_sets
-            .into_iter()
-            .map(|(lineage, reversion)| {
-                // Known to exist by construction, so the bare index is safe.
-                let old_entry_count = old_entry_counts[&lineage];
-                let lineage_data = self
-                    .lineage_data
-                    .get_mut(&lineage)
-                    .expect("Lineage has been checked to be present");
+        for entry in &entries {
+            match entry.kind() {
+                LineageMutationKind::AddLineage => {
+                    if self.lineage_data.contains_key(&entry.lineage()) {
+                        return Err(LargeSmtForestError::DuplicateLineage(entry.lineage()));
+                    }
+                },
+                LineageMutationKind::UpdateTree => {
+                    let Some(lineage_data) = self.lineage_data.get(&entry.lineage()) else {
+                        return Err(LargeSmtForestError::UnknownLineage(entry.lineage()));
+                    };
 
-                // If the operations change nothing we want to short-circuit for that tree.
-                if reversion.is_empty() {
-                    return Ok(TreeWithRoot::new(
-                        lineage,
-                        lineage_data.latest_version,
-                        lineage_data.latest_root,
-                    ));
-                }
+                    if Some(lineage_data.latest_version) != entry.old_version() {
+                        return Err(LargeSmtForestError::BadVersion {
+                            provided: entry.old_version().unwrap_or_default(),
+                            latest: lineage_data.latest_version,
+                        });
+                    }
+                    if lineage_data.latest_root != entry.old_root() {
+                        return Err(MerkleError::ConflictingRoots {
+                            expected_root: entry.old_root(),
+                            actual_root: lineage_data.latest_root,
+                        }
+                        .into());
+                    }
+                },
+            }
+        }
 
-                let updated_root = reversion.old_root;
+        let applied_entries = self.backend.apply_mutations(prepared)?;
 
-                // The call to `add_version_from_mutation_set` should only yield an error if the
-                // provided version does not pass the version check. This check has already been
-                // performed as a precondition for reaching this point of the forest update, and
-                // hence should only ever fail due to a programmer bug so we panic if it does fail.
-                lineage_data
-                    .history
-                    .add_version_from_mutation_set(
-                        lineage_data.latest_version,
-                        reversion,
-                        old_entry_count,
-                    )
-                    .unwrap_or_else(|_| {
-                        panic!(
-                            "Unable to add valid version {} to history",
-                            lineage_data.latest_version
-                        )
-                    });
+        assert_eq!(
+            entries.len(),
+            applied_entries.len(),
+            "backend returned an unexpected number of applied mutations"
+        );
+        let mut roots = Vec::with_capacity(applied_entries.len());
+        for (entry, applied) in entries.into_iter().zip(applied_entries) {
+            assert_eq!(entry.lineage(), applied.lineage());
+            assert_eq!(entry.old_version(), applied.old_version());
+            assert_eq!(entry.new_version(), applied.new_version());
+            assert_eq!(entry.old_root(), applied.old_root());
+            assert_eq!(entry.new_root(), applied.new_root());
+            assert_eq!(entry.kind(), applied.kind());
 
-                // At this point we know that we have a historical version for that tree, so we
-                // should track it as having a non-empty history.
-                self.non_empty_histories.insert(lineage);
+            let root = applied.result();
+            match entry.kind() {
+                LineageMutationKind::AddLineage => {
+                    let lineage_data = LineageData {
+                        history: History::empty(self.config.max_history_versions()),
+                        latest_version: root.version(),
+                        latest_root: root.root(),
+                    };
+                    self.lineage_data.insert(entry.lineage(), lineage_data);
+                },
+                LineageMutationKind::UpdateTree => {
+                    if entry.old_root() != entry.new_root() {
+                        let lineage_data = self
+                            .lineage_data
+                            .get_mut(&entry.lineage())
+                            .expect("Lineage has been checked to be present");
 
-                lineage_data.latest_root = updated_root;
-                lineage_data.latest_version = new_version;
+                        let old_version =
+                            entry.old_version().expect("update mutations have old versions");
+                        let old_entry_count = applied.old_entry_count();
+                        lineage_data
+                            .history
+                            .add_version_from_mutation_set(
+                                old_version,
+                                applied.into_reverse(),
+                                old_entry_count,
+                            )
+                            .unwrap_or_else(|_| {
+                                panic!("Unable to add valid version {} to history", old_version)
+                            });
 
-                Ok(TreeWithRoot::new(lineage, new_version, updated_root))
-            })
-            .collect::<Result<Vec<_>>>()
+                        self.non_empty_histories.insert(entry.lineage());
+                        lineage_data.latest_root = entry.new_root();
+                        lineage_data.latest_version = entry.new_version();
+                    }
+                },
+            }
+            roots.push(root);
+        }
+
+        Ok(roots)
     }
 }
 

--- a/miden-crypto/src/merkle/smt/large_forest/property_tests.rs
+++ b/miden-crypto/src/merkle/smt/large_forest/property_tests.rs
@@ -9,9 +9,8 @@ use proptest::prelude::*;
 use crate::{
     EMPTY_WORD, Word,
     merkle::smt::{
-        Backend, ForestConfig, ForestInMemoryBackend, ForestOperation, LargeSmtForest,
-        LargeSmtForestError, LineageId, RootInfo, Smt, SmtForestUpdateBatch, SmtUpdateBatch,
-        TreeId,
+        ForestConfig, ForestInMemoryBackend, ForestOperation, LargeSmtForest, LargeSmtForestError,
+        LineageId, RootInfo, Smt, SmtForestUpdateBatch, SmtUpdateBatch, TreeId,
         large_forest::test_utils::{
             apply_batch, arbitrary_batch, arbitrary_distinct_lineages, arbitrary_lineage,
             arbitrary_non_empty_word, arbitrary_version, arbitrary_word, assert_lineage_metadata,

--- a/miden-crypto/src/merkle/smt/large_forest/test_utils.rs
+++ b/miden-crypto/src/merkle/smt/large_forest/test_utils.rs
@@ -20,7 +20,7 @@ use crate::{
         large_forest::{
             backend::{BackendError, Result as BackendResult},
             root::{TreeEntry, TreeWithRoot},
-            utils::MutationSet,
+            utils::{AppliedLineageMutation, LineageMutation},
         },
     },
 };
@@ -319,42 +319,50 @@ impl BackendReader for FallibleEntriesBackend {
 
 impl Backend for FallibleEntriesBackend {
     type Reader = <ForestInMemoryBackend as Backend>::Reader;
+    type PreparedMutations = <ForestInMemoryBackend as Backend>::PreparedMutations;
 
     fn reader(&self) -> BackendResult<Self::Reader> {
         self.inner.reader()
     }
 
-    fn add_lineage(
-        &mut self,
+    fn compute_add_lineage_mutations(
+        &self,
         lineage: LineageId,
         version: VersionId,
         updates: SmtUpdateBatch,
-    ) -> BackendResult<TreeWithRoot> {
-        self.inner.add_lineage(lineage, version, updates)
+    ) -> BackendResult<(Vec<LineageMutation>, Self::PreparedMutations)> {
+        self.inner.compute_add_lineage_mutations(lineage, version, updates)
     }
 
-    fn update_tree(
-        &mut self,
+    fn compute_update_tree_mutations(
+        &self,
         lineage: LineageId,
         new_version: VersionId,
         updates: SmtUpdateBatch,
-    ) -> BackendResult<MutationSet> {
-        self.inner.update_tree(lineage, new_version, updates)
+    ) -> BackendResult<(Vec<LineageMutation>, Self::PreparedMutations)> {
+        self.inner.compute_update_tree_mutations(lineage, new_version, updates)
     }
 
-    fn add_lineages(
-        &mut self,
+    fn compute_add_lineages_mutations(
+        &self,
         version: VersionId,
         lineages: SmtForestUpdateBatch,
-    ) -> BackendResult<Vec<(LineageId, TreeWithRoot)>> {
-        self.inner.add_lineages(version, lineages)
+    ) -> BackendResult<(Vec<LineageMutation>, Self::PreparedMutations)> {
+        self.inner.compute_add_lineages_mutations(version, lineages)
     }
 
-    fn update_forest(
-        &mut self,
+    fn compute_update_forest_mutations(
+        &self,
         new_version: VersionId,
         updates: SmtForestUpdateBatch,
-    ) -> BackendResult<Vec<(LineageId, MutationSet)>> {
-        self.inner.update_forest(new_version, updates)
+    ) -> BackendResult<(Vec<LineageMutation>, Self::PreparedMutations)> {
+        self.inner.compute_update_forest_mutations(new_version, updates)
+    }
+
+    fn apply_mutations(
+        &mut self,
+        mutations: Self::PreparedMutations,
+    ) -> BackendResult<Vec<AppliedLineageMutation>> {
+        self.inner.apply_mutations(mutations)
     }
 }

--- a/miden-crypto/src/merkle/smt/large_forest/tests.rs
+++ b/miden-crypto/src/merkle/smt/large_forest/tests.rs
@@ -1161,6 +1161,90 @@ fn update_tree() -> Result<()> {
     Ok(())
 }
 
+#[test]
+fn compute_and_apply_update_tree_mutations() -> Result<()> {
+    let backend = ForestInMemoryBackend::new();
+    let mut forest = Forest::new(backend)?;
+    let mut rng = ContinuousRng::new([0x71; 32]);
+
+    let lineage: LineageId = rng.value();
+    let version_1: VersionId = 10;
+    let version_2: VersionId = 11;
+    let key_1: Word = rng.value();
+    let value_1: Word = rng.value();
+    let key_2: Word = rng.value();
+    let value_2: Word = rng.value();
+
+    let mut initial = SmtUpdateBatch::default();
+    initial.add_insert(key_1, value_1);
+    let original = forest.add_lineage(lineage, version_1, initial)?;
+
+    let mut updates = SmtUpdateBatch::default();
+    updates.add_insert(key_2, value_2);
+    let mutations = forest.compute_update_tree_mutations(lineage, version_2, updates)?;
+    let proposed_roots = mutations.roots().collect::<Vec<_>>();
+    assert_eq!(proposed_roots.len(), 1);
+    assert_eq!(proposed_roots[0].lineage(), lineage);
+    assert_eq!(proposed_roots[0].version(), version_2);
+    assert_ne!(proposed_roots[0].root(), original.root());
+
+    assert_eq!(
+        forest.root_info(TreeId::new(lineage, version_1)),
+        RootInfo::LatestVersion(original.root())
+    );
+    assert_eq!(forest.get(TreeId::new(lineage, version_1), key_2)?, None);
+    assert_eq!(forest.get_history(lineage).num_versions(), 0);
+
+    let applied_roots = forest.apply_mutations(mutations)?;
+    assert_eq!(applied_roots, proposed_roots);
+    assert_eq!(
+        forest.root_info(TreeId::new(lineage, version_2)),
+        RootInfo::LatestVersion(proposed_roots[0].root())
+    );
+    assert_eq!(forest.get(TreeId::new(lineage, version_2), key_2)?, Some(value_2));
+    assert_eq!(forest.get_history(lineage).num_versions(), 1);
+
+    Ok(())
+}
+
+#[test]
+fn apply_update_tree_mutations_rejects_stale_state() -> Result<()> {
+    let backend = ForestInMemoryBackend::new();
+    let mut forest = Forest::new(backend)?;
+    let mut rng = ContinuousRng::new([0x72; 32]);
+
+    let lineage: LineageId = rng.value();
+    let version_1: VersionId = 20;
+    let version_2: VersionId = 21;
+    let version_3: VersionId = 22;
+    let key_1: Word = rng.value();
+    let value_1: Word = rng.value();
+    let key_2: Word = rng.value();
+    let value_2: Word = rng.value();
+    let key_3: Word = rng.value();
+    let value_3: Word = rng.value();
+
+    forest.add_lineage(lineage, version_1, SmtUpdateBatch::default())?;
+
+    let mut pending_updates = SmtUpdateBatch::default();
+    pending_updates.add_insert(key_1, value_1);
+    let pending = forest.compute_update_tree_mutations(lineage, version_2, pending_updates)?;
+
+    let mut intervening_updates = SmtUpdateBatch::default();
+    intervening_updates.add_insert(key_2, value_2);
+    forest.update_tree(lineage, version_2, intervening_updates)?;
+
+    let stale_result = forest.apply_mutations(pending);
+    assert!(stale_result.is_err());
+
+    let mut fresh_updates = SmtUpdateBatch::default();
+    fresh_updates.add_insert(key_3, value_3);
+    let fresh = forest.compute_update_tree_mutations(lineage, version_3, fresh_updates)?;
+    assert!(forest.apply_mutations(fresh).is_ok());
+
+    Ok(())
+}
+
 // MULTI-TREE MODIFIER TESTS
 // ================================================================================================
 

--- a/miden-crypto/src/merkle/smt/large_forest/utils.rs
+++ b/miden-crypto/src/merkle/smt/large_forest/utils.rs
@@ -1,6 +1,17 @@
-//! Contains utility type aliases and functions for use as part of the SMT forest.
+//! Contains utility types, aliases, and functions for use as part of the SMT forest.
 
-use crate::{Word, merkle::smt::full::SMT_DEPTH};
+use alloc::vec::Vec;
+
+use crate::{
+    Word,
+    merkle::smt::{
+        full::SMT_DEPTH,
+        large_forest::{
+            backend::Backend,
+            root::{LineageId, TreeWithRoot, VersionId},
+        },
+    },
+};
 
 // TYPE ALIASES
 // ================================================================================================
@@ -8,3 +19,285 @@ use crate::{Word, merkle::smt::full::SMT_DEPTH};
 /// The mutation set used by the forest backends to provide reverse mutations that describe the
 /// changes necessary to revert the tree to its previous state.
 pub type MutationSet = crate::merkle::smt::MutationSet<SMT_DEPTH, Word, Word>;
+
+// FOREST MUTATIONS
+// ================================================================================================
+
+/// A prospective set of mutations to a forest.
+///
+/// This is the forest-level analogue of [`crate::merkle::smt::MutationSet`]. It represents changes
+/// that have already been computed but have not yet been committed to the underlying backend or to
+/// the forest's lineage metadata.
+///
+/// A mutation set has two parts:
+///
+/// - inspectable [`LineageMutation`] entries, which expose the affected lineages, requested
+///   versions, old roots, and proposed new roots; and
+/// - backend-specific prepared data, which is intentionally opaque and is consumed by
+///   [`crate::merkle::smt::LargeSmtForest::apply_mutations`].
+///
+/// The type is parameterized by the backend because different backend implementations may prepare
+/// different internal data. For example, an in-memory backend can keep regular SMT mutation sets,
+/// while a persistent backend can keep storage-level updates that avoid recomputing the tree walk
+/// during application.
+///
+/// Values of this type are only valid for the forest state against which they were computed.
+/// Applying them after the target lineage has changed will fail during forest-level validation.
+pub struct ForestMutationSet<B: Backend> {
+    entries: Vec<LineageMutation>,
+    prepared: B::PreparedMutations,
+}
+
+impl<B: Backend> ForestMutationSet<B> {
+    /// Constructs a forest mutation set from inspectable lineage entries and backend-prepared data.
+    ///
+    /// This constructor is crate-private because only forest/backend code can maintain the
+    /// invariant that the public lineage metadata and opaque prepared data describe the same set of
+    /// changes.
+    pub(crate) fn new(entries: Vec<LineageMutation>, prepared: B::PreparedMutations) -> Self {
+        Self { entries, prepared }
+    }
+
+    /// Returns the lineage-level mutations in this set.
+    ///
+    /// Callers can use this to inspect the old and new roots for each affected lineage before
+    /// committing the mutation set. The returned entries are read-only; the opaque backend portion
+    /// of the mutation set remains unavailable so that callers cannot accidentally break the link
+    /// between the visible metadata and the prepared backend data.
+    pub fn lineage_mutations(&self) -> &[LineageMutation] {
+        &self.entries
+    }
+
+    /// Returns the roots that would be observed after successfully applying this mutation set.
+    ///
+    /// This is a convenience view over [`Self::lineage_mutations`]. For update mutations that do
+    /// not change the underlying tree, the returned [`TreeWithRoot`] uses the existing latest
+    /// version rather than the requested new version, matching the behavior of
+    /// [`crate::merkle::smt::LargeSmtForest::update_tree`] and
+    /// [`crate::merkle::smt::LargeSmtForest::update_forest`].
+    pub fn roots(&self) -> impl Iterator<Item = TreeWithRoot> + '_ {
+        self.entries.iter().map(LineageMutation::result)
+    }
+
+    /// Consumes this value into its inspectable entries and backend-prepared mutation data.
+    ///
+    /// This is crate-private for the same reason as [`Self::new`]: only the forest can safely
+    /// coordinate applying the backend data and then updating lineage metadata/history from the
+    /// inspectable entries.
+    pub(crate) fn into_parts(self) -> (Vec<LineageMutation>, B::PreparedMutations) {
+        (self.entries, self.prepared)
+    }
+}
+
+/// A prospective mutation to one lineage in a forest.
+///
+/// This type records only inspectable metadata that callers need before committing a mutation set:
+/// affected lineage, version transition, root transition, and mutation kind. Backend-specific
+/// mutation data, including forward and reverse SMT mutation sets, stays in opaque backend
+/// prepared data until [`crate::merkle::smt::LargeSmtForest::apply_mutations`] commits it.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct LineageMutation {
+    lineage: LineageId,
+    old_version: Option<VersionId>,
+    new_version: VersionId,
+    old_root: Word,
+    new_root: Word,
+    kind: LineageMutationKind,
+}
+
+impl LineageMutation {
+    /// Constructs a lineage mutation.
+    ///
+    /// This constructor is crate-private because callers must not be able to fabricate mutation
+    /// metadata that is inconsistent with the backend-prepared data in a [`ForestMutationSet`].
+    pub(crate) fn new(
+        lineage: LineageId,
+        old_version: Option<VersionId>,
+        new_version: VersionId,
+        old_root: Word,
+        new_root: Word,
+        kind: LineageMutationKind,
+    ) -> Self {
+        Self {
+            lineage,
+            old_version,
+            new_version,
+            old_root,
+            new_root,
+            kind,
+        }
+    }
+
+    /// Returns the affected lineage.
+    pub fn lineage(&self) -> LineageId {
+        self.lineage
+    }
+
+    /// Returns the previous version for update mutations, or `None` for new lineages.
+    ///
+    /// This value is used by [`crate::merkle::smt::LargeSmtForest::apply_mutations`] to reject
+    /// stale mutation sets. For updates, it must still match the latest version in the forest when
+    /// the mutation set is applied.
+    pub fn old_version(&self) -> Option<VersionId> {
+        self.old_version
+    }
+
+    /// Returns the requested new version.
+    ///
+    /// For an update that does not change the tree, this version is the version requested by the
+    /// compute call, but the lineage will not advance when the mutation set is applied.
+    pub fn new_version(&self) -> VersionId {
+        self.new_version
+    }
+
+    /// Returns the root before this mutation.
+    ///
+    /// For updates, this must match the current latest root when the mutation set is applied. For a
+    /// new lineage, this is the empty SMT root from which the initial tree is computed.
+    pub fn old_root(&self) -> Word {
+        self.old_root
+    }
+
+    /// Returns the root after this mutation.
+    ///
+    /// This is the root commitment that callers usually inspect before deciding whether to commit a
+    /// computed mutation set.
+    pub fn new_root(&self) -> Word {
+        self.new_root
+    }
+
+    /// Returns the mutation kind.
+    pub fn kind(&self) -> LineageMutationKind {
+        self.kind
+    }
+
+    /// Returns the root information this mutation would produce if applied.
+    ///
+    /// For no-op update mutations, this returns the old version and old root, since applying such a
+    /// mutation does not allocate a new tree version. For new-lineage mutations and non-empty
+    /// update mutations, this returns the requested new version and computed new root.
+    pub fn result(&self) -> TreeWithRoot {
+        let version =
+            if self.kind == LineageMutationKind::UpdateTree && self.old_root == self.new_root {
+                self.old_version.expect("update tree mutations always have an old version")
+            } else {
+                self.new_version
+            };
+        TreeWithRoot::new(self.lineage, version, self.new_root)
+    }
+}
+
+/// Data returned by a backend after applying prepared mutations.
+///
+/// The forest uses this data to update lineage metadata and historical views after the backend has
+/// committed its latest-tree state. Unlike [`LineageMutation`], this type includes the reverse SMT
+/// mutation set and old entry count because those are only needed after a successful apply.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AppliedLineageMutation {
+    lineage: LineageId,
+    old_version: Option<VersionId>,
+    new_version: VersionId,
+    old_root: Word,
+    new_root: Word,
+    old_entry_count: usize,
+    reverse: MutationSet,
+    kind: LineageMutationKind,
+}
+
+impl AppliedLineageMutation {
+    /// Constructs an applied lineage mutation.
+    ///
+    /// This constructor is crate-private because backend implementations must keep the returned
+    /// history payload consistent with the prepared mutation data they just applied.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn new(
+        lineage: LineageId,
+        old_version: Option<VersionId>,
+        new_version: VersionId,
+        old_root: Word,
+        new_root: Word,
+        old_entry_count: usize,
+        reverse: MutationSet,
+        kind: LineageMutationKind,
+    ) -> Self {
+        Self {
+            lineage,
+            old_version,
+            new_version,
+            old_root,
+            new_root,
+            old_entry_count,
+            reverse,
+            kind,
+        }
+    }
+
+    /// Returns the affected lineage.
+    pub fn lineage(&self) -> LineageId {
+        self.lineage
+    }
+
+    /// Returns the previous version for update mutations, or `None` for new lineages.
+    pub fn old_version(&self) -> Option<VersionId> {
+        self.old_version
+    }
+
+    /// Returns the requested new version.
+    pub fn new_version(&self) -> VersionId {
+        self.new_version
+    }
+
+    /// Returns the root before this mutation.
+    pub fn old_root(&self) -> Word {
+        self.old_root
+    }
+
+    /// Returns the root after this mutation.
+    pub fn new_root(&self) -> Word {
+        self.new_root
+    }
+
+    /// Returns the entry count before this mutation.
+    pub fn old_entry_count(&self) -> usize {
+        self.old_entry_count
+    }
+
+    /// Returns the reverse mutation set for this lineage.
+    pub fn reverse(&self) -> &MutationSet {
+        &self.reverse
+    }
+
+    /// Consumes this mutation and returns the reverse mutation set.
+    pub(crate) fn into_reverse(self) -> MutationSet {
+        self.reverse
+    }
+
+    /// Returns the mutation kind.
+    pub fn kind(&self) -> LineageMutationKind {
+        self.kind
+    }
+
+    /// Returns the root information produced by this applied mutation.
+    ///
+    /// For no-op update mutations, this returns the old version, since applying such a
+    /// mutation does not allocate a new tree version. For new-lineage mutations and non-empty
+    /// update mutations, this returns the requested new version and computed new root.
+    pub fn result(&self) -> TreeWithRoot {
+        let version =
+            if self.kind == LineageMutationKind::UpdateTree && self.old_root == self.new_root {
+                self.old_version.expect("update tree mutations always have an old version")
+            } else {
+                self.new_version
+            };
+        TreeWithRoot::new(self.lineage, version, self.new_root)
+    }
+}
+
+/// The operation represented by a lineage mutation.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum LineageMutationKind {
+    /// A new lineage is being added.
+    AddLineage,
+    /// An existing lineage is being updated.
+    UpdateTree,
+}

--- a/miden-crypto/src/merkle/smt/mod.rs
+++ b/miden-crypto/src/merkle/smt/mod.rs
@@ -30,11 +30,12 @@ pub use large::{RocksDbConfig, RocksDbSnapshotStorage, RocksDbStorage};
 
 mod large_forest;
 pub use large_forest::{
-    Backend, BackendError, BackendReader, Config as ForestConfig,
-    DEFAULT_MAX_HISTORY_VERSIONS as FOREST_DEFAULT_MAX_HISTORY_VERSIONS, ForestOperation,
-    InMemoryBackend as ForestInMemoryBackend,
+    AppliedLineageMutation, Backend, BackendError, BackendReader, Config as ForestConfig,
+    DEFAULT_MAX_HISTORY_VERSIONS as FOREST_DEFAULT_MAX_HISTORY_VERSIONS, ForestMutationSet,
+    ForestOperation, InMemoryBackend as ForestInMemoryBackend,
     InMemoryBackendSnapshot as ForestInMemoryBackendReader, LargeSmtForest, LargeSmtForestError,
-    LineageId, MIN_HISTORY_VERSIONS as FOREST_MIN_HISTORY_VERSIONS, RootInfo, SmtForestUpdateBatch,
+    LineageId, LineageMutation, LineageMutationKind,
+    MIN_HISTORY_VERSIONS as FOREST_MIN_HISTORY_VERSIONS, RootInfo, SmtForestUpdateBatch,
     SmtUpdateBatch, TreeEntry, TreeId, TreeWithRoot, VersionId,
 };
 #[cfg(feature = "persistent-forest")]


### PR DESCRIPTION
This change introduces a two-phase mutation API for `LargeSmtForest`, matching the existing `LargeSmt` compute/apply model while keeping backend-specific mutation data opaque.

Main changes:
- Added `ForestMutationSet` as the forest-level pending mutation container.
- Added compute/apply methods on `LargeSmtForest`:
  - `compute_add_lineage_mutations`
  - `compute_update_tree_mutations`
  - `compute_add_lineages_mutations`
  - `compute_update_forest_mutations`
  - `apply_mutations`
- Updated existing one-phase methods (`add_lineage`, `update_tree`, `add_lineages`, `update_forest`) to delegate to compute/apply.
- Extended the `Backend` trait with backend-specific `PreparedMutations`.
- Removed one-phase mutation methods from the `Backend` trait; frontend code now only needs backend compute/apply.
- Added `LineageMutation` as public inspectable metadata for computed mutations.
- Added `AppliedLineageMutation` as backend-returned apply metadata used by the forest to update history.
- Updated both in-memory and RocksDB backends to implement the new API.
- Added tests for compute/apply behavior and stale mutation rejection.

Reasoning:

The previous `LargeSmtForest` mutation APIs computed and committed changes in one step. That made it impossible to inspect the updated root commitments for multiple lineages before committing backend writes. The new API separates mutation computation from mutation application, so callers can compute all prospective roots, inspect or publish them, and only then commit the changes.

Backend mutation data is intentionally opaque. This keeps `LargeSmtForest` backend-agnostic while allowing each backend to prepare efficient apply data. The in-memory backend stores regular SMT mutation sets; the persistent backend stores storage-level updates and metadata rather than exposing RocksDB-specific details.

`LineageMutation` was kept lightweight and inspectable. It now contains only the data callers need before commit: lineage, old/new versions, old/new roots, and mutation kind. Forward mutations are not exposed because they duplicate backend-prepared state. Reverse mutations and old entry counts are returned by `Backend::apply_mutations` as `AppliedLineageMutation`, because they are only needed after a successful commit to update forest history.

Closes #1009 