### PR TITLE
ci: add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,38 @@
+version: 2
+
+multi-ecosystem-groups:
+  dependency-refresh:
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Etc/UTC"
+    labels:
+      - "dependencies"
+      - "no changelog"
+
+updates:
+  - package-ecosystem: "cargo"
+    directories:
+      - "/"
+      - "/miden-crypto-fuzz"
+      - "/miden-serde-utils/fuzz"
+      - "/tools/zeroize-audit"
+    patterns:
+      - "*"
+    multi-ecosystem-group: "dependency-refresh"
+    open-pull-requests-limit: 1
+    cooldown:
+      semver-patch-days: 7
+      semver-minor-days: 7
+      semver-major-days: 15
+
+  # Action updates still have to pass actionlint and zizmor in actions-hygiene.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    patterns:
+      - "*"
+    multi-ecosystem-group: "dependency-refresh"
+    open-pull-requests-limit: 1
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
Fixes #1035.

This adds a weekly Dependabot refresh for Cargo and GitHub Actions.

Cargo coverage includes the root workspace, both fuzz workspaces, and `tools/zeroize-audit`. GitHub Actions updates still go through the existing actionlint and zizmor checks.

Review load stays low: one weekly group, one open PR, `dependencies` + `no changelog`, and cooldowns of 7 days for patch/minor updates and 15 days for major updates.
