### PR TITLE
refactor(merkle/smt/large_forest): simplify backend interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - [BREAKING] Fixed RocksDB CLI safety, non-canonical serde input handling, and qualified `WordWrapper` derive paths ([#1022](https://github.com/0xMiden/crypto/pull/1022)).
 - [BREAKING] Refactored `miden-lifted-stark::domain` around a uniform `Coset` trait shared by `TwoAdicSubgroup` and `TwoAdicCoset`, slimmed the `LiftedDomain` surface (drops dead getters, removes silently-dispatched `points`/`bit_reversed_points`/`vanishing_at` in favour of explicit `trace_subgroup()` / `lde_coset()` access), made `LiftedDomain` constructors fallible, moved selector logic onto `LiftedDomain`, and changed `log_blowup` to return `u8` ([#993](https://github.com/0xMiden/crypto/pull/993)).
 - [BREAKING] Implemented two-phase commit_mutations() / apply_mutations()-style API for `LargeSmtForest` ([#1018](https://github.com/0xMiden/crypto/pull/1018)).
+- [BREAKING] Simplify `LargeSmtForest` backend API ([#1030](https://github.com/0xMiden/crypto/pull/1030)).
 
 ## 0.25.1 (2026-05-21)
 

--- a/miden-crypto/src/merkle/smt/large_forest/backend/memory/mod.rs
+++ b/miden-crypto/src/merkle/smt/large_forest/backend/memory/mod.rs
@@ -395,17 +395,6 @@ impl Backend for InMemoryBackend {
 // These are the implementations of helper methods used by the backend tests.
 #[cfg(test)]
 impl InMemoryBackend {
-    pub(crate) fn compute_update_tree_mutations(
-        &self,
-        lineage: LineageId,
-        new_version: VersionId,
-        updates: SmtUpdateBatch,
-    ) -> Result<(Vec<LineageMutation>, InMemoryPreparedMutations)> {
-        let mut batch = SmtForestUpdateBatch::empty();
-        batch.operations(lineage).add_operations(updates.into_iter());
-        self.compute_mutations(new_version, batch)
-    }
-
     /// Adds the provided `lineage` to the forest.
     ///
     /// # Errors

--- a/miden-crypto/src/merkle/smt/large_forest/backend/memory/mod.rs
+++ b/miden-crypto/src/merkle/smt/large_forest/backend/memory/mod.rs
@@ -7,6 +7,8 @@ mod tests;
 
 use alloc::vec::Vec;
 
+#[cfg(test)]
+use crate::merkle::smt::large_forest::operation::SmtUpdateBatch;
 use crate::{
     EMPTY_WORD, Map, Word,
     merkle::{
@@ -16,7 +18,7 @@ use crate::{
             large_forest::{
                 Backend, BackendReader,
                 backend::{BackendError, Result},
-                operation::{SmtForestUpdateBatch, SmtUpdateBatch},
+                operation::SmtForestUpdateBatch,
                 root::{LineageId, TreeEntry, TreeWithRoot},
                 utils::{
                     AppliedLineageMutation, LineageMutation, LineageMutationKind, MutationSet,
@@ -249,147 +251,31 @@ impl Backend for InMemoryBackend {
         Ok(self.clone().into_snapshot())
     }
 
-    /// Computes the mutations required to add the provided `lineage` to the forest.
-    ///
-    /// # Errors
-    ///
-    /// - [`BackendError::DuplicateLineage`] if the provided `lineage` is the same as an
-    ///   already-known lineage. No data is changed in this case.
-    /// - [`BackendError::Merkle`] if the provided `updates` cannot be applied to the empty tree.
-    fn compute_add_lineage_mutations(
-        &self,
-        lineage: LineageId,
-        version: VersionId,
-        updates: SmtUpdateBatch,
-    ) -> Result<(Vec<LineageMutation>, Self::PreparedMutations)> {
-        if self.trees.contains_key(&lineage) {
-            return Err(BackendError::DuplicateLineage(lineage));
-        }
-
-        let tree = Smt::new();
-        let forward = tree.compute_mutations(updates.into_iter().map(Into::into))?;
-        let (mutation, prepared) = Self::mutation_from_tree(
-            lineage,
-            None,
-            version,
-            LineageMutationKind::AddLineage,
-            forward,
-        );
-
-        Ok((vec![mutation], InMemoryPreparedMutations { entries: vec![prepared] }))
-    }
-
-    /// Computes the mutations required to perform the provided `updates` on the tree with the
-    /// specified `lineage`, returning the mutation set.
-    ///
-    /// At most one new root is added to the backend for the entire batch.
-    ///
-    /// # Errors
-    ///
-    /// - [`BackendError::Merkle`] if an error occurs with the merkle tree semantics.
-    /// - [`BackendError::UnknownLineage`] if the provided `lineage` is not known by this backend.
-    fn compute_update_tree_mutations(
-        &self,
-        lineage: LineageId,
-        new_version: VersionId,
-        updates: SmtUpdateBatch,
-    ) -> Result<(Vec<LineageMutation>, Self::PreparedMutations)> {
-        let tree_data = self.trees.get(&lineage).ok_or(BackendError::UnknownLineage(lineage))?;
-        let forward = tree_data.tree.compute_mutations(updates.into_iter().map(Into::into))?;
-        let (mutation, prepared) = Self::mutation_from_tree(
-            lineage,
-            Some(tree_data.version),
-            new_version,
-            LineageMutationKind::UpdateTree,
-            forward,
-        );
-
-        Ok((vec![mutation], InMemoryPreparedMutations { entries: vec![prepared] }))
-    }
-
-    /// Computes the mutations required to add multiple new `lineages` to the tree, creating
-    /// an empty tree for each and applying the provided modifications to it, with the result
-    /// being given the specified `version`. Returns the mutation set.
-    ///
-    /// If the provide batch of modifications is empty for any given lineage, then the **empty tree
-    /// will be added** as the first version in that lineage.
-    ///
-    /// # Errors
-    ///
-    /// - [`BackendError::DuplicateLineage`] if any of the provided lineages already exists in the
-    ///   backend.
-    /// - [`BackendError::Merkle`] if an error occurs with the merkle tree semantics.
-    fn compute_add_lineages_mutations(
-        &self,
-        version: VersionId,
-        lineages: SmtForestUpdateBatch,
-    ) -> Result<(Vec<LineageMutation>, Self::PreparedMutations)> {
-        let updates = lineages
-            .into_iter()
-            .map(|(lineage, ops)| {
-                if self.trees.contains_key(&lineage) {
-                    return Err(BackendError::DuplicateLineage(lineage));
-                }
-                Ok((lineage, ops))
-            })
-            .collect::<Result<Vec<_>>>()?;
-
-        let mut mutations = Vec::with_capacity(updates.len());
-        let mut prepared = Vec::with_capacity(updates.len());
-        for (lineage, ops) in updates {
-            let tree = Smt::new();
-            let forward = tree.compute_mutations(ops.into_iter().map(Into::into))?;
-            let (mutation, prepared_entry) = Self::mutation_from_tree(
-                lineage,
-                None,
-                version,
-                LineageMutationKind::AddLineage,
-                forward,
-            );
-            mutations.push(mutation);
-            prepared.push(prepared_entry);
-        }
-
-        Ok((mutations, InMemoryPreparedMutations { entries: prepared }))
-    }
-
-    /// Computes the mutations required to apply the provided `updates` on the entire forest,
-    /// returning the mutation sets.
-    ///
-    /// The order of application of these mutations is unspecified.
-    ///
-    /// # Errors
-    ///
-    /// - [`BackendError::Merkle`] if an error occurs with the merkle tree semantics.
-    /// - [`BackendError::UnknownLineage`] if the provided `lineage` is not known by this backend.
-    fn compute_update_forest_mutations(
+    /// Computes the mutations required to apply the provided `updates` on the forest.
+    fn compute_mutations(
         &self,
         new_version: VersionId,
         updates: SmtForestUpdateBatch,
     ) -> Result<(Vec<LineageMutation>, Self::PreparedMutations)> {
-        let updates = updates
-            .into_iter()
-            .map(|(lineage, ops)| {
-                if !self.trees.contains_key(&lineage) {
-                    return Err(BackendError::UnknownLineage(lineage));
-                }
-
-                Ok((lineage, ops))
-            })
-            .collect::<Result<Vec<_>>>()?;
-
+        let updates = updates.into_iter().collect::<Vec<_>>();
         let mut mutations = Vec::with_capacity(updates.len());
         let mut prepared = Vec::with_capacity(updates.len());
         for (lineage, ops) in updates {
-            let tree_data = self.trees.get(&lineage).expect("Tree known to be present was not");
-            let forward = tree_data.tree.compute_mutations(ops.into_iter().map(Into::into))?;
-            let (mutation, prepared_entry) = Self::mutation_from_tree(
-                lineage,
-                Some(tree_data.version),
-                new_version,
-                LineageMutationKind::UpdateTree,
-                forward,
-            );
+            let (old_version, kind, forward) = if let Some(tree_data) = self.trees.get(&lineage) {
+                (
+                    Some(tree_data.version),
+                    LineageMutationKind::UpdateTree,
+                    tree_data.tree.compute_mutations(ops.into_iter().map(Into::into))?,
+                )
+            } else {
+                (
+                    None,
+                    LineageMutationKind::AddLineage,
+                    Smt::new().compute_mutations(ops.into_iter().map(Into::into))?,
+                )
+            };
+            let (mutation, prepared_entry) =
+                Self::mutation_from_tree(lineage, old_version, new_version, kind, forward);
             mutations.push(mutation);
             prepared.push(prepared_entry);
         }
@@ -509,6 +395,17 @@ impl Backend for InMemoryBackend {
 // These are the implementations of helper methods used by the backend tests.
 #[cfg(test)]
 impl InMemoryBackend {
+    pub(crate) fn compute_update_tree_mutations(
+        &self,
+        lineage: LineageId,
+        new_version: VersionId,
+        updates: SmtUpdateBatch,
+    ) -> Result<(Vec<LineageMutation>, InMemoryPreparedMutations)> {
+        let mut batch = SmtForestUpdateBatch::empty();
+        batch.operations(lineage).add_operations(updates.into_iter());
+        self.compute_mutations(new_version, batch)
+    }
+
     /// Adds the provided `lineage` to the forest.
     ///
     /// # Errors
@@ -522,8 +419,13 @@ impl InMemoryBackend {
         version: VersionId,
         updates: SmtUpdateBatch,
     ) -> Result<TreeWithRoot> {
-        let (_mutations, persistent_mutations) =
-            self.compute_add_lineage_mutations(lineage, version, updates)?;
+        if self.trees.contains_key(&lineage) {
+            return Err(BackendError::DuplicateLineage(lineage));
+        }
+
+        let mut batch = SmtForestUpdateBatch::empty();
+        batch.operations(lineage).add_operations(updates.into_iter());
+        let (_mutations, persistent_mutations) = self.compute_mutations(version, batch)?;
 
         let mut applied_mutations = self.apply_mutations(persistent_mutations)?;
         let applied_mutation = applied_mutations
@@ -550,8 +452,13 @@ impl InMemoryBackend {
         new_version: VersionId,
         updates: SmtUpdateBatch,
     ) -> Result<MutationSet> {
-        let (_mutations, persistent_mutations) =
-            self.compute_update_tree_mutations(lineage, new_version, updates)?;
+        if !self.trees.contains_key(&lineage) {
+            return Err(BackendError::UnknownLineage(lineage));
+        }
+
+        let mut batch = SmtForestUpdateBatch::empty();
+        batch.operations(lineage).add_operations(updates.into_iter());
+        let (_mutations, persistent_mutations) = self.compute_mutations(new_version, batch)?;
 
         let mut applied_mutations = self.apply_mutations(persistent_mutations)?;
         let applied_mutation = applied_mutations
@@ -579,8 +486,13 @@ impl InMemoryBackend {
         version: VersionId,
         lineages: SmtForestUpdateBatch,
     ) -> Result<Vec<(LineageId, TreeWithRoot)>> {
-        let (_mutations, persistent_mutations) =
-            self.compute_add_lineages_mutations(version, lineages)?;
+        for lineage in lineages.lineages() {
+            if self.trees.contains_key(lineage) {
+                return Err(BackendError::DuplicateLineage(*lineage));
+            }
+        }
+
+        let (_mutations, persistent_mutations) = self.compute_mutations(version, lineages)?;
 
         let applied_mutations = self.apply_mutations(persistent_mutations)?;
 
@@ -613,8 +525,13 @@ impl InMemoryBackend {
         new_version: VersionId,
         updates: SmtForestUpdateBatch,
     ) -> Result<Vec<(LineageId, MutationSet)>> {
-        let (_mutations, persistent_mutations) =
-            self.compute_update_forest_mutations(new_version, updates)?;
+        for lineage in updates.lineages() {
+            if !self.trees.contains_key(lineage) {
+                return Err(BackendError::UnknownLineage(*lineage));
+            }
+        }
+
+        let (_mutations, persistent_mutations) = self.compute_mutations(new_version, updates)?;
 
         let applied_mutations = self.apply_mutations(persistent_mutations)?;
 

--- a/miden-crypto/src/merkle/smt/large_forest/backend/memory/tests.rs
+++ b/miden-crypto/src/merkle/smt/large_forest/backend/memory/tests.rs
@@ -651,7 +651,9 @@ fn apply_mutations_returns_reversion_data() -> Result<()> {
     let expected_forward = reference.compute_mutations([(key_2, value_3)])?;
     let expected_reverse = reference.apply_mutations_with_reversion(expected_forward)?;
 
-    let (_, prepared) = backend.compute_update_tree_mutations(lineage, version_2, updates)?;
+    let mut batch = SmtForestUpdateBatch::empty();
+    batch.operations(lineage).add_operations(updates.into_iter());
+    let (_, prepared) = backend.compute_mutations(version_2, batch)?;
     let applied = backend.apply_mutations(prepared)?;
 
     assert_eq!(applied.len(), 1);
@@ -683,8 +685,9 @@ fn apply_mutations_rejects_stale_prepared_update() -> Result<()> {
 
     let mut stale_updates = SmtUpdateBatch::default();
     stale_updates.add_insert(key_2, value_2);
-    let (_visible, stale_prepared) =
-        backend.compute_update_tree_mutations(lineage, 2, stale_updates)?;
+    let mut stale_batch = SmtForestUpdateBatch::empty();
+    stale_batch.operations(lineage).add_operations(stale_updates.into_iter());
+    let (_visible, stale_prepared) = backend.compute_mutations(2, stale_batch)?;
 
     let mut intervening_updates = SmtUpdateBatch::default();
     intervening_updates.add_insert(key_3, value_3);

--- a/miden-crypto/src/merkle/smt/large_forest/backend/mod.rs
+++ b/miden-crypto/src/merkle/smt/large_forest/backend/mod.rs
@@ -17,7 +17,7 @@ use crate::{
         smt::{
             LeafIndex, SMT_DEPTH, SmtLeaf, SmtProof,
             large_forest::{
-                operation::{SmtForestUpdateBatch, SmtUpdateBatch},
+                operation::SmtForestUpdateBatch,
                 root::{LineageId, TreeEntry, TreeWithRoot, VersionId},
                 utils::{AppliedLineageMutation, LineageMutation},
             },
@@ -181,93 +181,20 @@ pub trait Backend: BackendReader {
     // TWO-PHASE MODIFIERS
     // ============================================================================================
 
-    /// Computes the backend data required to add one lineage, without applying it.
-    ///
-    /// The returned [`LineageMutation`] entries describe the visible root/version effects of the
-    /// prospective addition, while [`Self::PreparedMutations`] contains the backend-specific data
-    /// needed to commit those effects later via [`Self::apply_mutations`].
+    /// Computes the backend data required to mutate lineages, without applying it.
     ///
     /// # Expected Behavior
     ///
     /// Implementations must guarantee the following behavior in addition to the global invariants:
     ///
     /// - The backend's committed state must not change.
-    /// - If the provided `lineage` conflicts with an already-existing lineage in the backend, this
-    ///   method must return [`BackendError::DuplicateLineage`].
-    /// - The returned prepared mutations must be sufficient for [`Self::apply_mutations`] to apply
-    ///   the addition without recomputing the Merkle update from `updates`.
-    /// - Empty `updates` must still prepare a new empty lineage.
-    fn compute_add_lineage_mutations(
-        &self,
-        lineage: LineageId,
-        version: VersionId,
-        updates: SmtUpdateBatch,
-    ) -> Result<(Vec<LineageMutation>, Self::PreparedMutations)>;
-
-    /// Computes the backend data required to update one lineage, without applying it.
-    ///
-    /// The returned [`LineageMutation`] describes the visible root/version effect. The
-    /// backend-specific prepared payload is consumed by [`Self::apply_mutations`] to commit the
-    /// forward changes and return the reverse mutation data needed for history construction.
-    ///
-    /// # Expected Behavior
-    ///
-    /// Implementations must guarantee the following behavior in addition to the global invariants:
-    ///
-    /// - The backend's committed state must not change.
-    /// - If `lineage` is unknown to the backend, this method must return
-    ///   [`BackendError::UnknownLineage`].
-    /// - If applying `updates` would not change the tree, the returned lineage mutation must
-    ///   describe a no-op and the prepared data must not allocate a new backend tree version when
-    ///   applied.
-    /// - The returned prepared mutations must be sufficient for [`Self::apply_mutations`] to apply
-    ///   the update without recomputing the Merkle update from `updates`.
-    fn compute_update_tree_mutations(
-        &self,
-        lineage: LineageId,
-        new_version: VersionId,
-        updates: SmtUpdateBatch,
-    ) -> Result<(Vec<LineageMutation>, Self::PreparedMutations)>;
-
-    /// Computes the backend data required to add multiple lineages, without applying it.
-    ///
-    /// This is the batched equivalent of [`Self::compute_add_lineage_mutations`]. Backends may use
-    /// this method to prepare the additions in parallel or to build a more efficient batched apply
-    /// representation.
-    ///
-    /// # Expected Behavior
-    ///
-    /// Implementations must guarantee the following behavior in addition to the global invariants:
-    ///
-    /// - The backend's committed state must not change.
-    /// - If any provided lineage conflicts with an already-existing lineage, this method must
-    ///   return [`BackendError::DuplicateLineage`] and prepare no partial committed state.
-    /// - Each lineage in `lineages` must produce at most one [`LineageMutation`].
-    /// - The prepared mutations must be applicable atomically by [`Self::apply_mutations`] where
-    ///   the backend supports atomic writes.
-    fn compute_add_lineages_mutations(
-        &self,
-        version: VersionId,
-        lineages: SmtForestUpdateBatch,
-    ) -> Result<(Vec<LineageMutation>, Self::PreparedMutations)>;
-
-    /// Computes the backend data required to update multiple lineages, without applying it.
-    ///
-    /// This is the batched equivalent of [`Self::compute_update_tree_mutations`]. Backends may use
-    /// this method to exploit parallelism across lineages and to prepare a single batched commit.
-    ///
-    /// # Expected Behavior
-    ///
-    /// Implementations must guarantee the following behavior in addition to the global invariants:
-    ///
-    /// - The backend's committed state must not change.
-    /// - If any target lineage is unknown, this method must return [`BackendError::UnknownLineage`]
-    ///   and prepare no partial committed state.
+    /// - Each unknown lineage in `updates` is treated as an addition from the empty tree.
+    /// - Each known lineage in `updates` is treated as an update to its latest tree.
     /// - Each lineage in `updates` must produce at most one [`LineageMutation`].
     /// - No-op lineage updates must not allocate new backend tree versions when applied.
     /// - The prepared mutations must be applicable atomically by [`Self::apply_mutations`] where
     ///   the backend supports atomic writes.
-    fn compute_update_forest_mutations(
+    fn compute_mutations(
         &self,
         new_version: VersionId,
         updates: SmtForestUpdateBatch,

--- a/miden-crypto/src/merkle/smt/large_forest/backend/persistent/mod.rs
+++ b/miden-crypto/src/merkle/smt/large_forest/backend/persistent/mod.rs
@@ -47,15 +47,16 @@ use rocksdb as db;
 pub use snapshot::PersistentBackendReader;
 
 use super::{BackendError, Result};
+#[cfg(test)]
+use crate::merkle::smt::SmtUpdateBatch;
 use crate::{
     EMPTY_WORD, Map, Word,
     merkle::{
         EmptySubtreeRoots, MerkleError, NodeIndex,
         smt::{
             Backend, BackendReader, LeafIndex, LineageId, NodeMutation, NodeMutations, SMT_DEPTH,
-            SmtForestUpdateBatch, SmtLeaf, SmtLeafError, SmtProof, SmtUpdateBatch,
-            StorageUpdateParts, StorageUpdates, Subtree, SubtreeError, TreeEntry, TreeWithRoot,
-            VersionId,
+            SmtForestUpdateBatch, SmtLeaf, SmtLeafError, SmtProof, StorageUpdateParts,
+            StorageUpdates, Subtree, SubtreeError, TreeEntry, TreeWithRoot, VersionId,
             full::concurrent::{
                 MutatedSubtreeLeaves, SUBTREE_DEPTH, SubtreeLeaf, SubtreeLeavesIter,
                 fetch_sibling_pair, process_sorted_pairs_to_leaves,
@@ -331,137 +332,7 @@ impl Backend for PersistentBackend {
         ))
     }
 
-    /// Computes the mutations required to add the provided `lineage` to the forest with the
-    /// provided `version` and sets the associated tree to have the value created by applying
-    /// `updates` to the empty tree, returning the mutation set.
-    ///
-    /// # Errors
-    ///
-    /// - [`BackendError::DuplicateLineage`] if the provided `lineage` already exists in the
-    ///   backend.
-    /// - [`BackendError::Internal`] if the database cannot be accessed at any point.
-    /// - [`BackendError::Merkle`] if an error occurs with the merkle tree semantics.
-    fn compute_add_lineage_mutations(
-        &self,
-        lineage: LineageId,
-        version: VersionId,
-        updates: SmtUpdateBatch,
-    ) -> Result<(Vec<LineageMutation>, Self::PreparedMutations)> {
-        // We start by checking if the lineage already exists, preserving the behavior expected by
-        // the backend tests.
-        if self.lineages.contains_key(&lineage) {
-            return Err(BackendError::DuplicateLineage(lineage));
-        }
-
-        // We now build our new tree metadata, which begins as a fully-empty tree with the default
-        // root, no leaves, and no entries.
-        let metadata = TreeMetadata {
-            version,
-            root_value: *EmptySubtreeRoots::entry(SMT_DEPTH, 0),
-            entry_count: 0,
-        };
-
-        let (mutation, prepared) = self.prepare_tree_update(
-            lineage,
-            metadata,
-            version,
-            updates.into(),
-            LineageMutationKind::AddLineage,
-        )?;
-
-        Ok((vec![mutation], PersistentPreparedMutations { entries: vec![prepared] }))
-    }
-
-    /// Computes the mutations required to perform the provided `updates` on the tree with the
-    /// specified `lineage`, returning the mutation set.
-    ///
-    /// At most one new root is added to the backend for the entire batch.
-    ///
-    /// # Errors
-    ///
-    /// - [`BackendError::Internal`] if the database cannot be accessed at any point.
-    /// - [`BackendError::Merkle`] if an error occurs with the merkle tree semantics.
-    /// - [`BackendError::UnknownLineage`] if the provided `lineage` is not known by this backend.
-    fn compute_update_tree_mutations(
-        &self,
-        lineage: LineageId,
-        new_version: VersionId,
-        updates: SmtUpdateBatch,
-    ) -> Result<(Vec<LineageMutation>, Self::PreparedMutations)> {
-        // We check our lineage existence at the start just as a sanity check.
-        let metadata = self
-            .lineages
-            .get(&lineage)
-            .ok_or(BackendError::UnknownLineage(lineage))?
-            .clone();
-
-        let (mutation, prepared) = self.prepare_tree_update(
-            lineage,
-            metadata,
-            new_version,
-            updates.into(),
-            LineageMutationKind::UpdateTree,
-        )?;
-
-        Ok((vec![mutation], PersistentPreparedMutations { entries: vec![prepared] }))
-    }
-
-    /// Computes the mutations required to add multiple new `lineages` to the tree, creating
-    /// an empty tree for each and applying the provided modifications to it, with the result
-    /// being given the specified `version`. Returns the mutation set.
-    ///
-    /// If the provide batch of modifications is empty for any given lineage, then the **empty tree
-    /// will be added** as the first version in that lineage.
-    ///
-    /// # Errors
-    ///
-    /// - [`BackendError::DuplicateLineage`] if any of the provided lineages already exists in the
-    ///   backend.
-    /// - [`BackendError::Internal`] if the database cannot be accessed at any point.
-    /// - [`BackendError::Merkle`] if an error occurs with the merkle tree semantics.
-    fn compute_add_lineages_mutations(
-        &self,
-        version: VersionId,
-        lineages: SmtForestUpdateBatch,
-    ) -> Result<(Vec<LineageMutation>, Self::PreparedMutations)> {
-        // We start by checking that none of the lineages already exist, as we are expected by
-        // contract to error if any is a duplicate.
-        let updates = lineages
-            .into_iter()
-            .map(|(lineage, ops)| {
-                if self.lineages.contains_key(&lineage) {
-                    return Err(BackendError::DuplicateLineage(lineage));
-                }
-                Ok((lineage, ops))
-            })
-            .collect::<Result<Vec<_>>>()?;
-
-        // Process lineages in parallel.
-        let lineage_data = updates
-            .into_par_iter()
-            .map(|(lineage, ops)| {
-                let metadata = TreeMetadata {
-                    version,
-                    root_value: *EmptySubtreeRoots::entry(SMT_DEPTH, 0),
-                    entry_count: 0,
-                };
-                self.prepare_tree_update(
-                    lineage,
-                    metadata,
-                    version,
-                    ops.into_iter().map(Into::into).collect(),
-                    LineageMutationKind::AddLineage,
-                )
-            })
-            .collect::<Result<Vec<_>>>()?;
-
-        let (mutations, prepared): (Vec<_>, Vec<_>) = lineage_data.into_iter().unzip();
-
-        Ok((mutations, PersistentPreparedMutations { entries: prepared }))
-    }
-
-    /// Computes the mutations required to apply the provided `updates` on the entire forest,
-    /// returning the mutation sets.
+    /// Computes the mutations required to apply the provided `updates` on the forest.
     ///
     /// The order of application of these mutations is unspecified, but is guaranteed to produce no
     /// more than one new root for each operated-upon lineage. All operations are performed as part
@@ -472,35 +343,40 @@ impl Backend for PersistentBackend {
     /// - [`BackendError::Internal`] if the database cannot be accessed at any point.
     /// - [`BackendError::Merkle`] if an error occurs with the merkle tree semantics.
     /// - [`BackendError::UnknownLineage`] if the provided `lineage` is not known by this backend.
-    fn compute_update_forest_mutations(
+    fn compute_mutations(
         &self,
         new_version: VersionId,
         updates: SmtForestUpdateBatch,
     ) -> Result<(Vec<LineageMutation>, Self::PreparedMutations)> {
-        // We first have to check our precondition that all lineages are valid, returning an error
-        // as required by our contract if any lineage is unknown to the backend.
         let updates = updates
             .into_iter()
             .map(|(lineage, ops)| {
-                let metadata = self
-                    .lineages
-                    .get(&lineage)
-                    .ok_or(BackendError::UnknownLineage(lineage))?
-                    .clone();
-                Ok((lineage, ops, metadata))
+                let (metadata, kind) = if let Some(metadata) = self.lineages.get(&lineage) {
+                    (metadata.clone(), LineageMutationKind::UpdateTree)
+                } else {
+                    (
+                        TreeMetadata {
+                            version: new_version,
+                            root_value: *EmptySubtreeRoots::entry(SMT_DEPTH, 0),
+                            entry_count: 0,
+                        },
+                        LineageMutationKind::AddLineage,
+                    )
+                };
+                Ok((lineage, ops, metadata, kind))
             })
             .collect::<Result<Vec<_>>>()?;
 
         // Now we can simply issue the work in parallel.
         let lineage_data = updates
             .into_par_iter()
-            .map(|(lineage, ops, metadata)| {
+            .map(|(lineage, ops, metadata, kind)| {
                 self.prepare_tree_update(
                     lineage,
                     metadata,
                     new_version,
                     ops.into_iter().map(Into::into).collect(),
-                    LineageMutationKind::UpdateTree,
+                    kind,
                 )
             })
             .collect::<Result<Vec<_>>>()?;
@@ -616,6 +492,17 @@ impl Backend for PersistentBackend {
 // These are the implementations of helper methods used by the backend tests.
 #[cfg(test)]
 impl PersistentBackend {
+    pub(crate) fn compute_update_tree_mutations(
+        &self,
+        lineage: LineageId,
+        new_version: VersionId,
+        updates: SmtUpdateBatch,
+    ) -> Result<(Vec<LineageMutation>, PersistentPreparedMutations)> {
+        let mut batch = SmtForestUpdateBatch::empty();
+        batch.operations(lineage).add_operations(updates.into_iter());
+        self.compute_mutations(new_version, batch)
+    }
+
     /// Adds the provided `lineage` to the forest with the provided `version` and sets the
     /// associated tree to have the value created by applying `updates` to the empty tree, returning
     /// the root of this new tree.
@@ -632,8 +519,13 @@ impl PersistentBackend {
         version: VersionId,
         updates: SmtUpdateBatch,
     ) -> Result<TreeWithRoot> {
-        let (_mutations, persistent_mutations) =
-            self.compute_add_lineage_mutations(lineage, version, updates)?;
+        if self.lineages.contains_key(&lineage) {
+            return Err(BackendError::DuplicateLineage(lineage));
+        }
+
+        let mut batch = SmtForestUpdateBatch::empty();
+        batch.operations(lineage).add_operations(updates.into_iter());
+        let (_mutations, persistent_mutations) = self.compute_mutations(version, batch)?;
 
         let mut applied_mutations = self.apply_mutations(persistent_mutations)?;
         let applied_mutation = applied_mutations
@@ -660,8 +552,13 @@ impl PersistentBackend {
         new_version: VersionId,
         updates: SmtUpdateBatch,
     ) -> Result<MutationSet> {
-        let (_mutations, persistent_mutations) =
-            self.compute_update_tree_mutations(lineage, new_version, updates)?;
+        if !self.lineages.contains_key(&lineage) {
+            return Err(BackendError::UnknownLineage(lineage));
+        }
+
+        let mut batch = SmtForestUpdateBatch::empty();
+        batch.operations(lineage).add_operations(updates.into_iter());
+        let (_mutations, persistent_mutations) = self.compute_mutations(new_version, batch)?;
 
         let mut applied_mutations = self.apply_mutations(persistent_mutations)?;
         let applied_mutation = applied_mutations
@@ -689,8 +586,13 @@ impl PersistentBackend {
         version: VersionId,
         lineages: SmtForestUpdateBatch,
     ) -> Result<Vec<(LineageId, TreeWithRoot)>> {
-        let (_mutations, persistent_mutations) =
-            self.compute_add_lineages_mutations(version, lineages)?;
+        for lineage in lineages.lineages() {
+            if self.lineages.contains_key(lineage) {
+                return Err(BackendError::DuplicateLineage(*lineage));
+            }
+        }
+
+        let (_mutations, persistent_mutations) = self.compute_mutations(version, lineages)?;
 
         let applied_mutations = self.apply_mutations(persistent_mutations)?;
 
@@ -720,8 +622,13 @@ impl PersistentBackend {
         new_version: VersionId,
         updates: SmtForestUpdateBatch,
     ) -> Result<Vec<(LineageId, MutationSet)>> {
-        let (_mutations, persistent_mutations) =
-            self.compute_update_forest_mutations(new_version, updates)?;
+        for lineage in updates.lineages() {
+            if !self.lineages.contains_key(lineage) {
+                return Err(BackendError::UnknownLineage(*lineage));
+            }
+        }
+
+        let (_mutations, persistent_mutations) = self.compute_mutations(new_version, updates)?;
 
         let applied_mutations = self.apply_mutations(persistent_mutations)?;
 

--- a/miden-crypto/src/merkle/smt/large_forest/backend/persistent/mod.rs
+++ b/miden-crypto/src/merkle/smt/large_forest/backend/persistent/mod.rs
@@ -492,17 +492,6 @@ impl Backend for PersistentBackend {
 // These are the implementations of helper methods used by the backend tests.
 #[cfg(test)]
 impl PersistentBackend {
-    pub(crate) fn compute_update_tree_mutations(
-        &self,
-        lineage: LineageId,
-        new_version: VersionId,
-        updates: SmtUpdateBatch,
-    ) -> Result<(Vec<LineageMutation>, PersistentPreparedMutations)> {
-        let mut batch = SmtForestUpdateBatch::empty();
-        batch.operations(lineage).add_operations(updates.into_iter());
-        self.compute_mutations(new_version, batch)
-    }
-
     /// Adds the provided `lineage` to the forest with the provided `version` and sets the
     /// associated tree to have the value created by applying `updates` to the empty tree, returning
     /// the root of this new tree.

--- a/miden-crypto/src/merkle/smt/large_forest/backend/persistent/tests.rs
+++ b/miden-crypto/src/merkle/smt/large_forest/backend/persistent/tests.rs
@@ -866,8 +866,9 @@ fn apply_mutations_rejects_stale_prepared_update() -> Result<()> {
 
     let mut stale_updates = SmtUpdateBatch::default();
     stale_updates.add_insert(key_2, value_2);
-    let (_visible, stale_prepared) =
-        backend.compute_update_tree_mutations(lineage, 2, stale_updates)?;
+    let mut stale_batch = SmtForestUpdateBatch::empty();
+    stale_batch.operations(lineage).add_operations(stale_updates.into_iter());
+    let (_visible, stale_prepared) = backend.compute_mutations(2, stale_batch)?;
 
     let mut intervening_updates = SmtUpdateBatch::default();
     intervening_updates.add_insert(key_3, value_3);

--- a/miden-crypto/src/merkle/smt/large_forest/mod.rs
+++ b/miden-crypto/src/merkle/smt/large_forest/mod.rs
@@ -325,9 +325,11 @@ pub use backend::{
 };
 pub use config::{Config, DEFAULT_MAX_HISTORY_VERSIONS, MIN_HISTORY_VERSIONS};
 pub use error::{LargeSmtForestError, Result};
-pub use operation::{ForestOperation, SmtForestUpdateBatch, SmtUpdateBatch};
+pub use operation::{SmtForestOperation, SmtForestUpdateBatch, SmtUpdateBatch};
 pub use root::{LineageId, RootInfo, TreeEntry, TreeId, TreeWithRoot, VersionId};
-pub use utils::{AppliedLineageMutation, ForestMutationSet, LineageMutation, LineageMutationKind};
+pub use utils::{
+    AppliedLineageMutation, LineageMutation, LineageMutationKind, SmtForestMutationSet,
+};
 
 use crate::{
     EMPTY_WORD, Map, Set, Word,
@@ -833,7 +835,7 @@ impl<B: Backend> LargeSmtForest<B> {
         lineage: LineageId,
         new_version: VersionId,
         updates: SmtUpdateBatch,
-    ) -> Result<ForestMutationSet<B>> {
+    ) -> Result<SmtForestMutationSet<B>> {
         if let Some(lineage_data) = self.lineage_data.get(&lineage)
             && lineage_data.latest_version >= new_version
         {
@@ -846,7 +848,7 @@ impl<B: Backend> LargeSmtForest<B> {
         let mut batch = SmtForestUpdateBatch::empty();
         batch.operations(lineage).add_operations(updates.into_iter());
         let (entries, prepared) = self.backend.compute_mutations(new_version, batch)?;
-        Ok(ForestMutationSet::new(entries, prepared))
+        Ok(SmtForestMutationSet::new(entries, prepared))
     }
 
     /// Computes the mutations required to add a new `lineage`, without applying them.
@@ -855,7 +857,7 @@ impl<B: Backend> LargeSmtForest<B> {
         lineage: LineageId,
         new_version: VersionId,
         updates: SmtUpdateBatch,
-    ) -> Result<ForestMutationSet<B>> {
+    ) -> Result<SmtForestMutationSet<B>> {
         if self.lineage_data.contains_key(&lineage) {
             return Err(LargeSmtForestError::DuplicateLineage(lineage));
         }
@@ -898,7 +900,7 @@ impl<B: Backend> LargeSmtForest<B> {
         lineage: LineageId,
         new_version: VersionId,
         updates: SmtUpdateBatch,
-    ) -> Result<ForestMutationSet<B>> {
+    ) -> Result<SmtForestMutationSet<B>> {
         let Some(lineage_data) = self.lineage_data.get(&lineage) else {
             return Err(LargeSmtForestError::UnknownLineage(lineage));
         };
@@ -1058,7 +1060,7 @@ impl<B: Backend> LargeSmtForest<B> {
         &self,
         version: VersionId,
         lineages: SmtForestUpdateBatch,
-    ) -> Result<ForestMutationSet<B>> {
+    ) -> Result<SmtForestMutationSet<B>> {
         for lineage in lineages.lineages() {
             if self.lineage_data.contains_key(lineage) {
                 return Err(LargeSmtForestError::DuplicateLineage(*lineage));
@@ -1066,7 +1068,7 @@ impl<B: Backend> LargeSmtForest<B> {
         }
 
         let (entries, prepared) = self.backend.compute_mutations(version, lineages)?;
-        Ok(ForestMutationSet::new(entries, prepared))
+        Ok(SmtForestMutationSet::new(entries, prepared))
     }
 
     /// Computes mutations that would add or update multiple lineages without applying them.
@@ -1077,7 +1079,7 @@ impl<B: Backend> LargeSmtForest<B> {
         &self,
         new_version: VersionId,
         updates: SmtForestUpdateBatch,
-    ) -> Result<ForestMutationSet<B>> {
+    ) -> Result<SmtForestMutationSet<B>> {
         updates
             .lineages()
             .map(|lineage| {
@@ -1097,7 +1099,7 @@ impl<B: Backend> LargeSmtForest<B> {
             .collect::<Result<Vec<_>>>()?;
 
         let (entries, prepared) = self.backend.compute_mutations(new_version, updates)?;
-        Ok(ForestMutationSet::new(entries, prepared))
+        Ok(SmtForestMutationSet::new(entries, prepared))
     }
 
     /// Performs the provided `updates` on the forest, adding at most one new root with version
@@ -1165,7 +1167,7 @@ impl<B: Backend> LargeSmtForest<B> {
         &self,
         new_version: VersionId,
         updates: SmtForestUpdateBatch,
-    ) -> Result<ForestMutationSet<B>> {
+    ) -> Result<SmtForestMutationSet<B>> {
         updates
             .lineages()
             .map(|lineage| {
@@ -1223,7 +1225,7 @@ impl<B: Backend> LargeSmtForest<B> {
     /// - [`LargeSmtForestError::Fatal`] if the backend fails while applying its prepared data.
     pub fn apply_mutations(
         &mut self,
-        mutations: ForestMutationSet<B>,
+        mutations: SmtForestMutationSet<B>,
     ) -> Result<Vec<TreeWithRoot>> {
         let (entries, prepared) = mutations.into_parts();
 

--- a/miden-crypto/src/merkle/smt/large_forest/mod.rs
+++ b/miden-crypto/src/merkle/smt/large_forest/mod.rs
@@ -803,7 +803,7 @@ impl<B: BackendReader> LargeSmtForest<B> {
 /// Where anything more specific can be said about performance, the method documentation will
 /// contain more detail.
 impl<B: Backend> LargeSmtForest<B> {
-    /// Computes the mutations required to add a new `lineage`, without applying them.
+    /// Computes the mutations required to mutate one lineage, without applying them.
     ///
     /// This is the first phase of [`Self::add_lineage`]. It creates a [`ForestMutationSet`] that
     /// contains the proposed root commitment for the new lineage and backend-specific prepared
@@ -828,6 +828,28 @@ impl<B: Backend> LargeSmtForest<B> {
     /// The returned mutation set is valid only for the forest state against which it was computed.
     /// Passing it to [`Self::apply_mutations`] after the same lineage has been added by another
     /// operation will return an error.
+    pub fn compute_tree_mutations(
+        &self,
+        lineage: LineageId,
+        new_version: VersionId,
+        updates: SmtUpdateBatch,
+    ) -> Result<ForestMutationSet<B>> {
+        if let Some(lineage_data) = self.lineage_data.get(&lineage)
+            && lineage_data.latest_version >= new_version
+        {
+            return Err(LargeSmtForestError::BadVersion {
+                provided: new_version,
+                latest: lineage_data.latest_version,
+            });
+        }
+
+        let mut batch = SmtForestUpdateBatch::empty();
+        batch.operations(lineage).add_operations(updates.into_iter());
+        let (entries, prepared) = self.backend.compute_mutations(new_version, batch)?;
+        Ok(ForestMutationSet::new(entries, prepared))
+    }
+
+    /// Computes the mutations required to add a new `lineage`, without applying them.
     pub fn compute_add_lineage_mutations(
         &self,
         lineage: LineageId,
@@ -838,9 +860,7 @@ impl<B: Backend> LargeSmtForest<B> {
             return Err(LargeSmtForestError::DuplicateLineage(lineage));
         }
 
-        let (entries, prepared) =
-            self.backend.compute_add_lineage_mutations(lineage, new_version, updates)?;
-        Ok(ForestMutationSet::new(entries, prepared))
+        self.compute_tree_mutations(lineage, new_version, updates)
     }
 
     /// Computes the mutations required to update the latest tree in `lineage`, without applying
@@ -890,9 +910,7 @@ impl<B: Backend> LargeSmtForest<B> {
             });
         }
 
-        let (entries, prepared) =
-            self.backend.compute_update_tree_mutations(lineage, new_version, updates)?;
-        Ok(ForestMutationSet::new(entries, prepared))
+        self.compute_tree_mutations(lineage, new_version, updates)
     }
 
     /// Adds a new `lineage` to the forest, creating an empty tree and modifying it as specified by
@@ -1047,7 +1065,38 @@ impl<B: Backend> LargeSmtForest<B> {
             }
         }
 
-        let (entries, prepared) = self.backend.compute_add_lineages_mutations(version, lineages)?;
+        let (entries, prepared) = self.backend.compute_mutations(version, lineages)?;
+        Ok(ForestMutationSet::new(entries, prepared))
+    }
+
+    /// Computes mutations that would add or update multiple lineages without applying them.
+    ///
+    /// Lineages that are already present are updated, while unknown lineages are added from the
+    /// empty tree.
+    pub fn compute_forest_mutations(
+        &self,
+        new_version: VersionId,
+        updates: SmtForestUpdateBatch,
+    ) -> Result<ForestMutationSet<B>> {
+        updates
+            .lineages()
+            .map(|lineage| {
+                let Some(lineage_data) = self.lineage_data.get(lineage) else {
+                    return Ok(());
+                };
+
+                if lineage_data.latest_version < new_version {
+                    Ok(())
+                } else {
+                    Err(LargeSmtForestError::BadVersion {
+                        provided: new_version,
+                        latest: lineage_data.latest_version,
+                    })
+                }
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        let (entries, prepared) = self.backend.compute_mutations(new_version, updates)?;
         Ok(ForestMutationSet::new(entries, prepared))
     }
 
@@ -1135,9 +1184,7 @@ impl<B: Backend> LargeSmtForest<B> {
             })
             .collect::<Result<Vec<_>>>()?;
 
-        let (entries, prepared) =
-            self.backend.compute_update_forest_mutations(new_version, updates)?;
-        Ok(ForestMutationSet::new(entries, prepared))
+        self.compute_forest_mutations(new_version, updates)
     }
 
     /// Applies mutations previously computed by one of the forest compute methods.

--- a/miden-crypto/src/merkle/smt/large_forest/mod.rs
+++ b/miden-crypto/src/merkle/smt/large_forest/mod.rs
@@ -805,123 +805,13 @@ impl<B: BackendReader> LargeSmtForest<B> {
 /// Where anything more specific can be said about performance, the method documentation will
 /// contain more detail.
 impl<B: Backend> LargeSmtForest<B> {
-    /// Computes the mutations required to mutate one lineage, without applying them.
-    ///
-    /// This is the first phase of [`Self::add_lineage`]. It creates a [`ForestMutationSet`] that
-    /// contains the proposed root commitment for the new lineage and backend-specific prepared
-    /// data that can later be committed with [`Self::apply_mutations`].
-    ///
-    /// The forest and backend are not modified by this method. Callers can inspect the returned
-    /// mutation set, especially via [`ForestMutationSet::roots`] or
-    /// [`ForestMutationSet::lineage_mutations`], before deciding whether to commit it.
-    ///
-    /// If the provided `updates` batch is empty, the returned mutation set still represents adding
-    /// the empty tree as the first version of the lineage.
-    ///
-    /// # Errors
-    ///
-    /// - [`LargeSmtForestError::DuplicateLineage`] if `lineage` is already known by the forest.
-    /// - [`LargeSmtForestError::Fatal`] if the backend fails while computing prepared data.
-    /// - [`LargeSmtForestError::Merkle`] if the provided `updates` cannot be applied to the empty
-    ///   tree.
-    ///
-    /// # Applying the Result
-    ///
-    /// The returned mutation set is valid only for the forest state against which it was computed.
-    /// Passing it to [`Self::apply_mutations`] after the same lineage has been added by another
-    /// operation will return an error.
-    pub fn compute_tree_mutations(
-        &self,
-        lineage: LineageId,
-        new_version: VersionId,
-        updates: SmtUpdateBatch,
-    ) -> Result<SmtForestMutationSet<B>> {
-        if let Some(lineage_data) = self.lineage_data.get(&lineage)
-            && lineage_data.latest_version >= new_version
-        {
-            return Err(LargeSmtForestError::BadVersion {
-                provided: new_version,
-                latest: lineage_data.latest_version,
-            });
-        }
-
-        let mut batch = SmtForestUpdateBatch::empty();
-        batch.operations(lineage).add_operations(updates.into_iter());
-        let (entries, prepared) = self.backend.compute_mutations(new_version, batch)?;
-        Ok(SmtForestMutationSet::new(entries, prepared))
-    }
-
-    /// Computes the mutations required to add a new `lineage`, without applying them.
-    pub fn compute_add_lineage_mutations(
-        &self,
-        lineage: LineageId,
-        new_version: VersionId,
-        updates: SmtUpdateBatch,
-    ) -> Result<SmtForestMutationSet<B>> {
-        if self.lineage_data.contains_key(&lineage) {
-            return Err(LargeSmtForestError::DuplicateLineage(lineage));
-        }
-
-        self.compute_tree_mutations(lineage, new_version, updates)
-    }
-
-    /// Computes the mutations required to update the latest tree in `lineage`, without applying
-    /// them.
-    ///
-    /// This is the first phase of [`Self::update_tree`]. It computes the proposed new root for the
-    /// lineage and the backend-specific data needed to commit the update later via
-    /// [`Self::apply_mutations`]. Reverse mutations needed for history are returned by the backend
-    /// during the apply phase.
-    ///
-    /// The forest and backend are not modified by this method. Callers can inspect the returned
-    /// mutation set before committing it, which is useful when root commitments must be published,
-    /// checked, or combined with other data before the backend write occurs.
-    ///
-    /// If applying `updates` would not change the tree, the returned mutation set represents a
-    /// no-op. Applying it will not advance the lineage version or allocate a new tree version, and
-    /// [`ForestMutationSet::roots`] will report the current latest version/root.
-    ///
-    /// # Errors
-    ///
-    /// - [`LargeSmtForestError::UnknownLineage`] if `lineage` is not known by the forest.
-    /// - [`LargeSmtForestError::BadVersion`] if `new_version` is not newer than the latest version
-    ///   for `lineage`.
-    /// - [`LargeSmtForestError::Fatal`] if the backend fails while computing prepared data.
-    /// - [`LargeSmtForestError::Merkle`] if the provided `updates` cannot be applied to the latest
-    ///   tree.
-    ///
-    /// # Applying the Result
-    ///
-    /// The returned mutation set is valid only while the lineage remains at the same latest
-    /// version and root. [`Self::apply_mutations`] rejects stale mutation sets if the lineage has
-    /// changed since this method was called.
-    pub fn compute_update_tree_mutations(
-        &self,
-        lineage: LineageId,
-        new_version: VersionId,
-        updates: SmtUpdateBatch,
-    ) -> Result<SmtForestMutationSet<B>> {
-        let Some(lineage_data) = self.lineage_data.get(&lineage) else {
-            return Err(LargeSmtForestError::UnknownLineage(lineage));
-        };
-
-        if lineage_data.latest_version >= new_version {
-            return Err(LargeSmtForestError::BadVersion {
-                provided: new_version,
-                latest: lineage_data.latest_version,
-            });
-        }
-
-        self.compute_tree_mutations(lineage, new_version, updates)
-    }
-
     /// Adds a new `lineage` to the forest, creating an empty tree and modifying it as specified by
     /// `updates`, with the result taking the provided `new_version`.
     ///
-    /// This is the one-phase convenience API. It is equivalent to calling
-    /// [`Self::compute_add_lineage_mutations`] followed immediately by [`Self::apply_mutations`].
-    /// Use the two-phase API directly when the proposed root commitment must be inspected before
-    /// committing the backend changes.
+    /// This is the one-phase convenience API. It is equivalent to ensuring that the lineage
+    /// does not exist and then calling [`Self::compute_tree_mutations`] followed immediately
+    /// by [`Self::apply_mutations`]. Use the two-phase API directly when the proposed root
+    /// commitment must be inspected before committing the backend changes.
     ///
     /// If the provided `updates` batch is empty, then the **empty tree will be added** as the first
     /// version in the lineage.
@@ -945,12 +835,52 @@ impl<B: Backend> LargeSmtForest<B> {
         Ok(roots.pop().expect("single lineage mutation returns one root"))
     }
 
+    /// Computes the mutations required to add a new `lineage`, without applying them.
+    ///
+    /// This is the first phase of [`Self::add_lineage`]. It computes the proposed new root for the
+    /// lineage and the backend-specific data needed to commit the update later via
+    /// [`Self::apply_mutations`]. Reverse mutations needed for history are returned by the backend
+    /// during the apply phase.
+    ///
+    /// The forest and backend are not modified by this method. Callers can inspect the returned
+    /// mutation set before committing it, which is useful when root commitments must be published,
+    /// checked, or combined with other data before the backend write occurs.
+    ///
+    /// If the provided `updates` batch is empty, then the **empty tree will be added** as the first
+    /// version in the lineage.
+    ///
+    /// # Errors
+    ///
+    /// - [`LargeSmtForestError::DuplicateLineage`] if the provided `lineage` is the same as an
+    ///   already-known lineage.
+    /// - [`LargeSmtForestError::Fatal`] if the backend fails while computing the mutation.
+    /// - [`LargeSmtForestError::Merkle`] if the provided `updates` cannot be applied to the empty
+    ///   tree.
+    ///
+    /// # Applying the Result
+    ///
+    /// The returned mutation set is valid only while the lineage remains at the same latest
+    /// version and root. [`Self::apply_mutations`] rejects stale mutation sets if the lineage has
+    /// changed since this method was called.
+    fn compute_add_lineage_mutations(
+        &self,
+        lineage: LineageId,
+        new_version: VersionId,
+        updates: SmtUpdateBatch,
+    ) -> Result<SmtForestMutationSet<B>> {
+        if self.lineage_data.contains_key(&lineage) {
+            return Err(LargeSmtForestError::DuplicateLineage(lineage));
+        }
+
+        self.compute_tree_mutations(lineage, new_version, updates)
+    }
+
     /// Performs the provided `updates` on the latest tree in the specified `lineage`, adding a
     /// single new root to the forest (corresponding to `new_version`) for the entire batch, and
     /// returning the data for the new root of the tree.
     ///
-    /// This is the one-phase convenience API. It is equivalent to calling
-    /// [`Self::compute_update_tree_mutations`] followed immediately by
+    /// This is the one-phase convenience API. It is equivalent to ensuring that the lineage exists
+    /// then calling [`Self::compute_tree_mutations`] followed immediately by
     /// [`Self::apply_mutations`]. Use the two-phase API directly when the proposed root commitment
     /// must be inspected before committing the backend changes.
     ///
@@ -977,6 +907,101 @@ impl<B: Backend> LargeSmtForest<B> {
         let mut roots = self.apply_mutations(mutations)?;
         Ok(roots.pop().expect("single lineage mutation returns one root"))
     }
+
+    /// Computes the mutations required to update the latest tree in `lineage`, without applying
+    /// them.
+    ///
+    /// This is the first phase of [`Self::update_tree`]. It computes the proposed new root for the
+    /// lineage and the backend-specific data needed to commit the update later via
+    /// [`Self::apply_mutations`]. Reverse mutations needed for history are returned by the backend
+    /// during the apply phase.
+    ///
+    /// The forest and backend are not modified by this method. Callers can inspect the returned
+    /// mutation set before committing it, which is useful when root commitments must be published,
+    /// checked, or combined with other data before the backend write occurs.
+    ///
+    /// If applying `updates` would not change the tree, the returned mutation set represents a
+    /// no-op. Applying it will not advance the lineage version or allocate a new tree version, and
+    /// [`SmtForestMutationSet::roots`] will report the current latest version/root.
+    ///
+    /// # Errors
+    ///
+    /// - [`LargeSmtForestError::UnknownLineage`] if `lineage` is not known by the forest.
+    /// - [`LargeSmtForestError::BadVersion`] if `new_version` is not newer than the latest version
+    ///   for `lineage`.
+    /// - [`LargeSmtForestError::Fatal`] if the backend fails while computing prepared data.
+    /// - [`LargeSmtForestError::Merkle`] if the provided `updates` cannot be applied to the latest
+    ///   tree.
+    ///
+    /// # Applying the Result
+    ///
+    /// The returned mutation set is valid only while the lineage remains at the same latest
+    /// version and root. [`Self::apply_mutations`] rejects stale mutation sets if the lineage has
+    /// changed since this method was called.
+    fn compute_update_tree_mutations(
+        &self,
+        lineage: LineageId,
+        new_version: VersionId,
+        updates: SmtUpdateBatch,
+    ) -> Result<SmtForestMutationSet<B>> {
+        let Some(lineage_data) = self.lineage_data.get(&lineage) else {
+            return Err(LargeSmtForestError::UnknownLineage(lineage));
+        };
+
+        if lineage_data.latest_version >= new_version {
+            return Err(LargeSmtForestError::BadVersion {
+                provided: new_version,
+                latest: lineage_data.latest_version,
+            });
+        }
+
+        self.compute_tree_mutations(lineage, new_version, updates)
+    }
+
+    /// Computes the mutations required to mutate one lineage, without applying them.
+    ///
+    /// If the lineage is already present it is updated, while unknown lineages are added from the
+    /// empty tree.
+    ///
+    /// The forest and backend are not modified by this method. Callers can inspect the returned
+    /// mutation set, especially via [`SmtForestMutationSet::roots`] or
+    /// [`SmtForestMutationSet::lineage_mutations`], before deciding whether to commit it.
+    ///
+    /// If the provided `updates` batch is empty, the returned mutation set still represents adding
+    /// the empty tree as the first version of the lineage.
+    ///
+    /// # Errors
+    ///
+    /// - [`LargeSmtForestError::DuplicateLineage`] if `lineage` is already known by the forest.
+    /// - [`LargeSmtForestError::Fatal`] if the backend fails while computing prepared data.
+    /// - [`LargeSmtForestError::Merkle`] if the provided `updates` cannot be applied to the empty
+    ///   tree.
+    ///
+    /// # Applying the Result
+    ///
+    /// The returned mutation set is valid only for the forest state against which it was computed.
+    /// [`Self::apply_mutations`] rejects stale mutation sets if the lineage has changed since this
+    /// method was called.
+    pub fn compute_tree_mutations(
+        &self,
+        lineage: LineageId,
+        new_version: VersionId,
+        updates: SmtUpdateBatch,
+    ) -> Result<SmtForestMutationSet<B>> {
+        if let Some(lineage_data) = self.lineage_data.get(&lineage)
+            && lineage_data.latest_version >= new_version
+        {
+            return Err(LargeSmtForestError::BadVersion {
+                provided: new_version,
+                latest: lineage_data.latest_version,
+            });
+        }
+
+        let mut batch = SmtForestUpdateBatch::empty();
+        batch.operations(lineage).add_operations(updates.into_iter());
+        let (entries, prepared) = self.backend.compute_mutations(new_version, batch)?;
+        Ok(SmtForestMutationSet::new(entries, prepared))
+    }
 }
 
 // MULTI-TREE MODIFIERS
@@ -997,9 +1022,9 @@ impl<B: Backend> LargeSmtForest<B> {
     /// Adds multiple new `lineages` to the forest, creating an empty tree for each and applying the
     /// provided modifications to it, with the result being given the specified `version`.
     ///
-    /// This is the one-phase convenience API. It is equivalent to calling
-    /// [`Self::compute_add_lineages_mutations`] followed immediately by
-    /// [`Self::apply_mutations`]. Use the two-phase API directly when the proposed root
+    /// This is the one-phase convenience API. It is equivalent to make sure that none of the
+    /// lineages exists and then calling [`Self::compute_forest_mutations`] followed immediately
+    /// by [`Self::apply_mutations`]. Use the two-phase API directly when the proposed root
     /// commitments must be inspected before committing the backend changes.
     ///
     /// If the provided batch of modifications is empty for any given lineage, then the **empty tree
@@ -1012,7 +1037,7 @@ impl<B: Backend> LargeSmtForest<B> {
     /// [`Self::add_lineage`] in a loop, but in some cases it may be significantly more performant.
     ///
     /// The exact scope of any speed-up is determined by the backend in use, so it is worth reading
-    /// the documentation for the backend's [`Backend::compute_add_lineages_mutations`] method.
+    /// the documentation for the backend's [`Backend::compute_mutations`] method.
     ///
     /// # Errors
     ///
@@ -1033,7 +1058,7 @@ impl<B: Backend> LargeSmtForest<B> {
 
     /// Computes mutations that would add multiple new lineages without applying them.
     ///
-    /// This is the first phase of [`Self::add_lineages`]. It returns a [`ForestMutationSet`]
+    /// This is the first phase of [`Self::add_lineages`]. It returns a [`SmtForestMutationSet`]
     /// containing one proposed result per lineage in `lineages`, plus backend-specific prepared
     /// data that can later be committed with [`Self::apply_mutations`].
     ///
@@ -1056,7 +1081,7 @@ impl<B: Backend> LargeSmtForest<B> {
     /// - [`LargeSmtForestError::Fatal`] if the backend fails while computing prepared data.
     /// - [`LargeSmtForestError::Merkle`] if any provided updates cannot be applied to an empty
     ///   tree.
-    pub fn compute_add_lineages_mutations(
+    fn compute_add_lineages_mutations(
         &self,
         version: VersionId,
         lineages: SmtForestUpdateBatch,
@@ -1071,42 +1096,11 @@ impl<B: Backend> LargeSmtForest<B> {
         Ok(SmtForestMutationSet::new(entries, prepared))
     }
 
-    /// Computes mutations that would add or update multiple lineages without applying them.
-    ///
-    /// Lineages that are already present are updated, while unknown lineages are added from the
-    /// empty tree.
-    pub fn compute_forest_mutations(
-        &self,
-        new_version: VersionId,
-        updates: SmtForestUpdateBatch,
-    ) -> Result<SmtForestMutationSet<B>> {
-        updates
-            .lineages()
-            .map(|lineage| {
-                let Some(lineage_data) = self.lineage_data.get(lineage) else {
-                    return Ok(());
-                };
-
-                if lineage_data.latest_version < new_version {
-                    Ok(())
-                } else {
-                    Err(LargeSmtForestError::BadVersion {
-                        provided: new_version,
-                        latest: lineage_data.latest_version,
-                    })
-                }
-            })
-            .collect::<Result<Vec<_>>>()?;
-
-        let (entries, prepared) = self.backend.compute_mutations(new_version, updates)?;
-        Ok(SmtForestMutationSet::new(entries, prepared))
-    }
-
     /// Performs the provided `updates` on the forest, adding at most one new root with version
     /// `new_version` for each targeted lineage and returning the resulting root data.
     ///
-    /// This is the one-phase convenience API. It is equivalent to calling
-    /// [`Self::compute_update_forest_mutations`] followed immediately by
+    /// This is the one-phase convenience API. It is equivalent to checking that all of the lineages
+    /// exist then calling [`Self::compute_forest_mutations`] followed immediately by
     /// [`Self::apply_mutations`]. Use the two-phase API directly when the proposed root
     /// commitments must be inspected before committing the backend changes.
     ///
@@ -1135,7 +1129,7 @@ impl<B: Backend> LargeSmtForest<B> {
 
     /// Computes mutations that would update multiple existing lineages without applying them.
     ///
-    /// This is the first phase of [`Self::update_forest`]. It returns a [`ForestMutationSet`]
+    /// This is the first phase of [`Self::update_forest`]. It returns an [`SmtForestMutationSet`]
     /// containing one proposed result per lineage in `updates`, plus backend-specific prepared data
     /// that can later be committed with [`Self::apply_mutations`].
     ///
@@ -1163,7 +1157,7 @@ impl<B: Backend> LargeSmtForest<B> {
     /// - [`LargeSmtForestError::Fatal`] if the backend fails while computing prepared data.
     /// - [`LargeSmtForestError::Merkle`] if any provided updates cannot be applied to the relevant
     ///   latest tree.
-    pub fn compute_update_forest_mutations(
+    fn compute_update_forest_mutations(
         &self,
         new_version: VersionId,
         updates: SmtForestUpdateBatch,
@@ -1189,15 +1183,68 @@ impl<B: Backend> LargeSmtForest<B> {
         self.compute_forest_mutations(new_version, updates)
     }
 
+    /// Computes mutations that would add or update multiple lineages without applying them.
+    ///
+    /// Lineages that are already present are updated, while unknown lineages are added from the
+    /// empty tree.
+    ///
+    /// The forest and backend are not modified by this method. Callers can inspect all proposed
+    /// root commitments before committing the batch. This is useful when the forest update is only
+    /// one part of a larger transaction or when root commitments must be signed, checked, or stored
+    /// elsewhere before the backend write occurs.
+    ///
+    /// If a per-lineage update would not change the tree, the corresponding mutation is a no-op.
+    /// Applying the mutation set will not advance that lineage's version or allocate a new tree
+    /// version for it.
+    ///
+    /// # Performance
+    ///
+    /// Backends may compute the per-lineage mutations in parallel and may prepare a batched apply
+    /// representation. This method should generally be preferred over repeated
+    /// [`Self::compute_tree_mutations`] calls when updating multiple lineages.
+    ///
+    /// # Errors
+    ///
+    /// - [`LargeSmtForestError::Fatal`] if the backend fails while computing or applying the
+    ///   mutations.
+    /// - [`LargeSmtForestError::BadVersion`] if `new_version` is not newer than the latest version
+    ///   for any targeted lineage that is already present.
+    /// - [`LargeSmtForestError::Merkle`] if any provided updates cannot be applied to the relevant
+    ///   latest tree.
+    pub fn compute_forest_mutations(
+        &self,
+        new_version: VersionId,
+        updates: SmtForestUpdateBatch,
+    ) -> Result<SmtForestMutationSet<B>> {
+        updates
+            .lineages()
+            .map(|lineage| {
+                let Some(lineage_data) = self.lineage_data.get(lineage) else {
+                    return Ok(());
+                };
+
+                if lineage_data.latest_version < new_version {
+                    Ok(())
+                } else {
+                    Err(LargeSmtForestError::BadVersion {
+                        provided: new_version,
+                        latest: lineage_data.latest_version,
+                    })
+                }
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        let (entries, prepared) = self.backend.compute_mutations(new_version, updates)?;
+        Ok(SmtForestMutationSet::new(entries, prepared))
+    }
+
     /// Applies mutations previously computed by one of the forest compute methods.
     ///
-    /// This is the second phase of the two-phase update API. It consumes a [`ForestMutationSet`]
-    /// returned by one of:
+    /// This is the second phase of the two-phase update API. It consumes an
+    /// [`SmtForestMutationSet`] returned by one of:
     ///
-    /// - [`Self::compute_add_lineage_mutations`],
-    /// - [`Self::compute_update_tree_mutations`],
-    /// - [`Self::compute_add_lineages_mutations`], or
-    /// - [`Self::compute_update_forest_mutations`].
+    /// - [`Self::compute_tree_mutations`], or
+    /// - [`Self::compute_forest_mutations`].
     ///
     /// The backend validates that the mutation set is still applicable before committing anything.
     /// For update mutations, the latest version and root of every affected lineage must still match
@@ -1209,7 +1256,7 @@ impl<B: Backend> LargeSmtForest<B> {
     /// after the backend apply succeeds does the forest update its in-memory lineage metadata and
     /// history. This ordering keeps the forest consistent if the backend reports an error.
     ///
-    /// The returned roots match [`ForestMutationSet::roots`] for the applied mutation set. No-op
+    /// The returned roots match [`SmtForestMutationSet::roots`] for the applied mutation set. No-op
     /// update mutations return the existing latest version/root for their lineages.
     ///
     /// # Errors

--- a/miden-crypto/src/merkle/smt/large_forest/operation.rs
+++ b/miden-crypto/src/merkle/smt/large_forest/operation.rs
@@ -12,7 +12,7 @@ use crate::{EMPTY_WORD, Map, Set, Word, merkle::smt::large_forest::root::Lineage
 
 /// The operations that can be performed on an arbitrary leaf in a tree in a forest.
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub enum ForestOperation {
+pub enum SmtForestOperation {
     /// An insertion of `value` under `key` into the tree.
     ///
     /// If `key` already exists in the tree, the associated value will be replaced with `value`
@@ -22,7 +22,7 @@ pub enum ForestOperation {
     /// The removal of the `key` and its associated value from the tree.
     Remove { key: Word },
 }
-impl ForestOperation {
+impl SmtForestOperation {
     /// Insert the provided `value` into a tree under the provided `key`.
     pub fn insert(key: Word, value: Word) -> Self {
         Self::Insert { key, value }
@@ -36,17 +36,17 @@ impl ForestOperation {
     /// Retrieves the key from the operation.
     pub fn key(&self) -> Word {
         match self {
-            ForestOperation::Insert { key, .. } => *key,
-            ForestOperation::Remove { key } => *key,
+            SmtForestOperation::Insert { key, .. } => *key,
+            SmtForestOperation::Remove { key } => *key,
         }
     }
 }
 
-impl From<ForestOperation> for (Word, Word) {
-    fn from(value: ForestOperation) -> Self {
+impl From<SmtForestOperation> for (Word, Word) {
+    fn from(value: SmtForestOperation) -> Self {
         match value {
-            ForestOperation::Insert { key, value } => (key, value),
-            ForestOperation::Remove { key } => (key, EMPTY_WORD),
+            SmtForestOperation::Insert { key, value } => (key, value),
+            SmtForestOperation::Remove { key } => (key, EMPTY_WORD),
         }
     }
 }
@@ -58,7 +58,7 @@ impl From<ForestOperation> for (Word, Word) {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct SmtUpdateBatch {
     /// The operations to be performed on a tree.
-    operations: Vec<ForestOperation>,
+    operations: Vec<SmtForestOperation>,
 }
 impl SmtUpdateBatch {
     /// Creates an empty batch of operations.
@@ -67,33 +67,33 @@ impl SmtUpdateBatch {
     }
 
     /// Creates a batch containing the provided `operations`.
-    pub fn new(operations: impl Iterator<Item = ForestOperation>) -> Self {
+    pub fn new(operations: impl Iterator<Item = SmtForestOperation>) -> Self {
         Self {
             operations: operations.collect::<Vec<_>>(),
         }
     }
 
     /// Adds the provided `operations` to the batch.
-    pub fn add_operations(&mut self, operations: impl Iterator<Item = ForestOperation>) {
+    pub fn add_operations(&mut self, operations: impl Iterator<Item = SmtForestOperation>) {
         self.operations.extend(operations);
     }
 
     /// Adds the [`ForestOperation::Insert`] operation for the provided `key` and `value` pair to
     /// the batch.
     pub fn add_insert(&mut self, key: Word, value: Word) {
-        self.operations.push(ForestOperation::insert(key, value));
+        self.operations.push(SmtForestOperation::insert(key, value));
     }
 
     /// Adds the [`ForestOperation::Remove`] operation for the provided `key` to the batch.
     pub fn add_remove(&mut self, key: Word) {
-        self.operations.push(ForestOperation::remove(key));
+        self.operations.push(SmtForestOperation::remove(key));
     }
 
     /// Consumes the batch as a vector of operations, containing the last operation for any given
     /// `key` in the case that multiple operations per key are encountered.
     ///
     /// This vector is guaranteed to be sorted by the key on which an operation is performed.
-    pub fn consume(self) -> Vec<ForestOperation> {
+    pub fn consume(self) -> Vec<SmtForestOperation> {
         // As we want to keep the LAST operation for each key, rather than the first, we filter in
         // reverse.
         let mut seen_keys: Set<Word> = Set::new();
@@ -103,13 +103,13 @@ impl SmtUpdateBatch {
             .rev()
             .filter(|o| seen_keys.insert(o.key()))
             .collect::<Vec<_>>();
-        ops.sort_by_key(ForestOperation::key);
+        ops.sort_by_key(SmtForestOperation::key);
         ops
     }
 }
 
 impl IntoIterator for SmtUpdateBatch {
-    type Item = ForestOperation;
+    type Item = SmtForestOperation;
     type IntoIter = alloc::vec::IntoIter<Self::Item>;
 
     /// Consumes the batch as an iterator yielding operations while respecting the guarantees given
@@ -127,8 +127,8 @@ impl From<SmtUpdateBatch> for Vec<(Word, Word)> {
             .consume()
             .into_iter()
             .map(|op| match op {
-                ForestOperation::Insert { key, value } => (key, value),
-                ForestOperation::Remove { key } => (key, EMPTY_WORD),
+                SmtForestOperation::Insert { key, value } => (key, value),
+                SmtForestOperation::Remove { key } => (key, EMPTY_WORD),
             })
             .collect()
     }
@@ -141,9 +141,9 @@ where
     fn from(value: I) -> Self {
         Self::new(value.map(|(k, v)| {
             if v.is_empty() {
-                ForestOperation::Remove { key: k }
+                SmtForestOperation::Remove { key: k }
             } else {
-                ForestOperation::Insert { key: k, value: v }
+                SmtForestOperation::Insert { key: k, value: v }
             }
         }))
     }
@@ -176,7 +176,7 @@ impl SmtForestUpdateBatch {
     pub fn add_operations(
         &mut self,
         lineage: LineageId,
-        operations: impl Iterator<Item = ForestOperation>,
+        operations: impl Iterator<Item = SmtForestOperation>,
     ) {
         let batch = self.operations.entry(lineage).or_insert_with(SmtUpdateBatch::empty);
         batch.add_operations(operations);
@@ -198,14 +198,14 @@ impl SmtForestUpdateBatch {
 
     /// Consumes the batch as a map of batches, with each individual batch guaranteed to be in
     /// sorted order and contain only the last operation in the batch for any given key.
-    pub fn consume(self) -> Map<LineageId, Vec<ForestOperation>> {
+    pub fn consume(self) -> Map<LineageId, Vec<SmtForestOperation>> {
         self.operations.into_iter().map(|(k, v)| (k, v.consume())).collect()
     }
 }
 
 impl IntoIterator for SmtForestUpdateBatch {
-    type Item = (LineageId, Vec<ForestOperation>);
-    type IntoIter = crate::MapIntoIter<LineageId, Vec<ForestOperation>>;
+    type Item = (LineageId, Vec<SmtForestOperation>);
+    type IntoIter = crate::MapIntoIter<LineageId, Vec<SmtForestOperation>>;
 
     /// Consumes the batch as an iterator yielding pairs of `(lineage, operations)` while respecting
     /// the guarantees given by [`Self::consume`].
@@ -240,9 +240,9 @@ mod test {
         let o3_key: Word = rng.value();
         let o3_value: Word = rng.value();
 
-        let o1 = ForestOperation::insert(o1_key, o1_value);
-        let o2 = ForestOperation::remove(o2_key);
-        let o3 = ForestOperation::insert(o3_key, o3_value);
+        let o1 = SmtForestOperation::insert(o1_key, o1_value);
+        let o2 = SmtForestOperation::remove(o2_key);
+        let o3 = SmtForestOperation::insert(o3_key, o3_value);
 
         // ... and stick them in the batch in various ways
         batch.add_operations(vec![o1.clone()].into_iter());
@@ -254,7 +254,7 @@ mod test {
 
         // If we then consume the batch, we should have the operations ordered by their key.
         let ops = batch.consume();
-        assert!(ops.is_sorted_by_key(ForestOperation::key));
+        assert!(ops.is_sorted_by_key(SmtForestOperation::key));
 
         // Let's now make two additional operations with keys that overlay with keys from the first
         // three...
@@ -262,8 +262,8 @@ mod test {
         let o4_value: Word = rng.value();
         let o5_key = o1_key;
 
-        let o4 = ForestOperation::insert(o4_key, o4_value);
-        let o5 = ForestOperation::remove(o5_key);
+        let o4 = SmtForestOperation::insert(o4_key, o4_value);
+        let o5 = SmtForestOperation::remove(o5_key);
 
         // ... and also stick them into the batch.
         let mut batch = batch_tmp;
@@ -274,7 +274,7 @@ mod test {
         let ops = batch.consume();
 
         assert_eq!(ops.len(), 3);
-        assert!(ops.is_sorted_by_key(ForestOperation::key));
+        assert!(ops.is_sorted_by_key(SmtForestOperation::key));
 
         assert!(ops.contains(&o3));
         assert!(ops.contains(&o4));
@@ -292,14 +292,14 @@ mod test {
 
         // Let's start by adding a few operations to a tree.
         let t1_lineage: LineageId = rng.value();
-        let t1_o1 = ForestOperation::insert(rng.value(), rng.value());
-        let t1_o2 = ForestOperation::remove(rng.value());
+        let t1_o1 = SmtForestOperation::insert(rng.value(), rng.value());
+        let t1_o2 = SmtForestOperation::remove(rng.value());
         batch.add_operations(t1_lineage, vec![t1_o1, t1_o2].into_iter());
 
         // We can also add them differently.
         let t2_lineage: LineageId = rng.value();
-        let t2_o1 = ForestOperation::remove(rng.value());
-        let t2_o2 = ForestOperation::insert(rng.value(), rng.value());
+        let t2_o1 = SmtForestOperation::remove(rng.value());
+        let t2_o2 = SmtForestOperation::insert(rng.value(), rng.value());
         batch.operations(t2_lineage).add_operations(vec![t2_o1, t2_o2].into_iter());
 
         // When we consume the batch, each per-tree batch should be unique by key and sorted.
@@ -307,11 +307,11 @@ mod test {
         assert_eq!(ops.len(), 2);
 
         let t1_ops = ops.get(&t1_lineage).unwrap();
-        assert!(t1_ops.is_sorted_by_key(ForestOperation::key));
+        assert!(t1_ops.is_sorted_by_key(SmtForestOperation::key));
         assert_eq!(t1_ops.iter().unique_by(|o| o.key()).count(), 2);
 
         let t2_ops = ops.get(&t2_lineage).unwrap();
-        assert!(t2_ops.is_sorted_by_key(ForestOperation::key));
+        assert!(t2_ops.is_sorted_by_key(SmtForestOperation::key));
         assert_eq!(t2_ops.iter().unique_by(|o| o.key()).count(), 2);
     }
 }

--- a/miden-crypto/src/merkle/smt/large_forest/operation.rs
+++ b/miden-crypto/src/merkle/smt/large_forest/operation.rs
@@ -78,13 +78,13 @@ impl SmtUpdateBatch {
         self.operations.extend(operations);
     }
 
-    /// Adds the [`ForestOperation::Insert`] operation for the provided `key` and `value` pair to
+    /// Adds the [`SmtForestOperation::Insert`] operation for the provided `key` and `value` pair to
     /// the batch.
     pub fn add_insert(&mut self, key: Word, value: Word) {
         self.operations.push(SmtForestOperation::insert(key, value));
     }
 
-    /// Adds the [`ForestOperation::Remove`] operation for the provided `key` to the batch.
+    /// Adds the [`SmtForestOperation::Remove`] operation for the provided `key` to the batch.
     pub fn add_remove(&mut self, key: Word) {
         self.operations.push(SmtForestOperation::remove(key));
     }

--- a/miden-crypto/src/merkle/smt/large_forest/property_tests.rs
+++ b/miden-crypto/src/merkle/smt/large_forest/property_tests.rs
@@ -9,8 +9,8 @@ use proptest::prelude::*;
 use crate::{
     EMPTY_WORD, Word,
     merkle::smt::{
-        ForestConfig, ForestInMemoryBackend, ForestOperation, LargeSmtForest, LargeSmtForestError,
-        LineageId, RootInfo, Smt, SmtForestUpdateBatch, SmtUpdateBatch, TreeId,
+        ForestConfig, ForestInMemoryBackend, LargeSmtForest, LargeSmtForestError, LineageId,
+        RootInfo, Smt, SmtForestOperation, SmtForestUpdateBatch, SmtUpdateBatch, TreeId,
         large_forest::test_utils::{
             apply_batch, arbitrary_batch, arbitrary_distinct_lineages, arbitrary_lineage,
             arbitrary_non_empty_word, arbitrary_version, arbitrary_word, assert_lineage_metadata,
@@ -116,50 +116,50 @@ proptest! {
             .add_lineage(
                 lineage,
                 version,
-                SmtUpdateBatch::new([ForestOperation::insert(key_1, value_1)].into_iter()),
+                SmtUpdateBatch::new([SmtForestOperation::insert(key_1, value_1)].into_iter()),
             )
             .map_err(to_fail)?;
         forest
             .update_tree(
                 lineage,
                 version + 1,
-                SmtUpdateBatch::new([ForestOperation::insert(key_2, value_2)].into_iter()),
+                SmtUpdateBatch::new([SmtForestOperation::insert(key_2, value_2)].into_iter()),
             )
             .map_err(to_fail)?;
         forest
             .update_tree(
                 lineage,
                 version + 2,
-                SmtUpdateBatch::new([ForestOperation::insert(key_3, value_3)].into_iter()),
+                SmtUpdateBatch::new([SmtForestOperation::insert(key_3, value_3)].into_iter()),
             )
             .map_err(to_fail)?;
         forest
             .update_tree(
                 lineage,
                 version + 3,
-                SmtUpdateBatch::new([ForestOperation::insert(key_4, value_4)].into_iter()),
+                SmtUpdateBatch::new([SmtForestOperation::insert(key_4, value_4)].into_iter()),
             )
             .map_err(to_fail)?;
 
         let mut tree_v1 = Smt::new();
         apply_batch(
             &mut tree_v1,
-            SmtUpdateBatch::new([ForestOperation::insert(key_1, value_1)].into_iter()),
+            SmtUpdateBatch::new([SmtForestOperation::insert(key_1, value_1)].into_iter()),
         )?;
         let mut tree_v2 = tree_v1.clone();
         apply_batch(
             &mut tree_v2,
-            SmtUpdateBatch::new([ForestOperation::insert(key_2, value_2)].into_iter()),
+            SmtUpdateBatch::new([SmtForestOperation::insert(key_2, value_2)].into_iter()),
         )?;
         let mut tree_v3 = tree_v2.clone();
         apply_batch(
             &mut tree_v3,
-            SmtUpdateBatch::new([ForestOperation::insert(key_3, value_3)].into_iter()),
+            SmtUpdateBatch::new([SmtForestOperation::insert(key_3, value_3)].into_iter()),
         )?;
         let mut tree_v4 = tree_v3.clone();
         apply_batch(
             &mut tree_v4,
-            SmtUpdateBatch::new([ForestOperation::insert(key_4, value_4)].into_iter()),
+            SmtUpdateBatch::new([SmtForestOperation::insert(key_4, value_4)].into_iter()),
         )?;
 
         let sample_keys = vec![key_1, key_2, key_3, key_4];
@@ -523,7 +523,7 @@ proptest! {
         let invalid_value = Word::from([1u32, 1, 1, 1]);
         invalid_updates.add_operations(
             lineage_1,
-            SmtUpdateBatch::new([ForestOperation::insert(query_key, invalid_value)].into_iter())
+            SmtUpdateBatch::new([SmtForestOperation::insert(query_key, invalid_value)].into_iter())
                 .consume()
                 .into_iter(),
         );

--- a/miden-crypto/src/merkle/smt/large_forest/test_utils.rs
+++ b/miden-crypto/src/merkle/smt/large_forest/test_utils.rs
@@ -14,9 +14,9 @@ use proptest::prelude::*;
 use crate::{
     EMPTY_WORD, Map, ONE, ZERO,
     merkle::smt::{
-        Backend, BackendReader, ForestInMemoryBackend, ForestOperation, LargeSmtForest, LeafIndex,
-        LineageId, MAX_LEAF_ENTRIES, RootInfo, SMT_DEPTH, Smt, SmtForestUpdateBatch, SmtProof,
-        SmtUpdateBatch, TreeId, VersionId,
+        Backend, BackendReader, ForestInMemoryBackend, LargeSmtForest, LeafIndex, LineageId,
+        MAX_LEAF_ENTRIES, RootInfo, SMT_DEPTH, Smt, SmtForestOperation, SmtForestUpdateBatch,
+        SmtProof, SmtUpdateBatch, TreeId, VersionId,
         large_forest::{
             backend::{BackendError, Result as BackendResult},
             root::{TreeEntry, TreeWithRoot},
@@ -121,9 +121,9 @@ pub fn arbitrary_batch() -> impl Strategy<Value = SmtUpdateBatch> {
     arbitrary_entries().prop_map(|e| {
         SmtUpdateBatch::new(e.into_iter().map(|(k, v)| {
             if v == EMPTY_WORD {
-                ForestOperation::remove(k)
+                SmtForestOperation::remove(k)
             } else {
-                ForestOperation::insert(k, v)
+                SmtForestOperation::insert(k, v)
             }
         }))
     })

--- a/miden-crypto/src/merkle/smt/large_forest/test_utils.rs
+++ b/miden-crypto/src/merkle/smt/large_forest/test_utils.rs
@@ -325,38 +325,12 @@ impl Backend for FallibleEntriesBackend {
         self.inner.reader()
     }
 
-    fn compute_add_lineage_mutations(
-        &self,
-        lineage: LineageId,
-        version: VersionId,
-        updates: SmtUpdateBatch,
-    ) -> BackendResult<(Vec<LineageMutation>, Self::PreparedMutations)> {
-        self.inner.compute_add_lineage_mutations(lineage, version, updates)
-    }
-
-    fn compute_update_tree_mutations(
-        &self,
-        lineage: LineageId,
-        new_version: VersionId,
-        updates: SmtUpdateBatch,
-    ) -> BackendResult<(Vec<LineageMutation>, Self::PreparedMutations)> {
-        self.inner.compute_update_tree_mutations(lineage, new_version, updates)
-    }
-
-    fn compute_add_lineages_mutations(
-        &self,
-        version: VersionId,
-        lineages: SmtForestUpdateBatch,
-    ) -> BackendResult<(Vec<LineageMutation>, Self::PreparedMutations)> {
-        self.inner.compute_add_lineages_mutations(version, lineages)
-    }
-
-    fn compute_update_forest_mutations(
+    fn compute_mutations(
         &self,
         new_version: VersionId,
         updates: SmtForestUpdateBatch,
     ) -> BackendResult<(Vec<LineageMutation>, Self::PreparedMutations)> {
-        self.inner.compute_update_forest_mutations(new_version, updates)
+        self.inner.compute_mutations(new_version, updates)
     }
 
     fn apply_mutations(

--- a/miden-crypto/src/merkle/smt/large_forest/tests.rs
+++ b/miden-crypto/src/merkle/smt/large_forest/tests.rs
@@ -1208,6 +1208,48 @@ fn compute_and_apply_update_tree_mutations() -> Result<()> {
 }
 
 #[test]
+fn compute_and_apply_forest_mutations_can_mix_additions_and_updates() -> Result<()> {
+    let backend = ForestInMemoryBackend::new();
+    let mut forest = Forest::new(backend)?;
+    let mut rng = ContinuousRng::new([0x74; 32]);
+
+    let existing_lineage: LineageId = rng.value();
+    let new_lineage: LineageId = rng.value();
+    let version_1: VersionId = 10;
+    let version_2: VersionId = 11;
+
+    let existing_key: Word = rng.value();
+    let existing_value: Word = rng.value();
+    let new_key: Word = rng.value();
+    let new_value: Word = rng.value();
+
+    forest.add_lineage(existing_lineage, version_1, SmtUpdateBatch::default())?;
+
+    let mut batch = SmtForestUpdateBatch::empty();
+    batch.operations(existing_lineage).add_insert(existing_key, existing_value);
+    batch.operations(new_lineage).add_insert(new_key, new_value);
+
+    let mutations = forest.compute_forest_mutations(version_2, batch)?;
+    let proposed_roots = mutations.roots().collect::<Vec<_>>();
+    assert_eq!(proposed_roots.len(), 2);
+    assert!(proposed_roots.iter().any(|root| root.lineage() == existing_lineage));
+    assert!(proposed_roots.iter().any(|root| root.lineage() == new_lineage));
+
+    assert_eq!(forest.get(TreeId::new(existing_lineage, version_1), existing_key)?, None);
+    assert_matches!(forest.root_info(TreeId::new(new_lineage, version_2)), RootInfo::Missing);
+
+    let applied_roots = forest.apply_mutations(mutations)?;
+    assert_eq!(applied_roots.len(), 2);
+    assert_eq!(
+        forest.get(TreeId::new(existing_lineage, version_2), existing_key)?,
+        Some(existing_value)
+    );
+    assert_eq!(forest.get(TreeId::new(new_lineage, version_2), new_key)?, Some(new_value));
+
+    Ok(())
+}
+
+#[test]
 fn apply_update_tree_mutations_rejects_stale_state() -> Result<()> {
     let backend = ForestInMemoryBackend::new();
     let mut forest = Forest::new(backend)?;

--- a/miden-crypto/src/merkle/smt/large_forest/tests.rs
+++ b/miden-crypto/src/merkle/smt/large_forest/tests.rs
@@ -18,9 +18,8 @@ use crate::{
     merkle::{
         EmptySubtreeRoots,
         smt::{
-            BackendReader, ForestInMemoryBackend, ForestOperation, LargeSmtForest,
-            LargeSmtForestError, RootInfo, Smt, SmtForestUpdateBatch, SmtUpdateBatch, TreeId,
-            VersionId,
+            BackendReader, ForestInMemoryBackend, LargeSmtForest, LargeSmtForestError, RootInfo,
+            Smt, SmtForestOperation, SmtForestUpdateBatch, SmtUpdateBatch, TreeId, VersionId,
             large_forest::{
                 LineageData,
                 history::{ChangedKeys, History, NodeChanges},
@@ -321,7 +320,7 @@ fn lineage_count() -> Result<()> {
 
     // This should stay the same if we update a tree.
     let operations =
-        SmtUpdateBatch::new([ForestOperation::insert(rng.value(), rng.value())].into_iter());
+        SmtUpdateBatch::new([SmtForestOperation::insert(rng.value(), rng.value())].into_iter());
     forest.update_tree(lineage_1, version + 1, operations)?;
     assert_eq!(forest.lineage_count(), 3);
 
@@ -338,12 +337,12 @@ fn root_info() -> Result<()> {
     let lineage_1: LineageId = rng.value();
     let version_1: VersionId = rng.value();
     let operations =
-        SmtUpdateBatch::new([ForestOperation::insert(rng.value(), rng.value())].into_iter());
+        SmtUpdateBatch::new([SmtForestOperation::insert(rng.value(), rng.value())].into_iter());
     let historical_root = forest.add_lineage(lineage_1, version_1, operations)?;
 
     let version_2 = version_1 + 1;
     let operations =
-        SmtUpdateBatch::new([ForestOperation::insert(rng.value(), rng.value())].into_iter());
+        SmtUpdateBatch::new([SmtForestOperation::insert(rng.value(), rng.value())].into_iter());
     let current_root = forest.update_tree(lineage_1, version_2, operations)?;
 
     // When we query for a root (lineage_1, version_1), we should get back HistoricalVersion.
@@ -400,8 +399,8 @@ fn open() -> Result<()> {
         version_1,
         SmtUpdateBatch::new(
             [
-                ForestOperation::insert(key_1, value_1_v1),
-                ForestOperation::insert(key_2, value_2_v1),
+                SmtForestOperation::insert(key_1, value_1_v1),
+                SmtForestOperation::insert(key_2, value_2_v1),
             ]
             .into_iter(),
         ),
@@ -443,9 +442,9 @@ fn open() -> Result<()> {
         version_2,
         SmtUpdateBatch::new(
             [
-                ForestOperation::insert(key_1, value_1_v2),
-                ForestOperation::insert(key_3, value_3_v1),
-                ForestOperation::remove(key_2),
+                SmtForestOperation::insert(key_1, value_1_v2),
+                SmtForestOperation::insert(key_3, value_3_v1),
+                SmtForestOperation::remove(key_2),
             ]
             .into_iter(),
         ),
@@ -500,8 +499,8 @@ fn get() -> Result<()> {
         version_1,
         SmtUpdateBatch::new(
             [
-                ForestOperation::insert(key_1, value_1_v1),
-                ForestOperation::insert(key_2, value_2_v1),
+                SmtForestOperation::insert(key_1, value_1_v1),
+                SmtForestOperation::insert(key_2, value_2_v1),
             ]
             .into_iter(),
         ),
@@ -541,8 +540,8 @@ fn get() -> Result<()> {
         version_2,
         SmtUpdateBatch::new(
             [
-                ForestOperation::insert(key_1, value_1_v2),
-                ForestOperation::insert(key_3, value_3_v1),
+                SmtForestOperation::insert(key_1, value_1_v2),
+                SmtForestOperation::insert(key_3, value_3_v1),
             ]
             .into_iter(),
         ),
@@ -914,8 +913,11 @@ fn entries_never_returns_empty_entry() -> Result<()> {
     let key_2: Word = rng.value();
     let value_2: Word = rng.value();
     let operations = SmtUpdateBatch::new(
-        [ForestOperation::insert(key_1, value_1), ForestOperation::insert(key_2, value_2)]
-            .into_iter(),
+        [
+            SmtForestOperation::insert(key_1, value_1),
+            SmtForestOperation::insert(key_2, value_2),
+        ]
+        .into_iter(),
     );
     forest.update_tree(lineage_1, version_2, operations)?;
 
@@ -931,7 +933,7 @@ fn entries_never_returns_empty_entry() -> Result<()> {
     forest.add_lineage(
         lineage_2,
         version_1,
-        SmtUpdateBatch::new([ForestOperation::insert(key_1, value_1)].into_iter()),
+        SmtUpdateBatch::new([SmtForestOperation::insert(key_1, value_1)].into_iter()),
     )?;
 
     // Now we add an update to a different leaf.
@@ -940,7 +942,7 @@ fn entries_never_returns_empty_entry() -> Result<()> {
     forest.update_tree(
         lineage_2,
         version_2,
-        SmtUpdateBatch::new([ForestOperation::insert(key_2, value_2)].into_iter()),
+        SmtUpdateBatch::new([SmtForestOperation::insert(key_2, value_2)].into_iter()),
     )?;
 
     // Now, when we query for entries on the historical version, we should only see one entry, and
@@ -958,7 +960,7 @@ fn entries_never_returns_empty_entry() -> Result<()> {
     forest.add_lineage(
         lineage_3,
         version_1,
-        SmtUpdateBatch::new([ForestOperation::insert(key_1, value_1)].into_iter()),
+        SmtUpdateBatch::new([SmtForestOperation::insert(key_1, value_1)].into_iter()),
     )?;
 
     // We now add an update in the same leaf.
@@ -967,7 +969,7 @@ fn entries_never_returns_empty_entry() -> Result<()> {
     forest.update_tree(
         lineage_3,
         version_2,
-        SmtUpdateBatch::new([ForestOperation::insert(key_2, value_2)].into_iter()),
+        SmtUpdateBatch::new([SmtForestOperation::insert(key_2, value_2)].into_iter()),
     )?;
 
     // Now when we query the historical version, we should only see one entry, and no reversions.
@@ -998,8 +1000,8 @@ fn entries_history_empty_values_do_not_reorder() -> Result<()> {
         version_1,
         SmtUpdateBatch::new(
             [
-                ForestOperation::insert(key_a, value_a),
-                ForestOperation::insert(key_c, value_c_v1),
+                SmtForestOperation::insert(key_a, value_a),
+                SmtForestOperation::insert(key_c, value_c_v1),
             ]
             .into_iter(),
         ),
@@ -1015,8 +1017,8 @@ fn entries_history_empty_values_do_not_reorder() -> Result<()> {
         version_2,
         SmtUpdateBatch::new(
             [
-                ForestOperation::insert(key_b, value_b),
-                ForestOperation::insert(key_c, value_c_v2),
+                SmtForestOperation::insert(key_b, value_b),
+                SmtForestOperation::insert(key_c, value_c_v2),
             ]
             .into_iter(),
         ),

--- a/miden-crypto/src/merkle/smt/large_forest/utils.rs
+++ b/miden-crypto/src/merkle/smt/large_forest/utils.rs
@@ -109,7 +109,7 @@ impl LineageMutation {
     /// Constructs a lineage mutation.
     ///
     /// This constructor is crate-private because callers must not be able to fabricate mutation
-    /// metadata that is inconsistent with the backend-prepared data in a [`ForestMutationSet`].
+    /// metadata that is inconsistent with the backend-prepared data in an [`SmtForestMutationSet`].
     pub(crate) fn new(
         lineage: LineageId,
         old_version: Option<VersionId>,

--- a/miden-crypto/src/merkle/smt/large_forest/utils.rs
+++ b/miden-crypto/src/merkle/smt/large_forest/utils.rs
@@ -43,12 +43,12 @@ pub type MutationSet = crate::merkle::smt::MutationSet<SMT_DEPTH, Word, Word>;
 ///
 /// Values of this type are only valid for the forest state against which they were computed.
 /// Applying them after the target lineage has changed will fail during forest-level validation.
-pub struct ForestMutationSet<B: Backend> {
+pub struct SmtForestMutationSet<B: Backend> {
     entries: Vec<LineageMutation>,
     prepared: B::PreparedMutations,
 }
 
-impl<B: Backend> ForestMutationSet<B> {
+impl<B: Backend> SmtForestMutationSet<B> {
     /// Constructs a forest mutation set from inspectable lineage entries and backend-prepared data.
     ///
     /// This constructor is crate-private because only forest/backend code can maintain the

--- a/miden-crypto/src/merkle/smt/mod.rs
+++ b/miden-crypto/src/merkle/smt/mod.rs
@@ -31,12 +31,13 @@ pub use large::{RocksDbConfig, RocksDbSnapshotStorage, RocksDbStorage};
 mod large_forest;
 pub use large_forest::{
     AppliedLineageMutation, Backend, BackendError, BackendReader, Config as ForestConfig,
-    DEFAULT_MAX_HISTORY_VERSIONS as FOREST_DEFAULT_MAX_HISTORY_VERSIONS, ForestMutationSet,
-    ForestOperation, InMemoryBackend as ForestInMemoryBackend,
+    DEFAULT_MAX_HISTORY_VERSIONS as FOREST_DEFAULT_MAX_HISTORY_VERSIONS,
+    InMemoryBackend as ForestInMemoryBackend,
     InMemoryBackendSnapshot as ForestInMemoryBackendReader, LargeSmtForest, LargeSmtForestError,
     LineageId, LineageMutation, LineageMutationKind,
-    MIN_HISTORY_VERSIONS as FOREST_MIN_HISTORY_VERSIONS, RootInfo, SmtForestUpdateBatch,
-    SmtUpdateBatch, TreeEntry, TreeId, TreeWithRoot, VersionId,
+    MIN_HISTORY_VERSIONS as FOREST_MIN_HISTORY_VERSIONS, RootInfo, SmtForestMutationSet,
+    SmtForestOperation, SmtForestUpdateBatch, SmtUpdateBatch, TreeEntry, TreeId, TreeWithRoot,
+    VersionId,
 };
 #[cfg(feature = "persistent-forest")]
 pub use large_forest::{


### PR DESCRIPTION
This is a follow-up PR to #1018 that implements some of the changes suggested by @bobbinth:

- Collapsed Backend compute API from 4 methods to one `compute_mutations()` plus existing `apply_mutations()`.
- Added forest-level `compute_tree_mutations()` and `compute_forest_mutations()`.
- `compute_forest_mutations()` can mix existing-lineage updates and new-lineage additions in one batch.
- Kept existing convenience methods like `add_lineage()`, `update_tree()`, `add_lineages()`, and `update_forest()` as compatibility wrappers with their old validation behavior.
- Added a regression test for mixed add/update forest mutations in `miden-crypto/src/merkle/smt/large_forest/tests.rs`.
- Rename `ForestOperation` to `SmtForestOperation` and `ForestMutationSet` to `SmtForestMutationSet` for the sake of naming consistency.