### PR TITLE
Fix RocksDB CLI safety, serde canonicality, and WordWrapper paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - perf: fuse per-group accumulator and defer allocations ([#1008](https://github.com/0xMiden/crypto/pull/1008))
 - [BREAKING] Reorganized `miden-lifted-stark` internals: consolidated `align`, `bitrev`, `horner`, and `packing` helpers under a new `util` module; removed the legacy `fri::*` re-export facade ([#1000](https://github.com/0xMiden/crypto/pull/1000)).
 - [BREAKING] Extracted `BackendReader`, allowing `LargeSmtForest<S>` to work with read-only storage backends ([#986](https://github.com/0xMiden/crypto/pull/986)).
+- [BREAKING] Fixed RocksDB CLI safety, non-canonical serde input handling, and qualified `WordWrapper` derive paths ([#1022](https://github.com/0xMiden/crypto/pull/1022)).
 - [BREAKING] Refactored `miden-lifted-stark::domain` around a uniform `Coset` trait shared by `TwoAdicSubgroup` and `TwoAdicCoset`, slimmed the `LiftedDomain` surface (drops dead getters, removes silently-dispatched `points`/`bit_reversed_points`/`vanishing_at` in favour of explicit `trace_subgroup()` / `lde_coset()` access), made `LiftedDomain` constructors fallible, moved selector logic onto `LiftedDomain`, and changed `log_blowup` to return `u8` ([#993](https://github.com/0xMiden/crypto/pull/993)).
 
 ## 0.25.0 (2026-05-01)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1144,6 +1144,7 @@ dependencies = [
 name = "miden-crypto-derive"
 version = "0.26.0"
 dependencies = [
+ "miden-field",
  "quote",
  "syn",
 ]

--- a/Makefile
+++ b/Makefile
@@ -227,10 +227,10 @@ fuzz-signatures: ## Run fuzzing for DSA signature deserialization
 check-tools: ## Checks if development tools are installed
 	@echo "Checking development tools..."
 	@command -v typos >/dev/null 2>&1 && echo "[OK] typos is installed" || echo "[MISSING] typos is not installed (run: make install-tools)"
-	@command -v cargo nextest >/dev/null 2>&1 && echo "[OK] nextest is installed" || echo "[MISSING] nextest is not installed (run: make install-tools)"
+	@command -v cargo-nextest >/dev/null 2>&1 && echo "[OK] nextest is installed" || echo "[MISSING] nextest is not installed (run: make install-tools)"
 	@command -v taplo >/dev/null 2>&1 && echo "[OK] taplo is installed" || echo "[MISSING] taplo is not installed (run: make install-tools)"
 	@command -v cargo-shear >/dev/null 2>&1 && echo "[OK] cargo-shear is installed" || echo "[MISSING] cargo-shear is not installed (run: make install-tools)"
-	@command -v cargo deny >/dev/null 2>&1 && echo "[OK] cargo-deny is installed" || echo "[MISSING] cargo-deny is not installed (run: make install-tools)"
+	@command -v cargo-deny >/dev/null 2>&1 && echo "[OK] cargo-deny is installed" || echo "[MISSING] cargo-deny is not installed (run: make install-tools)"
 
 .PHONY: install-tools
 install-tools: ## Installs development tools required by the Makefile (typos, nextest, taplo, cargo-shear, cargo-deny)

--- a/miden-crypto-derive/Cargo.toml
+++ b/miden-crypto-derive/Cargo.toml
@@ -20,5 +20,8 @@ test       = false
 quote = { workspace = true }
 syn   = { features = ["full"], workspace = true }
 
+[dev-dependencies]
+miden-field = { workspace = true }
+
 [lints]
 workspace = true

--- a/miden-crypto-derive/src/lib.rs
+++ b/miden-crypto-derive/src/lib.rs
@@ -1,6 +1,6 @@
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::{Data, DeriveInput, Fields, Type, parse_macro_input};
+use syn::{Data, DeriveInput, Fields, PathArguments, Type, parse_macro_input};
 
 // SILENT DEBUG MACRO
 // ================================================================================================
@@ -169,19 +169,16 @@ pub fn word_wrapper_derive(input: TokenStream) -> TokenStream {
         },
     };
 
-    // Verify that the field type is 'Word' (or a path ending in 'Word')
-    if let Type::Path(type_path) = field_type {
-        let last_segment = type_path.path.segments.last();
-        if let Some(segment) = last_segment {
-            if segment.ident != "Word" {
-                return syn::Error::new_spanned(
-                    field_type,
-                    "WordWrapper can only be derived for types wrapping a 'Word' field",
-                )
-                .to_compile_error()
-                .into();
-            }
-        } else {
+    let word_type = if let Type::Path(type_path) = field_type {
+        let Some(segment) = type_path.path.segments.last() else {
+            return syn::Error::new_spanned(
+                field_type,
+                "WordWrapper can only be derived for types wrapping a 'Word' field",
+            )
+            .to_compile_error()
+            .into();
+        };
+        if segment.ident != "Word" {
             return syn::Error::new_spanned(
                 field_type,
                 "WordWrapper can only be derived for types wrapping a 'Word' field",
@@ -189,6 +186,16 @@ pub fn word_wrapper_derive(input: TokenStream) -> TokenStream {
             .to_compile_error()
             .into();
         }
+        if !matches!(segment.arguments, PathArguments::None) {
+            return syn::Error::new_spanned(
+                field_type,
+                "WordWrapper can only be derived for types wrapping a 'Word' field",
+            )
+            .to_compile_error()
+            .into();
+        }
+
+        field_type
     } else {
         return syn::Error::new_spanned(
             field_type,
@@ -196,7 +203,7 @@ pub fn word_wrapper_derive(input: TokenStream) -> TokenStream {
         )
         .to_compile_error()
         .into();
-    }
+    };
 
     let expanded = quote! {
         impl #impl_generics #name #ty_generics #where_clause {
@@ -206,12 +213,12 @@ pub fn word_wrapper_derive(input: TokenStream) -> TokenStream {
             ///
             /// This requires the caller to uphold the guarantees/invariants of this type (if any).
             /// Check the type-level documentation for guarantees/invariants.
-            pub fn from_raw(word: Word) -> Self {
+            pub fn from_raw(word: #word_type) -> Self {
                 Self(word)
             }
 
             /// Returns the elements representation of this value.
-            pub fn as_elements(&self) -> &[Felt] {
+            pub fn as_elements(&self) -> &[<#word_type as ::core::ops::Index<usize>>::Output] {
                 self.0.as_elements()
             }
 
@@ -226,7 +233,7 @@ pub fn word_wrapper_derive(input: TokenStream) -> TokenStream {
             }
 
             /// Returns the underlying word of this value.
-            pub fn as_word(&self) -> Word {
+            pub fn as_word(&self) -> #word_type {
                 self.0
             }
         }

--- a/miden-crypto-derive/tests/word_wrapper.rs
+++ b/miden-crypto-derive/tests/word_wrapper.rs
@@ -1,0 +1,67 @@
+#![allow(unused_qualifications)]
+
+use miden_crypto_derive::WordWrapper;
+
+mod qualified {
+    mod field {
+        pub use miden_field::Word;
+    }
+
+    #[derive(super::WordWrapper)]
+    pub struct QualifiedWord(miden_field::Word);
+
+    #[derive(super::WordWrapper)]
+    pub struct ModuleQualifiedWord(miden_field::word::Word);
+
+    #[derive(super::WordWrapper)]
+    pub struct ReexportedWord(field::Word);
+
+    #[test]
+    fn derives_accessors_for_qualified_word_path() {
+        let word = miden_field::Word::default();
+        let wrapper = QualifiedWord::from_raw(word);
+
+        let elements: &[miden_field::Felt] = wrapper.as_elements();
+        assert_eq!(elements, word.as_elements());
+        assert_eq!(wrapper.as_word(), word);
+    }
+
+    #[test]
+    fn derives_accessors_for_module_qualified_word_path() {
+        let word = miden_field::word::Word::default();
+        let wrapper = ModuleQualifiedWord::from_raw(word);
+
+        let elements: &[miden_field::Felt] = wrapper.as_elements();
+        assert_eq!(elements, word.as_elements());
+        assert_eq!(wrapper.as_word(), word);
+    }
+
+    #[test]
+    fn derives_accessors_for_reexported_word_path() {
+        let word = field::Word::default();
+        let wrapper = ReexportedWord::from_raw(word);
+
+        let elements: &[miden_field::Felt] = wrapper.as_elements();
+        assert_eq!(elements, word.as_elements());
+        assert_eq!(wrapper.as_word(), word);
+    }
+}
+
+mod unqualified {
+    use miden_field::{Felt, Word};
+
+    use super::WordWrapper;
+
+    #[derive(WordWrapper)]
+    pub struct UnqualifiedWord(Word);
+
+    #[test]
+    fn derives_accessors_for_unqualified_word_path() {
+        let word = Word::default();
+        let wrapper = UnqualifiedWord::from_raw(word);
+
+        let elements: &[Felt] = wrapper.as_elements();
+        assert_eq!(elements, word.as_elements());
+        assert_eq!(wrapper.as_word(), word);
+    }
+}

--- a/miden-crypto/src/main.rs
+++ b/miden-crypto/src/main.rs
@@ -42,7 +42,7 @@ pub struct BenchmarkCmd {
     #[clap(short = 'b', long = "batches", default_value = "1")]
     batches: usize,
     /// Storage backend to use at runtime: memory or rocksdb
-    #[arg(short = 's', long = "storage", value_enum, default_value = "memory")]
+    #[arg(long = "storage", value_enum, default_value = "memory")]
     storage: StorageKind,
 }
 
@@ -352,13 +352,26 @@ fn storage_io_error(message: String, err: std::io::Error) -> LargeSmtError {
 
 #[cfg(test)]
 mod tests {
-    use clap::ValueEnum;
+    use clap::{CommandFactory, Parser, ValueEnum};
 
     use super::*;
 
     #[test]
     fn storage_value_parser_accepts_memory() {
         assert_eq!(StorageKind::from_str("memory", true).unwrap(), StorageKind::Memory);
+    }
+
+    #[test]
+    fn clap_command_definition_is_valid() {
+        BenchmarkCmd::command().debug_assert();
+    }
+
+    #[test]
+    fn parses_size_short_and_memory_storage() {
+        let args = BenchmarkCmd::parse_from(["miden-crypto", "-s", "10", "--storage", "memory"]);
+
+        assert_eq!(args.size, 10);
+        assert_eq!(args.storage, StorageKind::Memory);
     }
 
     #[cfg(not(feature = "rocksdb"))]
@@ -377,6 +390,16 @@ mod tests {
     #[test]
     fn storage_value_parser_accepts_rocksdb_with_feature() {
         assert_eq!(StorageKind::from_str("rocksdb", true).unwrap(), StorageKind::Rocksdb);
+    }
+
+    #[cfg(feature = "rocksdb")]
+    #[test]
+    fn parses_explicit_rocksdb_storage_with_feature() {
+        let args =
+            BenchmarkCmd::parse_from(["miden-crypto", "--size", "10", "--storage", "rocksdb"]);
+
+        assert_eq!(args.size, 10);
+        assert_eq!(args.storage, StorageKind::Rocksdb);
     }
 
     #[test]

--- a/miden-crypto/src/main.rs
+++ b/miden-crypto/src/main.rs
@@ -1,14 +1,14 @@
+#[cfg(any(test, feature = "rocksdb"))]
+use std::path::Path;
 use std::{path::PathBuf, time::Instant};
 
 use clap::{Parser, ValueEnum};
-#[cfg(not(feature = "rocksdb"))]
-use miden_crypto::merkle::smt::StorageError;
 #[cfg(feature = "rocksdb")]
 use miden_crypto::merkle::smt::{RocksDbConfig, RocksDbStorage};
 use miden_crypto::{
     EMPTY_WORD, Felt, ONE, Word,
     hash::poseidon2::Poseidon2,
-    merkle::smt::{LargeSmt, LargeSmtError, MemoryStorage},
+    merkle::smt::{LargeSmt, LargeSmtError, MemoryStorage, StorageError},
     rand::test_utils::rand_value,
 };
 use rand::{RngExt, prelude::IteratorRandom, rng};
@@ -35,6 +35,9 @@ pub struct BenchmarkCmd {
     /// Open existing database and skip construction
     #[clap(short = 'o', long = "open", default_value = "false")]
     open: bool,
+    /// Delete an existing benchmark database path before creating a new one
+    #[clap(long = "reset", default_value = "false")]
+    reset: bool,
     /// Number of batch operations
     #[clap(short = 'b', long = "batches", default_value = "1")]
     batches: usize,
@@ -63,6 +66,7 @@ pub fn benchmark_smt() -> Result<(), LargeSmtError> {
     let updates = args.updates;
     let storage_path = args.storage_path;
     let batches = args.batches;
+    let reset = args.reset;
 
     println!(
         "Running benchmark with {} storage",
@@ -83,7 +87,7 @@ pub fn benchmark_smt() -> Result<(), LargeSmtError> {
     let mut tree = if args.open {
         open_existing(storage_path, args.storage)?
     } else {
-        construction(entries.clone(), tree_size, storage_path, args.storage)?
+        construction(entries.clone(), tree_size, storage_path, args.storage, reset)?
     };
     insertion(&mut tree, insertions)?;
     for _ in 0..batches {
@@ -101,10 +105,11 @@ pub fn construction(
     size: usize,
     database_path: Option<PathBuf>,
     storage: StorageKind,
+    reset: bool,
 ) -> Result<LargeSmt<Storage>, LargeSmtError> {
     println!("Running a construction benchmark:");
     let now = Instant::now();
-    let storage = get_storage(database_path, false, storage)?;
+    let storage = get_storage(database_path, false, reset, storage)?;
     let tree = LargeSmt::with_entries(storage, entries)?;
     let elapsed = now.elapsed().as_secs_f32();
     println!("Constructed an SMT with {size} key-value pairs in {elapsed:.1} seconds");
@@ -119,7 +124,7 @@ pub fn open_existing(
 ) -> Result<LargeSmt<Storage>, LargeSmtError> {
     println!("Opening an existing database:");
     let now = Instant::now();
-    let storage = get_storage(storage_path, true, storage)?;
+    let storage = get_storage(storage_path, true, false, storage)?;
     let tree = LargeSmt::load(storage)?;
     let elapsed = now.elapsed().as_secs_f32();
     println!("Opened an existing database in {elapsed:.1} seconds");
@@ -286,6 +291,7 @@ pub fn proof_generation(tree: &mut LargeSmt<Storage>) -> Result<(), LargeSmtErro
 fn get_storage(
     database_path: Option<PathBuf>,
     open: bool,
+    reset: bool,
     kind: StorageKind,
 ) -> Result<Storage, LargeSmtError> {
     match kind {
@@ -297,12 +303,7 @@ fn get_storage(
                     .unwrap_or_else(|| std::env::temp_dir().join("miden_crypto_benchmark"));
                 println!("Using database path: {}", path.display());
                 if !open {
-                    // delete the folder if it exists as we are creating a new database
-                    if path.exists() {
-                        std::fs::remove_dir_all(path.clone()).unwrap();
-                    }
-                    std::fs::create_dir_all(path.clone())
-                        .expect("Failed to create database directory");
+                    prepare_database_directory(&path, reset)?;
                 }
                 let db = RocksDbStorage::open(
                     RocksDbConfig::new(path).with_cache_size(1 << 30).with_max_open_files(2048),
@@ -320,6 +321,35 @@ fn get_storage(
     }
 }
 
+#[cfg(any(test, feature = "rocksdb"))]
+fn prepare_database_directory(path: &Path, reset: bool) -> Result<(), LargeSmtError> {
+    if path.exists() {
+        if !reset {
+            return Err(StorageError::Unsupported(format!(
+                "database path already exists: {}; pass --reset to delete it before creating a new benchmark database",
+                path.display()
+            ))
+            .into());
+        }
+
+        std::fs::remove_dir_all(path).map_err(|err| {
+            storage_io_error(format!("failed to reset database path {}", path.display()), err)
+        })?;
+    }
+
+    std::fs::create_dir_all(path).map_err(|err| {
+        storage_io_error(format!("failed to create database path {}", path.display()), err)
+    })?;
+
+    Ok(())
+}
+
+#[cfg(any(test, feature = "rocksdb"))]
+fn storage_io_error(message: String, err: std::io::Error) -> LargeSmtError {
+    StorageError::Backend(Box::new(std::io::Error::new(err.kind(), format!("{message}: {err}"))))
+        .into()
+}
+
 #[cfg(test)]
 mod tests {
     use clap::ValueEnum;
@@ -334,7 +364,7 @@ mod tests {
     #[cfg(not(feature = "rocksdb"))]
     #[test]
     fn rejects_explicit_rocksdb_storage_without_feature() {
-        let err = get_storage(None, false, StorageKind::Rocksdb).unwrap_err();
+        let err = get_storage(None, false, false, StorageKind::Rocksdb).unwrap_err();
         match err {
             LargeSmtError::Storage(StorageError::Unsupported(msg)) => {
                 assert!(msg.contains("rocksdb feature"));
@@ -347,5 +377,34 @@ mod tests {
     #[test]
     fn storage_value_parser_accepts_rocksdb_with_feature() {
         assert_eq!(StorageKind::from_str("rocksdb", true).unwrap(), StorageKind::Rocksdb);
+    }
+
+    #[test]
+    fn existing_database_path_requires_reset_and_preserves_contents() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let sentinel = temp_dir.path().join("sentinel.txt");
+        std::fs::write(&sentinel, "keep").unwrap();
+
+        let err = prepare_database_directory(temp_dir.path(), false).unwrap_err();
+        match err {
+            LargeSmtError::Storage(StorageError::Unsupported(msg)) => {
+                assert!(msg.contains("--reset"));
+            },
+            other => panic!("expected reset-required error, got {other:?}"),
+        }
+
+        assert_eq!(std::fs::read_to_string(&sentinel).unwrap(), "keep");
+    }
+
+    #[test]
+    fn reset_database_path_removes_existing_contents() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let sentinel = temp_dir.path().join("sentinel.txt");
+        std::fs::write(&sentinel, "delete").unwrap();
+
+        prepare_database_directory(temp_dir.path(), true).unwrap();
+
+        assert!(temp_dir.path().is_dir());
+        assert!(!sentinel.exists());
     }
 }

--- a/miden-crypto/src/main.rs
+++ b/miden-crypto/src/main.rs
@@ -1,6 +1,8 @@
 use std::{path::PathBuf, time::Instant};
 
 use clap::{Parser, ValueEnum};
+#[cfg(not(feature = "rocksdb"))]
+use miden_crypto::merkle::smt::StorageError;
 #[cfg(feature = "rocksdb")]
 use miden_crypto::merkle::smt::{RocksDbConfig, RocksDbStorage};
 use miden_crypto::{
@@ -47,13 +49,14 @@ pub enum StorageKind {
     Rocksdb,
 }
 
-fn main() {
-    benchmark_smt();
+fn main() -> Result<(), LargeSmtError> {
+    benchmark_smt()?;
     println!("Benchmark completed successfully");
+    Ok(())
 }
 
 /// Run a benchmark for [`Smt`].
-pub fn benchmark_smt() {
+pub fn benchmark_smt() -> Result<(), LargeSmtError> {
     let args = BenchmarkCmd::parse();
     let tree_size = args.size;
     let insertions = args.insertions;
@@ -78,16 +81,18 @@ pub fn benchmark_smt() {
     }
 
     let mut tree = if args.open {
-        open_existing(storage_path, args.storage).unwrap()
+        open_existing(storage_path, args.storage)?
     } else {
-        construction(entries.clone(), tree_size, storage_path, args.storage).unwrap()
+        construction(entries.clone(), tree_size, storage_path, args.storage)?
     };
-    insertion(&mut tree, insertions).unwrap();
+    insertion(&mut tree, insertions)?;
     for _ in 0..batches {
-        batched_insertion(&mut tree, insertions).unwrap();
-        batched_update(&mut tree, &entries, updates).unwrap();
+        batched_insertion(&mut tree, insertions)?;
+        batched_update(&mut tree, &entries, updates)?;
     }
-    proof_generation(&mut tree).unwrap();
+    proof_generation(&mut tree)?;
+
+    Ok(())
 }
 
 /// Runs the construction benchmark for [`Smt`], returning the constructed tree.
@@ -99,7 +104,7 @@ pub fn construction(
 ) -> Result<LargeSmt<Storage>, LargeSmtError> {
     println!("Running a construction benchmark:");
     let now = Instant::now();
-    let storage = get_storage(database_path, false, storage);
+    let storage = get_storage(database_path, false, storage)?;
     let tree = LargeSmt::with_entries(storage, entries)?;
     let elapsed = now.elapsed().as_secs_f32();
     println!("Constructed an SMT with {size} key-value pairs in {elapsed:.1} seconds");
@@ -114,7 +119,7 @@ pub fn open_existing(
 ) -> Result<LargeSmt<Storage>, LargeSmtError> {
     println!("Opening an existing database:");
     let now = Instant::now();
-    let storage = get_storage(storage_path, true, storage);
+    let storage = get_storage(storage_path, true, storage)?;
     let tree = LargeSmt::load(storage)?;
     let elapsed = now.elapsed().as_secs_f32();
     println!("Opened an existing database in {elapsed:.1} seconds");
@@ -278,9 +283,13 @@ pub fn proof_generation(tree: &mut LargeSmt<Storage>) -> Result<(), LargeSmtErro
 }
 
 #[allow(unused_variables)]
-fn get_storage(database_path: Option<PathBuf>, open: bool, kind: StorageKind) -> Storage {
+fn get_storage(
+    database_path: Option<PathBuf>,
+    open: bool,
+    kind: StorageKind,
+) -> Result<Storage, LargeSmtError> {
     match kind {
-        StorageKind::Memory => Box::new(BoxedStorage(MemoryStorage::new())),
+        StorageKind::Memory => Ok(Box::new(BoxedStorage(MemoryStorage::new()))),
         StorageKind::Rocksdb => {
             #[cfg(feature = "rocksdb")]
             {
@@ -297,15 +306,46 @@ fn get_storage(database_path: Option<PathBuf>, open: bool, kind: StorageKind) ->
                 }
                 let db = RocksDbStorage::open(
                     RocksDbConfig::new(path).with_cache_size(1 << 30).with_max_open_files(2048),
-                )
-                .expect("Failed to open database");
-                Box::new(BoxedStorage(db))
+                )?;
+                Ok(Box::new(BoxedStorage(db)))
             }
             #[cfg(not(feature = "rocksdb"))]
             {
-                eprintln!("rocksdb feature not enabled; falling back to memory storage");
-                Box::new(BoxedStorage(MemoryStorage::new()))
+                Err(StorageError::Unsupported(
+                    "rocksdb storage was requested, but the rocksdb feature is not enabled".into(),
+                )
+                .into())
             }
         },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::ValueEnum;
+
+    use super::*;
+
+    #[test]
+    fn storage_value_parser_accepts_memory() {
+        assert_eq!(StorageKind::from_str("memory", true).unwrap(), StorageKind::Memory);
+    }
+
+    #[cfg(not(feature = "rocksdb"))]
+    #[test]
+    fn rejects_explicit_rocksdb_storage_without_feature() {
+        let err = get_storage(None, false, StorageKind::Rocksdb).unwrap_err();
+        match err {
+            LargeSmtError::Storage(StorageError::Unsupported(msg)) => {
+                assert!(msg.contains("rocksdb feature"));
+            },
+            other => panic!("expected unsupported rocksdb storage error, got {other:?}"),
+        }
+    }
+
+    #[cfg(feature = "rocksdb")]
+    #[test]
+    fn storage_value_parser_accepts_rocksdb_with_feature() {
+        assert_eq!(StorageKind::from_str("rocksdb", true).unwrap(), StorageKind::Rocksdb);
     }
 }

--- a/miden-crypto/src/merkle/mmr/partial.rs
+++ b/miden-crypto/src/merkle/mmr/partial.rs
@@ -766,7 +766,14 @@ impl Deserializable for PartialMmr {
             ));
         }
         let tracked: Vec<usize> = Vec::read_from(source)?;
-        let tracked_leaves: BTreeSet<usize> = tracked.into_iter().collect();
+        let mut tracked_leaves = BTreeSet::new();
+        for leaf_pos in tracked {
+            if !tracked_leaves.insert(leaf_pos) {
+                return Err(DeserializationError::InvalidValue(
+                    "duplicate tracked leaf in partial mmr encoding".to_string(),
+                ));
+            }
+        }
 
         // Construct MmrPeaks to validate forest/peaks consistency
         let peaks = MmrPeaks::new(forest, peaks_vec).map_err(|e| {
@@ -1064,6 +1071,27 @@ mod tests {
         let decoded = PartialMmr::read_from_bytes(&bytes).unwrap();
 
         assert_eq!(partial_mmr, decoded);
+    }
+
+    #[test]
+    fn test_partial_mmr_deserialization_rejects_duplicate_tracked_leaves() {
+        let mmr = Mmr::try_from_iter(LEAVES.iter().copied()).unwrap();
+        let mut partial_mmr = PartialMmr::from_peaks(mmr.peaks());
+        let leaf_pos = 1usize;
+        let node = mmr.get(leaf_pos).unwrap();
+        let proof = mmr.open(leaf_pos).unwrap();
+        partial_mmr.track(leaf_pos, node, proof.path().merkle_path()).unwrap();
+
+        let mut bytes = Vec::new();
+        partial_mmr.forest.num_leaves().write_into(&mut bytes);
+        partial_mmr.peaks.write_into(&mut bytes);
+        partial_mmr.nodes.write_into(&mut bytes);
+        bytes.write_u8(PartialMmr::TRACKED_LEAVES_MARKER);
+        vec![leaf_pos, leaf_pos].write_into(&mut bytes);
+
+        let result = PartialMmr::read_from_bytes(&bytes);
+
+        assert!(matches!(result, Err(DeserializationError::InvalidValue(_))));
     }
 
     #[test]
@@ -1434,6 +1462,7 @@ mod tests {
         bad_bytes.extend_from_slice(&1usize.to_bytes()); // BTreeMap length
         bad_bytes.extend_from_slice(&0usize.to_bytes()); // invalid index 0
         bad_bytes.extend_from_slice(&int_to_node(0).to_bytes()); // value
+        bad_bytes.push(PartialMmr::TRACKED_LEAVES_MARKER);
         // tracked_leaves: empty vec
         bad_bytes.extend_from_slice(&0usize.to_bytes());
 

--- a/miden-crypto/tests/rocksdb_large_smt.rs
+++ b/miden-crypto/tests/rocksdb_large_smt.rs
@@ -143,6 +143,19 @@ fn rocksdb_persistence_after_insertion() {
 fn rocksdb_persistence_after_insert_batch_with_deletions() {
     // Create a tree with initial entries
     let entries = generate_entries(10_000);
+    let unchanged_key = entries[1_500].0;
+    let unchanged_value = entries[1_500].1;
+    let updated_key = entries[1_501].0;
+    let updated_value = Word::new([
+        Felt::new_unchecked(3),
+        Felt::new_unchecked(3),
+        Felt::new_unchecked(3),
+        Felt::new_unchecked(3),
+    ]);
+    let deleted_key = entries[100].0;
+    let newly_inserted_key =
+        Word::new([ONE, ONE, Felt::new_unchecked(20_000), Felt::new_unchecked(20_000 % 1000)]);
+    let newly_inserted_value = Word::new([ONE, ONE, ONE, Felt::new_unchecked(20_000)]);
 
     let (initial_storage, temp_dir_guard) = setup_storage();
     let db_path = temp_dir_guard.path().to_path_buf();
@@ -163,6 +176,9 @@ fn rocksdb_persistence_after_insert_batch_with_deletions() {
         let value = Word::new([ONE, ONE, ONE, Felt::new_unchecked(i as u64)]);
         batch_entries.push((key, value));
     }
+
+    // Update an existing entry that is not deleted below
+    batch_entries.push((updated_key, updated_value));
 
     // Delete some existing entries
     for i in 0..1000 {
@@ -197,6 +213,10 @@ fn rocksdb_persistence_after_insert_batch_with_deletions() {
     assert_eq!(num_leaves, num_leaves_2);
     assert_eq!(num_entries, num_entries_2);
     assert_eq!(smt.root(), root, "Tree reconstruction failed - root mismatch after deletions");
+    assert_eq!(smt.get_value(&unchanged_key), unchanged_value);
+    assert_eq!(smt.get_value(&newly_inserted_key), newly_inserted_value);
+    assert_eq!(smt.get_value(&updated_key), updated_value);
+    assert_eq!(smt.get_value(&deleted_key), EMPTY_WORD);
 }
 
 #[test]

--- a/miden-crypto/tests/rocksdb_large_smt.rs
+++ b/miden-crypto/tests/rocksdb_large_smt.rs
@@ -114,15 +114,23 @@ fn rocksdb_persistence_after_insertion() {
     let db_path = temp_dir_guard.path().to_path_buf();
 
     let mut smt = LargeSmt::<RocksDbStorage>::with_entries(initial_storage, entries).unwrap();
-    let key = Word::new([ONE, ONE, ONE, ONE]);
+    let initial_num_leaves = smt.num_leaves();
+    let initial_num_entries = smt.num_entries();
+    let key = Word::new([ONE, ONE, Felt::new_unchecked(20_000), Felt::new_unchecked(20_000)]);
     let new_value = Word::new([
         Felt::new_unchecked(2),
         Felt::new_unchecked(2),
         Felt::new_unchecked(2),
         Felt::new_unchecked(2),
     ]);
-    smt.insert(key, new_value).unwrap();
+    let previous_value = smt.insert(key, new_value).unwrap();
+    assert_eq!(previous_value, EMPTY_WORD);
+    assert_eq!(smt.get_value(&key), new_value);
+    assert_eq!(smt.num_leaves(), initial_num_leaves + 1);
+    assert_eq!(smt.num_entries(), initial_num_entries + 1);
     let root = smt.root();
+    let num_leaves = smt.num_leaves();
+    let num_entries = smt.num_entries();
 
     let mut inner_nodes: Vec<InnerNodeInfo> = smt.inner_nodes().unwrap().collect();
     inner_nodes.sort_by_key(|info| info.value);
@@ -137,6 +145,9 @@ fn rocksdb_persistence_after_insertion() {
     assert_eq!(inner_nodes.len(), inner_nodes_2.len());
     assert_eq!(inner_nodes, inner_nodes_2);
     assert_eq!(smt.root(), root);
+    assert_eq!(smt.num_leaves(), num_leaves);
+    assert_eq!(smt.num_entries(), num_entries);
+    assert_eq!(smt.get_value(&key), new_value);
 }
 
 #[test]

--- a/miden-serde-utils/src/lib.rs
+++ b/miden-serde-utils/src/lib.rs
@@ -482,6 +482,10 @@ where
         let v1 = T1::read_from(source)?;
         Ok((v1,))
     }
+
+    fn min_serialized_size() -> usize {
+        T1::min_serialized_size()
+    }
 }
 
 impl<T1, T2> Deserializable for (T1, T2)
@@ -872,5 +876,15 @@ mod tests {
         let result = BTreeSet::<u8>::read_from_bytes(&bytes);
 
         assert!(matches!(result, Err(DeserializationError::InvalidValue(_))));
+    }
+
+    #[test]
+    fn budgeted_vec_of_one_element_tuples_accepts_exact_budget() {
+        let values = Vec::<(usize,)>::from([(0,), (1,), (2,)]);
+        let bytes = values.to_bytes();
+
+        let decoded = Vec::<(usize,)>::read_from_bytes_with_budget(&bytes, bytes.len()).unwrap();
+
+        assert_eq!(decoded, values);
     }
 }

--- a/miden-serde-utils/src/lib.rs
+++ b/miden-serde-utils/src/lib.rs
@@ -690,7 +690,16 @@ impl<T: Deserializable> Deserializable for Vec<T> {
 impl<K: Deserializable + Ord, V: Deserializable> Deserializable for BTreeMap<K, V> {
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
         let len = source.read_usize()?;
-        source.read_many_iter(len)?.collect()
+        let mut map = BTreeMap::new();
+        for entry in source.read_many_iter(len)? {
+            let (key, value) = entry?;
+            if map.insert(key, value).is_some() {
+                return Err(DeserializationError::InvalidValue(String::from(
+                    "duplicate key in BTreeMap encoding",
+                )));
+            }
+        }
+        Ok(map)
     }
 
     fn min_serialized_size() -> usize {
@@ -701,7 +710,15 @@ impl<K: Deserializable + Ord, V: Deserializable> Deserializable for BTreeMap<K, 
 impl<T: Deserializable + Ord> Deserializable for BTreeSet<T> {
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
         let len = source.read_usize()?;
-        source.read_many_iter(len)?.collect()
+        let mut set = BTreeSet::new();
+        for item in source.read_many_iter(len)? {
+            if !set.insert(item?) {
+                return Err(DeserializationError::InvalidValue(String::from(
+                    "duplicate item in BTreeSet encoding",
+                )));
+            }
+        }
+        Ok(set)
     }
 
     fn min_serialized_size() -> usize {
@@ -829,5 +846,31 @@ mod tests {
         let bytes = string.to_bytes();
         let as_arc = Arc::<str>::read_from_bytes(&bytes).unwrap();
         assert_eq!(&*as_arc, "other direction");
+    }
+
+    #[test]
+    fn btree_map_rejects_duplicate_keys() {
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&2usize.to_bytes());
+        bytes.extend_from_slice(&7u8.to_bytes());
+        bytes.extend_from_slice(&1u8.to_bytes());
+        bytes.extend_from_slice(&7u8.to_bytes());
+        bytes.extend_from_slice(&2u8.to_bytes());
+
+        let result = BTreeMap::<u8, u8>::read_from_bytes(&bytes);
+
+        assert!(matches!(result, Err(DeserializationError::InvalidValue(_))));
+    }
+
+    #[test]
+    fn btree_set_rejects_duplicate_items() {
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&2usize.to_bytes());
+        bytes.extend_from_slice(&7u8.to_bytes());
+        bytes.extend_from_slice(&7u8.to_bytes());
+
+        let result = BTreeSet::<u8>::read_from_bytes(&bytes);
+
+        assert!(matches!(result, Err(DeserializationError::InvalidValue(_))));
     }
 }


### PR DESCRIPTION
This PR fixes several small correctness gaps in RocksDB CLI handling, storage tests, serde decoding, derive output, and tool checks. Per-commit review highly advised.

- The RocksDB CLI path now fails when `--storage rocksdb` is used without the `rocksdb` feature. It no longer falls back to memory storage for an explicit RocksDB request. The benchmark command also keeps existing RocksDB paths by default and only deletes them when `--reset` is passed.
- The benchmark CLI no longer uses `-s` for both `--size` and `--storage`. `-s` remains the short flag for `--size`; storage is selected with `--storage`.
- The RocksDB integration tests now check lookup results after reopening a tree. They cover unchanged keys, inserted keys, updated keys, and deleted keys. The single-insert test now uses a new key instead of updating an existing one.
- Serde decoding now rejects duplicate encoded entries for `BTreeMap`, `BTreeSet`, and `PartialMmr` tracked leaves. One-element tuple decoding now reports the right minimum serialized size for budgeted reads.[^1]
- `WordWrapper` derive now supports qualified and reexported `Word` paths without requiring local `Word` or `Felt` imports.
- The Makefile tool check now looks for `cargo-nextest` and `cargo-deny`, which are the actual plugin binaries.

[^1]: A real Rust `BTreeMap` or `BTreeSet` cannot hold duplicates, and this repo’s serializer will not produce them. But a malformed or hand-built byte stream can say “2 entries” and then encode the same key or item twice. Before the fix, deserialization could accept that input and silently collapse it into one map/set entry.