### PR TITLE
ci: Add Codspeed smt benchmarks

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,3 +1,4 @@
 self-hosted-runner:
   labels:
+    - codspeed-macro
     - warp-ubuntu-latest-x64-4x

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -34,8 +34,12 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          toolchain="$(sed -n 's/^channel[[:space:]]*=[[:space:]]*"\(.*\)"$/\1/p' rust-toolchain.toml)"
-          rustup toolchain install "${toolchain}" --profile minimal
+          rustup toolchain install --profile minimal
+
+      - name: Install LLVM/Clang
+        uses: ./.github/actions/install-llvm
+        with:
+          version: "17"
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -20,9 +20,9 @@ jobs:
       contents: read
       id-token: write
     env:
-      CRYPTO_SMT_MEASUREMENT_TIME_SECS: "2"
+      CRYPTO_SMT_MEASUREMENT_TIME_MILLIS: "1000"
       CRYPTO_SMT_SAMPLE_SIZE: "10"
-      CRYPTO_SMT_WARM_UP_TIME_SECS: "1"
+      CRYPTO_SMT_WARM_UP_TIME_MILLIS: "250"
       RAYON_NUM_THREADS: "8"
     steps:
       - name: Check out repository

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -1,0 +1,59 @@
+name: codspeed
+
+on:
+  push:
+    branches:
+      - main
+      - next
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  codspeed:
+    name: Run CodSpeed benchmarks
+    runs-on: codspeed-macro
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      CRYPTO_SMT_MEASUREMENT_TIME_SECS: "2"
+      CRYPTO_SMT_SAMPLE_SIZE: "10"
+      CRYPTO_SMT_WARM_UP_TIME_SECS: "1"
+      RAYON_NUM_THREADS: "8"
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      - name: Install Rust toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          toolchain="$(sed -n 's/^channel[[:space:]]*=[[:space:]]*"\(.*\)"$/\1/p' rust-toolchain.toml)"
+          rustup toolchain install "${toolchain}" --profile minimal
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+
+      - name: Install cargo-codspeed
+        shell: bash
+        run: |
+          set -euo pipefail
+          cargo install cargo-codspeed --version 4.6.0 --locked
+
+      - name: Build benchmarks
+        shell: bash
+        run: |
+          set -euo pipefail
+          cargo codspeed build --measurement-mode walltime --profile optimized -p miden-crypto-smt-codspeed-bench --bench smt_codspeed
+
+      - name: Run benchmarks
+        uses: CodSpeedHQ/action@3194d9a39c4d46684cb44bf7207fc56626aad8fd # v4.15.1
+        with:
+          mode: walltime
+          run: cargo codspeed run --measurement-mode walltime -p miden-crypto-smt-codspeed-bench --bench smt_codspeed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,7 +87,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -98,7 +98,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -106,6 +106,15 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "arrayref"
@@ -238,6 +247,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
@@ -373,10 +388,78 @@ dependencies = [
 ]
 
 [[package]]
