### PR TITLE
refactor: use common max domain when lifting traces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - perf: fuse per-group accumulator and defer allocations ([#1008](https://github.com/0xMiden/crypto/pull/1008))
 - [BREAKING] Reorganized `miden-lifted-stark` internals: consolidated `align`, `bitrev`, `horner`, and `packing` helpers under a new `util` module; moved `reconstruct_quotient` onto `LiftedCoset`; removed the legacy `fri::*` re-export facade ([#1000](https://github.com/0xMiden/crypto/pull/1000)).
 - [BREAKING] Extracted `BackendReader`, allowing `LargeSmtForest<S>` to work with read-only storage backends ([#986](https://github.com/0xMiden/crypto/pull/986)).
+- Use common max domain when lifting traces ([#1013](https://github.com/0xMiden/crypto/pull/1013)).
 
 ## 0.25.0 (2026-05-01)
 

--- a/stark/miden-lifted-stark/benches/deep_quotient.rs
+++ b/stark/miden-lifted-stark/benches/deep_quotient.rs
@@ -53,7 +53,8 @@ fn bench_deep_quotient(c: &mut Criterion) {
             matrix_groups.iter().map(|matrices| lmcs.build_tree(matrices.clone())).collect();
 
         // Precompute coset points (LDE domain matches max matrix height)
-        let coset_points = bit_reversed_coset_points::<Felt>(log_lde_height);
+        let coset_shift = miden_lifted_stark::lde_coset_shift::<Felt>(log_lde_height - LOG_BLOWUP);
+        let coset_points = bit_reversed_coset_points::<Felt>(coset_shift, log_lde_height);
 
         // Get matrix references from trees (stored as BitReversedMatrixView after build_tree)
         let matrices_refs: Vec<Vec<_>> =

--- a/stark/miden-lifted-stark/src/coset.rs
+++ b/stark/miden-lifted-stark/src/coset.rs
@@ -13,21 +13,35 @@ use p3_util::log2_strict_usize;
 
 use crate::{pcs::params::MAX_LOG_DOMAIN_SIZE, selectors::Selectors};
 
+/// Canonical multiplicative coset shift for a trace of height `2^log_trace_height`.
+///
+/// # Panics
+///
+/// Panics if `log_trace_height > F::TWO_ADICITY`.
+#[inline]
+pub fn lde_coset_shift<F: TwoAdicField>(log_trace_height: u8) -> F {
+    assert!(
+        (log_trace_height as usize) <= F::TWO_ADICITY,
+        "log_trace_height ({log_trace_height}) exceeds F::TWO_ADICITY ({})",
+        F::TWO_ADICITY,
+    );
+    F::GENERATOR.exp_power_of_2(F::TWO_ADICITY - log_trace_height as usize)
+}
+
 // ============================================================================
 // LiftedCoset
 // ============================================================================
 
 /// Lifted coset for polynomial evaluation.
 ///
-/// Represents a coset (gK)ʳ where:
+/// Represents the LDE coset that a trace lives on:
 /// - K is the evaluation domain of size 2^log_lde_height
 /// - r = 2^log_lift_ratio is the lift factor (row repetition)
-/// - The shift is gʳ where g = F::GENERATOR
+/// - The shift is [`lde_coset_shift`] applied to `log_trace_height`.
 ///
 /// Key relationships:
 /// - log_blowup = log_lde_height - log_trace_height
 /// - log_lift_ratio = log_max_lde_height - log_lde_height
-/// - lde_shift = gʳ = F::GENERATOR.exp_power_of_2(log_lift_ratio)
 ///
 /// # Invariants
 ///
@@ -118,18 +132,15 @@ impl LiftedCoset {
         self.log_lde_height < self.log_max_lde_height
     }
 
-    /// Compute the coset shift for this matrix's LDE domain.
+    /// Compute the coset shift for this trace's evaluation domains.
     ///
-    /// For a matrix with lift ratio `r = 2^log_lift_ratio`, the coset shift is gʳ
-    /// where g is the field generator.
+    /// Equivalent to `lde_coset_shift(self.log_trace_height)`.
     ///
-    /// Why gʳ: lifting embeds a smaller-domain polynomial into the max domain by
-    /// composition `p_lift(X) = p(Xʳ)`. Evaluating `p_lift` on the max coset `g·K_max`
-    /// corresponds to evaluating `p` on the nested coset `gʳ·K`, because
-    /// `(g·ω)ʳ = gʳ·ωʳ` and ωʳ ranges over K when ω ranges over `K_max`.
+    /// Lifting is preserved: `(max_shift)^r = sub_shift` for `r = N_max / N_sub`,
+    /// so `p_lift(X) = p(X^r)` on the max coset matches `p` on the sub coset.
     #[inline]
     pub fn lde_shift<F: TwoAdicField>(&self) -> F {
-        F::GENERATOR.exp_power_of_2(self.log_lift_ratio())
+        lde_coset_shift::<F>(self.log_trace_height)
     }
 
     /// The trace height (number of constraint rows).
@@ -433,23 +444,45 @@ mod tests {
 
     #[test]
     fn domain_info_lde_shift() {
-        // Trace height 2^10, blowup 2^3, max trace 2^12
         let info = LiftedCoset::new(10, 3, 12);
         let shift: Felt = info.lde_shift();
-
-        // shift = g^(2^2) = g^4
-        let expected = Felt::GENERATOR.exp_power_of_2(2);
+        let expected = Felt::GENERATOR.exp_power_of_2(Felt::TWO_ADICITY - 10);
         assert_eq!(shift, expected);
     }
 
     #[test]
     fn domain_info_no_lift_shift() {
-        // When not lifted, shift should be g^1 = g
         let info = LiftedCoset::unlifted(10, 3);
         let shift: Felt = info.lde_shift();
+        let expected = Felt::GENERATOR.exp_power_of_2(Felt::TWO_ADICITY - 10);
+        assert_eq!(shift, expected);
+    }
 
-        // shift = g^(2^0) = g
-        assert_eq!(shift, Felt::GENERATOR);
+    #[test]
+    fn lde_shift_is_stable_across_per_proof_max() {
+        let a: Felt = LiftedCoset::new(10, 3, 12).lde_shift();
+        let b: Felt = LiftedCoset::new(10, 3, 14).lde_shift();
+        let c: Felt = LiftedCoset::unlifted(10, 3).lde_shift();
+        assert_eq!(a, b);
+        assert_eq!(a, c);
+    }
+
+    #[test]
+    fn lde_shift_is_invariant_under_quotient_domain() {
+        let lde = LiftedCoset::new(10, 3, 12);
+        let quot = lde.quotient_domain(2);
+        assert_eq!(lde.lde_shift::<Felt>(), quot.lde_shift::<Felt>());
+    }
+
+    #[test]
+    fn lde_shift_lifting_invariant() {
+        // (max_shift)^r == sub_shift  where  r = N_max / N_sub
+        let sub = LiftedCoset::new(8, 3, 12);
+        let max = LiftedCoset::new(12, 3, 12);
+        let r = max.log_trace_height - sub.log_trace_height;
+        let sub_shift: Felt = sub.lde_shift();
+        let max_shift: Felt = max.lde_shift();
+        assert_eq!(max_shift.exp_power_of_2(r as usize), sub_shift);
     }
 
     #[test]

--- a/stark/miden-lifted-stark/src/lib.rs
+++ b/stark/miden-lifted-stark/src/lib.rs
@@ -63,7 +63,7 @@ pub(crate) mod util;
 pub mod verifier;
 
 pub use config::{GenericStarkConfig, StarkConfig};
-pub use coset::LiftedCoset;
+pub use coset::{LiftedCoset, lde_coset_shift};
 pub use debug::{check_constraints, check_constraints_multi};
 pub use instance::{AirInstance, AirWitness, InstanceShapes, InstanceValidationError};
 pub use lmcs::{

--- a/stark/miden-lifted-stark/src/pcs/deep/interpolate.rs
+++ b/stark/miden-lifted-stark/src/pcs/deep/interpolate.rs
@@ -232,7 +232,7 @@ mod tests {
         let shift = Felt::GENERATOR;
 
         // Coset points in bit-reversed order for our barycentric evaluation
-        let coset_points_br = bit_reversed_coset_points::<Felt>(log_n);
+        let coset_points_br = bit_reversed_coset_points::<Felt>(shift, log_n);
 
         // Random out-of-domain evaluation point
         let z: QuadFelt = rng.sample(StandardUniform);
@@ -308,7 +308,7 @@ mod tests {
         let shift = Felt::GENERATOR;
 
         // Coset points in both orderings
-        let coset_points_br = bit_reversed_coset_points::<Felt>(log_n);
+        let coset_points_br = bit_reversed_coset_points::<Felt>(shift, log_n);
         let mut coset_points_std = coset_points_br.clone();
         reverse_slice_index_bits(&mut coset_points_std); // Convert to standard order
 
@@ -374,7 +374,7 @@ mod tests {
         let shift = Felt::GENERATOR;
 
         // Coset points in bit-reversed order
-        let coset_points_br = bit_reversed_coset_points::<Felt>(log_n);
+        let coset_points_br = bit_reversed_coset_points::<Felt>(shift, log_n);
 
         // Two random out-of-domain evaluation points
         let z1: QuadFelt = rng.sample(StandardUniform);
@@ -456,7 +456,7 @@ mod tests {
         let n = 1 << log_n;
         let shift = Felt::GENERATOR;
 
-        let coset_points_br = bit_reversed_coset_points::<Felt>(log_n);
+        let coset_points_br = bit_reversed_coset_points::<Felt>(shift, log_n);
 
         let z1: QuadFelt = rng.sample(StandardUniform);
         let z2: QuadFelt = rng.sample(StandardUniform);

--- a/stark/miden-lifted-stark/src/pcs/deep/prover.rs
+++ b/stark/miden-lifted-stark/src/pcs/deep/prover.rs
@@ -71,7 +71,11 @@ impl<EF> DeepPoly<EF> {
         );
 
         let log_lde_height = log2_strict_u8(lde_height);
-        let coset_points = bit_reversed_coset_points::<L::F>(log_lde_height);
+        let log_trace_height = log_lde_height
+            .checked_sub(log_blowup)
+            .expect("log_blowup must not exceed log_lde_height");
+        let lde_shift = crate::coset::lde_coset_shift::<L::F>(log_trace_height);
+        let coset_points = bit_reversed_coset_points::<L::F>(lde_shift, log_lde_height);
 
         let matrices_groups: Vec<Vec<&M>> =
             trace_trees.iter().map(|tree| tree.leaves().iter().collect()).collect();

--- a/stark/miden-lifted-stark/src/pcs/deep/tests.rs
+++ b/stark/miden-lifted-stark/src/pcs/deep/tests.rs
@@ -70,9 +70,15 @@ fn deep_quotient_end_to_end() {
 
     // Step 4: Verifier constructs DeepOracle with same transcript state
     let mut verifier_channel = verifier_channel_with_commitment(&transcript, &commitment);
-    let (deep_oracle, _evals) =
-        DeepOracle::new(params, &[z1, z2], commitments, log_lde_height, &mut verifier_channel)
-            .expect("DeepOracle construction should succeed");
+    let (deep_oracle, _evals) = DeepOracle::new(
+        params,
+        &[z1, z2],
+        commitments,
+        log_lde_height,
+        log_blowup,
+        &mut verifier_channel,
+    )
+    .expect("DeepOracle construction should succeed");
 
     // Step 5: Verify at multiple query tree indices (proofs are read from transcript)
     let verifier_evals = deep_oracle

--- a/stark/miden-lifted-stark/src/pcs/deep/verifier.rs
+++ b/stark/miden-lifted-stark/src/pcs/deep/verifier.rs
@@ -42,6 +42,9 @@ pub struct DeepOracle<F: TwoAdicField, EF: ExtensionField<F>, L: Lmcs<F = F>> {
     /// Verifier expects all commitments to be lifted to this same LDE height.
     log_lde_height: u8,
 
+    /// Log₂ of the LDE blowup factor.
+    log_blowup: u8,
+
     /// Reduced openings: pairs of `(zⱼ, f_reduced(zⱼ))` from the prover's claims.
     reduced_openings: Vec<(EF, EF)>,
 
@@ -73,11 +76,16 @@ impl<F: TwoAdicField, EF: ExtensionField<F>, L: Lmcs<F = F>> DeepOracle<F, EF, L
         eval_points: &[EF],
         commitments: Vec<(L::Commitment, Vec<usize>)>,
         log_lde_height: u8,
+        log_blowup: u8,
         channel: &mut Ch,
     ) -> Result<(Self, OpenedValues<EF>), DeepError>
     where
         Ch: VerifierChannel<F = F, Commitment = L::Commitment>,
     {
+        if log_blowup > log_lde_height {
+            return Err(DeepError::BlowupExceedsLdeHeight { log_lde_height, log_blowup });
+        }
+
         let group_widths: Vec<&[usize]> = commitments.iter().map(|(_, gw)| gw.as_slice()).collect();
         let evals = read_eval_matrices::<F, EF, Ch>(&group_widths, eval_points.len(), channel)?;
 
@@ -108,6 +116,7 @@ impl<F: TwoAdicField, EF: ExtensionField<F>, L: Lmcs<F = F>> DeepOracle<F, EF, L
         let oracle = Self {
             commitments,
             log_lde_height,
+            log_blowup,
             reduced_openings,
             challenge_columns,
             challenge_points,
@@ -161,7 +170,7 @@ impl<F: TwoAdicField, EF: ExtensionField<F>, L: Lmcs<F = F>> DeepOracle<F, EF, L
         }
 
         let generator = F::two_adic_generator(self.log_lde_height as usize);
-        let shift = F::GENERATOR;
+        let shift = crate::coset::lde_coset_shift::<F>(self.log_lde_height - self.log_blowup);
 
         // Reconstruct Q(x) at each queried domain point x from the opened row data.
         // If the prover's OOD claims were correct, these values lie on the
@@ -204,6 +213,8 @@ pub enum DeepError {
     InvalidOpening { tree: usize, tree_index: usize },
     #[error("evaluation point coincides with domain point at tree index {tree_index}")]
     EvalPointOnDomain { tree_index: usize },
+    #[error("log_blowup ({log_blowup}) exceeds log_lde_height ({log_lde_height})")]
+    BlowupExceedsLdeHeight { log_lde_height: u8, log_blowup: u8 },
     #[error("transcript error: {0}")]
     TranscriptError(#[from] TranscriptError),
 }

--- a/stark/miden-lifted-stark/src/pcs/verifier.rs
+++ b/stark/miden-lifted-stark/src/pcs/verifier.rs
@@ -79,6 +79,7 @@ where
         &eval_points,
         commitments.to_vec(),
         log_lde_height,
+        params.fri.log_blowup,
         channel,
     )?;
 

--- a/stark/miden-lifted-stark/src/prover/README.md
+++ b/stark/miden-lifted-stark/src/prover/README.md
@@ -59,7 +59,8 @@ Let:
   $n_j D_j$. Let $D_{\max} = \max_j D_j$.
 - $B$ be the **PCS/FRI blowup** used for commitment domains, with
   $D_{\max} \le B$.
-- $g$ be the fixed multiplicative shift (`F::GENERATOR`).
+- $g$ be the canonical multiplicative shift, defined per trace height as
+  $g_n = \texttt{F::GENERATOR}^{2^{(\texttt{F::TWO\_ADICITY} - \log_2 n)}}$.
 
 Define two-adic subgroups:
 

--- a/stark/miden-lifted-stark/src/prover/commit.rs
+++ b/stark/miden-lifted-stark/src/prover/commit.rs
@@ -149,8 +149,9 @@ where
 
 /// Commit multiple trace matrices with lifting: LDE → LMCS tree.
 ///
-/// Traces must be sorted by height in ascending order. Each trace is lifted to
-/// the max LDE domain using the appropriate nested coset shift.
+/// Traces must be sorted by height in ascending order. Each trace is committed
+/// on its own canonical coset (see [`crate::coset::lde_coset_shift`]), which
+/// nests inside the max-trace LDE coset.
 ///
 /// The DFT output is wrapped in `BitReversedMatrixView` (zero-cost view) and
 /// passed directly to the LMCS — no materialization needed.
@@ -169,11 +170,12 @@ where
 /// - If trace heights are not powers of two
 /// - If traces are not sorted by height in ascending order
 ///
-/// Lifting note: for a trace of height `n` embedded into a max height `n_max`, let
-/// `r = n_max / n`. The commitment should behave as if it contains evaluations of the
-/// lifted polynomial `f_lift(X) = f(Xʳ)` on the max LDE coset. This is achieved by
-/// evaluating the original trace on a *nested* coset with shift gʳ: the map
-/// `(g·ω)ʳ = gʳ·ωʳ` sends the max domain down to the smaller one.
+/// Lifting note: for a trace of height `n` embedded into a max height `n_max`
+/// via `r = n_max / n`, let `g_n` be the canonical shift for size `n` and `g`
+/// the canonical max-trace shift; the lifting identity `g^r = g_n` means
+/// evaluating the original trace on its own nested coset `g_n · K_n` matches
+/// `f_lift(X) = f(Xʳ)` on the max LDE coset `g · K_max`, via
+/// `(g · ω)ʳ = gʳ · ωʳ = g_n · ωʳ`.
 pub fn commit_traces<F, EF, SC>(
     config: &SC,
     traces: Vec<RowMajorMatrix<F>>,

--- a/stark/miden-lifted-stark/src/prover/periodic.rs
+++ b/stark/miden-lifted-stark/src/prover/periodic.rs
@@ -105,7 +105,7 @@ mod tests {
     use alloc::{vec, vec::Vec};
 
     use p3_dft::TwoAdicSubgroupDft;
-    use p3_field::{Field, PackedValue, PrimeCharacteristicRing};
+    use p3_field::{PackedValue, PrimeCharacteristicRing};
 
     use super::*;
     use crate::testing::configs::goldilocks_poseidon2 as gl;
@@ -136,13 +136,14 @@ mod tests {
         let periodic_lde = PeriodicLde::build(&coset, Some(repeated_matrix));
 
         // Compute expected LDE for each column via full expansion (natural order)
+        let expected_shift = coset.lde_shift::<gl::Felt>();
         let expected: Vec<Vec<gl::Felt>> = columns
             .iter()
             .map(|col| {
                 let full: Vec<gl::Felt> = (0..trace_height).map(|i| col[i % col.len()]).collect();
                 let matrix = RowMajorMatrix::new(full, 1);
                 NaiveDft
-                    .coset_lde_batch(matrix, log_blowup.into(), gl::Felt::GENERATOR)
+                    .coset_lde_batch(matrix, log_blowup.into(), expected_shift)
                     .to_row_major_matrix()
                     .values
             })

--- a/stark/miden-lifted-stark/src/util/bitrev.rs
+++ b/stark/miden-lifted-stark/src/util/bitrev.rs
@@ -105,23 +105,21 @@ pub fn materialize_bitrev<T: Clone + Send + Sync>(
     BitReversalPerm::new_view(evals.bit_reverse_rows().to_row_major_matrix())
 }
 
-/// Coset points `gK` in bit-reversed order.
-///
-/// Note: the coset shift `g` is fixed to `F::GENERATOR` by convention in this PCS.
+/// Coset points `shift · K` in bit-reversed order, where `K` is the two-adic
+/// subgroup of size `2^log_n`.
 ///
 /// Bit-reversal gives two properties essential for lifting:
-/// - **Adjacent negation**: `gK[2i+1] = -gK[2i]`, so both square to the same value
-/// - **Squaring gives prefix**: `(gK[2i])² = (gK)²[i]` — the even-indexed elements, when squared,
-///   form the half-size sub-coset. Generalizes to r-th powers.
+/// - **Adjacent negation**: `(shift·K)[2i+1] = -(shift·K)[2i]`, so both square to the same value
+/// - **Squaring gives prefix**: `((shift·K)[2i])² = ((shift·K)²)[i]` — the even-indexed elements,
+///   when squared, form the half-size sub-coset. Generalizes to r-th powers.
 ///
 /// Together these enable iterative weight folding in barycentric evaluation.
 ///
 /// # Panics
 /// Panics if the two-adic coset construction fails (e.g., `log_n` exceeds the field's
 /// two-adicity), since this unwraps `TwoAdicMultiplicativeCoset::new`.
-pub fn bit_reversed_coset_points<F: TwoAdicField>(log_n: u8) -> Vec<F> {
-    let coset =
-        p3_field::coset::TwoAdicMultiplicativeCoset::new(F::GENERATOR, log_n as usize).unwrap();
+pub fn bit_reversed_coset_points<F: TwoAdicField>(shift: F, log_n: u8) -> Vec<F> {
+    let coset = p3_field::coset::TwoAdicMultiplicativeCoset::new(shift, log_n as usize).unwrap();
     let mut pts: Vec<F> = coset.iter().collect();
     reverse_slice_index_bits(&mut pts);
     pts

--- a/stark/miden-lifted-stark/src/verifier/README.md
+++ b/stark/miden-lifted-stark/src/verifier/README.md
@@ -63,7 +63,8 @@ Let:
 - $N = 2^n$ be the **maximum** trace height across all traces.
 - $D = 2^d$ be the **constraint degree** (quotient-domain blowup).
 - $B = 2^b$ be the **PCS/FRI blowup**, with $D \le B$.
-- $g$ be the fixed multiplicative shift (`F::GENERATOR`).
+- $g$ be the canonical coset shift for the max trace:
+  $g = \texttt{F::GENERATOR}^{2^{(\texttt{F::TWO\_ADICITY} - n)}}$.
 
 Define subgroups:
 


### PR DESCRIPTION
## Describe your changes

closes #963 

Note that I haven't moved the `Coset` to the PCS module as the issue initially suggested, because to me it feels better suited where it stands, as it's part of the protocol layer and not solely the PCS layer. Happy to migrate it anyway if required.

## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
