### PR TITLE
Fix serde utils fuzz lockfile

### DIFF
--- a/miden-serde-utils/fuzz/Cargo.lock
+++ b/miden-serde-utils/fuzz/Cargo.lock
@@ -102,7 +102,7 @@ dependencies = [
 
 [[package]]
 name = "miden-serde-utils"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "p3-field",
  "p3-goldilocks",


### PR DESCRIPTION
Re-generate the fuzz crate's Cargo.lock (this failure was caught by PR CI [here](https://github.com/0xMiden/crypto/actions/runs/26846611041), so no needed change on that front)