+name = "codspeed"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7ce4a32373a5c84f4fa785099b300b9b1796311abc122b9eb62c65fa615145d"
+dependencies = [
+ "anyhow",
+ "cc",
+ "colored",
+ "getrandom 0.2.17",
+ "glob",
+ "libc",
+ "nix",
+ "serde",
+ "serde_json",
+ "statrs",
+]
+
+[[package]]
+name = "codspeed-criterion-compat"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5557c4e023f427ba208b849193c51c2ebd40534828490cd3f5f7f7fc0284ce5"
+dependencies = [
+ "clap",
+ "codspeed",
+ "codspeed-criterion-compat-walltime",
+ "colored",
+ "regex",
+]
+
+[[package]]
+name = "codspeed-criterion-compat-walltime"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43ac19f0a5c3542301e9d011d658f93c3f550698ec8ba7d7c072692e7924c401"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "codspeed",
+ "criterion-plot 0.5.0",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "colored"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
+dependencies = [
+ "lazy_static",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "const-oid"
@@ -419,7 +502,7 @@ dependencies = [
  "cast",
  "ciborium",
  "clap",
- "criterion-plot",
+ "criterion-plot 0.8.2",
  "itertools 0.13.0",
  "num-traits",
  "oorandom",
@@ -431,6 +514,16 @@ dependencies = [
  "serde_json",
  "tinytemplate",
  "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -641,7 +734,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -748,6 +841,17 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
@@ -833,6 +937,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -884,10 +994,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -1150,6 +1280,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "miden-crypto-smt-codspeed-bench"
+version = "0.27.0"
+dependencies = [
+ "codspeed-criterion-compat",
+ "miden-crypto",
+ "tempfile",
+]
+
+[[package]]
 name = "miden-field"
 version = "0.27.0"
 dependencies = [
@@ -1248,6 +1387,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1263,7 +1414,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2147,7 +2298,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2333,6 +2484,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "statrs"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a3fe7c28c6512e766b0874335db33c94ad7b8f9054228ae1c2abd47ce7d335e"
+dependencies = [
+ "approx",
+ "num-traits",
+]
+
+[[package]]
 name = "strength_reduce"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2371,7 +2532,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2605,6 +2766,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
 name = "wasip2"
 version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2733,7 +2900,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2750,12 +2917,85 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 exclude = ["miden-crypto-fuzz"]
 members = [
+  "benches/smt-codspeed",
   "miden-bench",
   "miden-crypto",
   "miden-crypto-derive",
@@ -101,6 +102,11 @@ tracing-subscriber = { features = ["env-filter", "fmt", "std"], version = "0.3.1
 [workspace.lints.rust]
 # Suppress warnings about `cfg(fuzzing)`, which is automatically set when using `cargo-fuzz`.
 unexpected_cfgs = { check-cfg = ['cfg(fuzzing)'], level = "warn" }
+
+[profile.optimized]
+codegen-units = 1
+inherits      = "release"
+lto           = true
 
 [profile.test-release]
 debug            = 2

--- a/benches/README.md
+++ b/benches/README.md
@@ -1,0 +1,19 @@
+# Benchmarks
+
+This directory holds benchmark crates that are not tied to one published package.
+
+## SMT CodSpeed Benchmarks
+
+The `smt-codspeed` crate runs wall-time CodSpeed benchmarks for sparse Merkle tree
+operations in `miden-crypto`.
+
+Run the benchmarks locally with:
+
+```sh
+cargo codspeed build --measurement-mode walltime --profile optimized -p miden-crypto-smt-codspeed-bench --bench smt_codspeed
+cargo codspeed run --measurement-mode walltime -p miden-crypto-smt-codspeed-bench --bench smt_codspeed
+```
+
+The `codspeed` workflow runs the same crate on `main`, `next`, and manual
+workflow dispatches. CodSpeed results are available from the workflow run and
+from the CodSpeed dashboard for this repository.

--- a/benches/smt-codspeed/Cargo.toml
+++ b/benches/smt-codspeed/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+authors.workspace      = true
+description            = "CodSpeed benchmarks for Miden crypto SMT operations."
+edition.workspace      = true
+license.workspace      = true
+name                   = "miden-crypto-smt-codspeed-bench"
+publish                = false
+repository.workspace   = true
+rust-version.workspace = true
+version.workspace      = true
+
+[dev-dependencies]
+criterion    = { package = "codspeed-criterion-compat", version = "=4.6.0" }
+miden-crypto = { default-features = false, features = ["rocksdb"], path = "../../miden-crypto" }
+tempfile     = { workspace = true }
+
+[[bench]]
+harness = false
+name    = "smt_codspeed"
+
+[lints]
+workspace = true

--- a/benches/smt-codspeed/Cargo.toml
+++ b/benches/smt-codspeed/Cargo.toml
@@ -14,6 +14,10 @@ criterion    = { package = "codspeed-criterion-compat", version = "=4.6.0" }
 miden-crypto = { default-features = false, features = ["rocksdb"], path = "../../miden-crypto" }
 tempfile     = { workspace = true }
 
+[lib]
+doctest = false
+test    = false
+
 [[bench]]
 harness = false
 name    = "smt_codspeed"

--- a/benches/smt-codspeed/benches/smt_codspeed.rs
+++ b/benches/smt-codspeed/benches/smt_codspeed.rs
@@ -23,24 +23,24 @@ fn env_usize(name: &str, default: usize) -> usize {
     }
 }
 
-fn env_u64(name: &str, default: u64) -> u64 {
+fn env_duration_millis(name: &str, default: u64) -> Duration {
     match std::env::var(name) {
         Ok(raw) => {
             let value = raw
                 .parse::<u64>()
                 .unwrap_or_else(|error| panic!("{name} must be a positive integer: {error}"));
             assert!(value > 0, "{name} must be greater than zero");
-            value
+            Duration::from_millis(value)
         },
-        Err(_) => default,
+        Err(_) => Duration::from_millis(default),
     }
 }
 
 fn criterion_config() -> Criterion {
     Criterion::default()
         .sample_size(env_usize("CRYPTO_SMT_SAMPLE_SIZE", 10))
-        .measurement_time(Duration::from_secs(env_u64("CRYPTO_SMT_MEASUREMENT_TIME_SECS", 2)))
-        .warm_up_time(Duration::from_secs(env_u64("CRYPTO_SMT_WARM_UP_TIME_SECS", 1)))
+        .measurement_time(env_duration_millis("CRYPTO_SMT_MEASUREMENT_TIME_MILLIS", 1_000))
+        .warm_up_time(env_duration_millis("CRYPTO_SMT_WARM_UP_TIME_MILLIS", 250))
 }
 
 fn configure_group<M: criterion::measurement::Measurement>(
@@ -49,8 +49,8 @@ fn configure_group<M: criterion::measurement::Measurement>(
     group
         .sampling_mode(SamplingMode::Flat)
         .sample_size(env_usize("CRYPTO_SMT_SAMPLE_SIZE", 10))
-        .measurement_time(Duration::from_secs(env_u64("CRYPTO_SMT_MEASUREMENT_TIME_SECS", 2)))
-        .warm_up_time(Duration::from_secs(env_u64("CRYPTO_SMT_WARM_UP_TIME_SECS", 1)));
+        .measurement_time(env_duration_millis("CRYPTO_SMT_MEASUREMENT_TIME_MILLIS", 1_000))
+        .warm_up_time(env_duration_millis("CRYPTO_SMT_WARM_UP_TIME_MILLIS", 250));
 }
 
 fn word(seed: u64) -> Word {

--- a/benches/smt-codspeed/benches/smt_codspeed.rs
+++ b/benches/smt-codspeed/benches/smt_codspeed.rs
@@ -1,0 +1,275 @@
+use std::{hint::black_box, time::Duration};
+
+use criterion::{
+    BatchSize, BenchmarkId, Criterion, SamplingMode, Throughput, criterion_group, criterion_main,
+};
+use miden_crypto::{
+    Felt, ONE, Word,
+    merkle::smt::{
+        LargeSmt, LeafIndex, MemoryStorage, RocksDbConfig, RocksDbStorage, SimpleSmt, Smt,
+    },
+};
+
+fn env_usize(name: &str, default: usize) -> usize {
+    match std::env::var(name) {
+        Ok(raw) => {
+            let value = raw
+                .parse::<usize>()
+                .unwrap_or_else(|error| panic!("{name} must be a positive integer: {error}"));
+            assert!(value > 0, "{name} must be greater than zero");
+            value
+        },
+        Err(_) => default,
+    }
+}
+
+fn env_u64(name: &str, default: u64) -> u64 {
+    match std::env::var(name) {
+        Ok(raw) => {
+            let value = raw
+                .parse::<u64>()
+                .unwrap_or_else(|error| panic!("{name} must be a positive integer: {error}"));
+            assert!(value > 0, "{name} must be greater than zero");
+            value
+        },
+        Err(_) => default,
+    }
+}
+
+fn criterion_config() -> Criterion {
+    Criterion::default()
+        .sample_size(env_usize("CRYPTO_SMT_SAMPLE_SIZE", 10))
+        .measurement_time(Duration::from_secs(env_u64("CRYPTO_SMT_MEASUREMENT_TIME_SECS", 2)))
+        .warm_up_time(Duration::from_secs(env_u64("CRYPTO_SMT_WARM_UP_TIME_SECS", 1)))
+}
+
+fn configure_group<M: criterion::measurement::Measurement>(
+    group: &mut criterion::BenchmarkGroup<M>,
+) {
+    group
+        .sampling_mode(SamplingMode::Flat)
+        .sample_size(env_usize("CRYPTO_SMT_SAMPLE_SIZE", 10))
+        .measurement_time(Duration::from_secs(env_u64("CRYPTO_SMT_MEASUREMENT_TIME_SECS", 2)))
+        .warm_up_time(Duration::from_secs(env_u64("CRYPTO_SMT_WARM_UP_TIME_SECS", 1)));
+}
+
+fn word(seed: u64) -> Word {
+    Word::new([
+        Felt::new_unchecked(seed),
+        ONE,
+        Felt::new_unchecked(seed.wrapping_mul(17)),
+        Felt::new_unchecked(seed.wrapping_mul(65_537)),
+    ])
+}
+
+fn value(seed: u64) -> Word {
+    Word::new([
+        Felt::new_unchecked(seed.wrapping_add(1)),
+        Felt::new_unchecked(seed.wrapping_add(2)),
+        Felt::new_unchecked(seed.wrapping_add(3)),
+        Felt::new_unchecked(seed.wrapping_add(4)),
+    ])
+}
+
+fn entries(count: usize, offset: u64) -> Vec<(Word, Word)> {
+    (0..count as u64).map(|i| (word(offset + i), value(offset + i))).collect()
+}
+
+fn simple_entries(count: usize) -> Vec<(u64, Word)> {
+    (0..count as u64).map(|i| (i, value(i))).collect()
+}
+
+fn keys(count: usize, offset: u64) -> Vec<Word> {
+    (0..count as u64).map(|i| word(offset + i)).collect()
+}
+
+fn smt_benches(c: &mut Criterion) {
+    let mut construction = c.benchmark_group("smt/construction");
+    configure_group(&mut construction);
+    for size in [256, 4_096] {
+        construction.throughput(Throughput::Elements(size as u64));
+        construction.bench_function(BenchmarkId::new("Smt::with_entries", size), |bench| {
+            bench.iter_batched(
+                || entries(size, 0),
+                |entries| black_box(Smt::with_entries(entries).unwrap()),
+                BatchSize::LargeInput,
+            );
+        });
+        construction.bench_function(BenchmarkId::new("SimpleSmt::with_leaves", size), |bench| {
+            bench.iter_batched(
+                || simple_entries(size),
+                |entries| black_box(SimpleSmt::<32>::with_leaves(entries).unwrap()),
+                BatchSize::LargeInput,
+            );
+        });
+    }
+    construction.finish();
+
+    let smt = Smt::with_entries(entries(4_096, 0)).unwrap();
+    let open_keys = keys(32, 0);
+    let mut reads = c.benchmark_group("smt/read");
+    configure_group(&mut reads);
+    reads.throughput(Throughput::Elements(open_keys.len() as u64));
+    reads.bench_function("Smt::open/32", |bench| {
+        bench.iter(|| {
+            for key in &open_keys {
+                black_box(smt.open(key));
+            }
+        });
+    });
+
+    let simple_smt = SimpleSmt::<32>::with_leaves(simple_entries(4_096)).unwrap();
+    let simple_keys: Vec<_> = (0..32).map(|i| LeafIndex::<32>::new(i).unwrap()).collect();
+    reads.bench_function("SimpleSmt::open/32", |bench| {
+        bench.iter(|| {
+            for key in &simple_keys {
+                black_box(simple_smt.open(key));
+            }
+        });
+    });
+    reads.finish();
+
+    let mut mutations = c.benchmark_group("smt/mutations");
+    configure_group(&mut mutations);
+    for size in [32, 256] {
+        mutations.throughput(Throughput::Elements(size as u64));
+        mutations.bench_function(BenchmarkId::new("Smt::compute_mutations", size), |bench| {
+            let smt = Smt::with_entries(entries(4_096, 0)).unwrap();
+            let updates = entries(size, 10_000);
+            bench.iter(|| black_box(smt.compute_mutations(updates.clone()).unwrap()));
+        });
+        mutations.bench_function(BenchmarkId::new("Smt::apply_mutations", size), |bench| {
+            bench.iter_batched(
+                || {
+                    let smt = Smt::with_entries(entries(4_096, 0)).unwrap();
+                    let mutations = smt.compute_mutations(entries(size, 10_000)).unwrap();
+                    (smt, mutations)
+                },
+                |(mut smt, mutations)| {
+                    smt.apply_mutations(mutations).unwrap();
+                    black_box(())
+                },
+                BatchSize::LargeInput,
+            );
+        });
+    }
+    mutations.finish();
+}
+
+fn large_smt_memory_benches(c: &mut Criterion) {
+    let mut group = c.benchmark_group("large_smt/memory");
+    configure_group(&mut group);
+
+    group.bench_function("open/32", |bench| {
+        let smt = LargeSmt::with_entries(MemoryStorage::new(), entries(4_096, 0)).unwrap();
+        let open_keys = keys(32, 0);
+        bench.iter(|| {
+            for key in &open_keys {
+                black_box(smt.open(key));
+            }
+        });
+    });
+
+    for size in [128, 1_024] {
+        group.throughput(Throughput::Elements(size as u64));
+        group.bench_function(BenchmarkId::new("compute_mutations", size), |bench| {
+            let smt = LargeSmt::with_entries(MemoryStorage::new(), entries(4_096, 0)).unwrap();
+            let updates = entries(size, 10_000);
+            bench.iter(|| black_box(smt.compute_mutations(updates.clone()).unwrap()));
+        });
+        group.bench_function(BenchmarkId::new("apply_mutations", size), |bench| {
+            bench.iter_batched(
+                || {
+                    let smt =
+                        LargeSmt::with_entries(MemoryStorage::new(), entries(4_096, 0)).unwrap();
+                    let mutations = smt.compute_mutations(entries(size, 10_000)).unwrap();
+                    (smt, mutations)
+                },
+                |(mut smt, mutations)| {
+                    smt.apply_mutations(mutations).unwrap();
+                    black_box(())
+                },
+                BatchSize::LargeInput,
+            );
+        });
+        group.bench_function(BenchmarkId::new("insert_batch/populated", size), |bench| {
+            bench.iter_batched(
+                || {
+                    let smt =
+                        LargeSmt::with_entries(MemoryStorage::new(), entries(4_096, 0)).unwrap();
+                    let batch = entries(size, 10_000);
+                    (smt, batch)
+                },
+                |(mut smt, batch)| black_box(smt.insert_batch(batch).unwrap()),
+                BatchSize::LargeInput,
+            );
+        });
+    }
+
+    group.finish();
+}
+
+fn rocksdb_smt(entries_count: usize) -> (tempfile::TempDir, LargeSmt<RocksDbStorage>) {
+    let temp_dir = tempfile::TempDir::new().unwrap();
+    let storage = RocksDbStorage::open(RocksDbConfig::new(temp_dir.path())).unwrap();
+    let smt = LargeSmt::with_entries(storage, entries(entries_count, 0)).unwrap();
+    (temp_dir, smt)
+}
+
+fn large_smt_rocksdb_benches(c: &mut Criterion) {
+    let mut group = c.benchmark_group("large_smt/rocksdb");
+    configure_group(&mut group);
+
+    group.bench_function("open/32", |bench| {
+        let (_temp_dir, smt) = rocksdb_smt(4_096);
+        let open_keys = keys(32, 0);
+        bench.iter(|| {
+            for key in &open_keys {
+                black_box(smt.open(key));
+            }
+        });
+    });
+
+    for size in [128, 1_024] {
+        group.throughput(Throughput::Elements(size as u64));
+        group.bench_function(BenchmarkId::new("compute_mutations", size), |bench| {
+            let (_temp_dir, smt) = rocksdb_smt(4_096);
+            let updates = entries(size, 10_000);
+            bench.iter(|| black_box(smt.compute_mutations(updates.clone()).unwrap()));
+        });
+        group.bench_function(BenchmarkId::new("apply_mutations", size), |bench| {
+            bench.iter_batched(
+                || {
+                    let (temp_dir, smt) = rocksdb_smt(4_096);
+                    let mutations = smt.compute_mutations(entries(size, 10_000)).unwrap();
+                    (temp_dir, smt, mutations)
+                },
+                |(_temp_dir, mut smt, mutations)| {
+                    smt.apply_mutations(mutations).unwrap();
+                    black_box(())
+                },
+                BatchSize::LargeInput,
+            );
+        });
+        group.bench_function(BenchmarkId::new("insert_batch/populated", size), |bench| {
+            bench.iter_batched(
+                || {
+                    let (temp_dir, smt) = rocksdb_smt(4_096);
+                    let batch = entries(size, 10_000);
+                    (temp_dir, smt, batch)
+                },
+                |(_temp_dir, mut smt, batch)| black_box(smt.insert_batch(batch).unwrap()),
+                BatchSize::LargeInput,
+            );
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group! {
+    name = benches;
+    config = criterion_config();
+    targets = smt_benches, large_smt_memory_benches, large_smt_rocksdb_benches
+}
+criterion_main!(benches);

--- a/benches/smt-codspeed/src/lib.rs
+++ b/benches/smt-codspeed/src/lib.rs
@@ -1,0 +1,1 @@
+//! CodSpeed benchmark package for SMT/LargeSmt Criterion benches.

--- a/deny.toml
+++ b/deny.toml
@@ -24,6 +24,7 @@ allow = [
   "BSD-2-Clause",
   "BSD-3-Clause",
   "CC0-1.0",
+  "ISC",
   "MIT",
   "Unicode-3.0",
   "Zlib",
@@ -39,6 +40,9 @@ multiple-versions = "deny"
 skip = [
   # Allow duplicate spin versions - transitively pulled by p3-dft and flume
   { name = "spin" },
+  # RocksDB's bindgen path still pulls older versions of crates used elsewhere.
+  { name = "itertools", version = "=0.13.0" },
+  { name = "shlex", version = "=1.3.0" },
 ]
 skip-tree = [
   # Stable crypto crates still depend on rand_core 0.6 and chacha20 0.9.


### PR DESCRIPTION
This adds a CodSpeed walltime job for SMT and LargeSmt benchmarks.

The benchmark suite covers SMT construction, reads, mutation planning, and mutation application. It also covers LargeSmt with memory and RocksDB storage.

The workflow runs on `codspeed-macro`, installs the repo Rust toolchain, installs LLVM/Clang for RocksDB, builds with the optimized profile, and runs CodSpeed in walltime mode.

The runtime is tuned for a ~6 minute CodSpeed budget. The benchmark run is about 43 seconds locally with warm build artifacts on M4.