### PR TITLE
fix(lifted-stark): isolate serial constraint eval path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Added `Signature::from_der()` for EdDSA signatures ([#979](https://github.com/0xMiden/crypto/pull/979)).
 - Fixed `SimpleSmt::set_subtree()` to clear stale leaves and inner nodes in the replaced subtree region ([#981](https://github.com/0xMiden/crypto/pull/981)).
 - Fixed `SliceReader` bounds checking to reject overflowing read lengths ([#987](https://github.com/0xMiden/crypto/pull/987)).
+- Fixed `miden-lifted-stark` builds when `p3-maybe-rayon/parallel` is enabled without `miden-lifted-stark/parallel` ([#1023](https://github.com/0xMiden/crypto/pull/1023)).
 
 ## 0.24.0 (2026-04-19)
 

--- a/stark/miden-lifted-stark/src/lmcs/lifted_tree.rs
+++ b/stark/miden-lifted-stark/src/lmcs/lifted_tree.rs
@@ -12,7 +12,7 @@ use tracing::info_span;
 
 use crate::lmcs::{
     LmcsTree, bitrev::BitReversibleMatrix, proof::LeafOpening, row_list::RowList,
-    tree_indices::TreeIndices, utils::PackedValueExt,
+    tree_indices::TreeIndices,
 };
 
 /// A uniform binary Merkle tree whose leaves are constructed from matrices with power-of-two
@@ -443,7 +443,8 @@ fn absorb_matrix<PF, PD, M, H, const WIDTH: usize, const DIGEST_ELEMS: usize>(
             .par_chunks_mut(PF::WIDTH)
             .enumerate()
             .for_each(|(packed_idx, states_chunk)| {
-                let mut packed_state: [PD; WIDTH] = PackedValueExt::pack_columns(states_chunk);
+                let mut packed_state: [PD; WIDTH] =
+                    array::from_fn(|col| PD::from_fn(|lane| states_chunk[lane][col]));
                 let row_idx = packed_idx * PF::WIDTH;
                 let row = matrix.vertically_packed_row::<PF>(row_idx);
                 sponge.absorb_into(&mut packed_state, row);

--- a/stark/miden-lifted-stark/src/lmcs/lifted_tree.rs
+++ b/stark/miden-lifted-stark/src/lmcs/lifted_tree.rs
@@ -443,7 +443,7 @@ fn absorb_matrix<PF, PD, M, H, const WIDTH: usize, const DIGEST_ELEMS: usize>(
             .par_chunks_mut(PF::WIDTH)
             .enumerate()
             .for_each(|(packed_idx, states_chunk)| {
-                let mut packed_state: [PD; WIDTH] = PD::pack_columns(states_chunk);
+                let mut packed_state: [PD; WIDTH] = PackedValueExt::pack_columns(states_chunk);
                 let row_idx = packed_idx * PF::WIDTH;
                 let row = matrix.vertically_packed_row::<PF>(row_idx);
                 sponge.absorb_into(&mut packed_state, row);

--- a/stark/miden-lifted-stark/src/prover/constraints/mod.rs
+++ b/stark/miden-lifted-stark/src/prover/constraints/mod.rs
@@ -18,6 +18,7 @@ use p3_field::{
     TwoAdicField,
 };
 use p3_matrix::{Matrix, bitrev::BitReversedMatrixView, dense::RowMajorMatrixView};
+#[cfg(feature = "parallel")]
 use p3_maybe_rayon::prelude::*;
 use packed_row_bitrev::RowMajorMatrixBitrevPackedExt;
 
@@ -205,7 +206,7 @@ pub fn evaluate_constraints_into<F, EF, A>(
         let mut main_buf = Vec::<P<F>>::new();
         let mut aux_base_buf = Vec::<P<F>>::new();
         let mut aux_pe_buf = Vec::<PE<F, EF>>::new();
-        output.par_chunks_mut(points_per_task).enumerate().for_each(|(g, big_slice)| {
+        output.chunks_mut(points_per_task).enumerate().for_each(|(g, big_slice)| {
             eval_big_slice(&mut main_buf, &mut aux_base_buf, &mut aux_pe_buf, g, big_slice);
         });
     }


### PR DESCRIPTION
This fixes a `miden-lifted-stark` compile failure that can happen when `p3-maybe-rayon/parallel` is enabled by the wider dependency graph, but `miden-lifted-stark/parallel` itself is not enabled.

In that feature combination, the crate was still taking its non-parallel fallback path, but `p3_maybe_rayon` exposed true Rayon parallel iterators. That made the fallback closure require `Fn`, while it mutably captured scratch buffers, causing a borrow checker error.

The fix keeps the fallback path explicitly serial by using `chunks_mut` there. The parallel path is unchanged and still uses per-worker buffers via `for_each_init`.

Also included is a small cleanup to call the local `PackedValueExt::pack_columns` helper explicitly, avoiding ambiguity with newer dependency resolution.