### PR TITLE
chore: narrow dependency refresh

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,12 @@
 version: 2
 
-multi-ecosystem-groups:
-  dependency-refresh:
+updates:
+  - package-ecosystem: "cargo"
+    directories:
+      - "/"
+      - "/miden-crypto-fuzz"
+      - "/miden-serde-utils/fuzz"
+      - "/tools/zeroize-audit"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -11,18 +16,30 @@ multi-ecosystem-groups:
       - "dependencies"
       - "no changelog"
     open-pull-requests-limit: 1
-
-updates:
-  - package-ecosystem: "cargo"
-    directories:
-      - "/"
-      - "/miden-crypto-fuzz"
-      - "/miden-serde-utils/fuzz"
-      - "/tools/zeroize-audit"
-    patterns:
-      - "*"
-    multi-ecosystem-group: "dependency-refresh"
+    groups:
+      cargo-refresh:
+        patterns:
+          - "*"
+        group-by: "dependency-name"
+    ignore:
+      - dependency-name: "der"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-major"
+      - dependency-name: "hkdf"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-major"
+      - dependency-name: "sha2"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-major"
+      - dependency-name: "sha3"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-major"
     cooldown:
+      default-days: 7
       semver-patch-days: 7
       semver-minor-days: 7
       semver-major-days: 15
@@ -30,8 +47,18 @@ updates:
   # Action updates still have to pass actionlint and zizmor in actions-hygiene.
   - package-ecosystem: "github-actions"
     directory: "/"
-    patterns:
-      - "*"
-    multi-ecosystem-group: "dependency-refresh"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Etc/UTC"
+    labels:
+      - "dependencies"
+      - "no changelog"
+    open-pull-requests-limit: 1
+    groups:
+      github-actions:
+        patterns:
+          - "*"
     cooldown:
       default-days: 7

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -369,7 +369,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
 dependencies = [
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -674,9 +674,9 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "flume"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+checksum = "5e139bc46ca777eb5efaf62df0ab8cc5fd400866427e56c68b22e414e53bd3be"
 dependencies = [
  "spin 0.9.8",
 ]
@@ -1136,7 +1136,7 @@ dependencies = [
  "sha3",
  "subtle",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror",
  "x25519-dalek",
 ]
 
@@ -1165,7 +1165,7 @@ dependencies = [
  "rstest",
  "serde",
  "subtle",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -1177,7 +1177,7 @@ dependencies = [
  "p3-field",
  "p3-matrix",
  "p3-util",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -1207,7 +1207,7 @@ dependencies = [
  "p3-util",
  "rand 0.10.1",
  "serde",
- "thiserror 2.0.18",
+ "thiserror",
  "tracing",
  "tracing-subscriber",
 ]
@@ -1227,7 +1227,7 @@ dependencies = [
  "p3-challenger",
  "p3-field",
  "serde",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -1519,7 +1519,7 @@ dependencies = [
  "rand 0.10.1",
  "serde",
  "spin 0.10.0",
- "thiserror 2.0.18",
+ "thiserror",
  "tracing",
 ]
 
@@ -1649,7 +1649,7 @@ dependencies = [
  "p3-util",
  "rand 0.10.1",
  "serde",
- "thiserror 2.0.18",
+ "thiserror",
  "tracing",
 ]
 
@@ -1764,7 +1764,7 @@ dependencies = [
  "p3-maybe-rayon",
  "p3-util",
  "serde",
- "thiserror 2.0.18",
+ "thiserror",
  "tracing",
 ]
 
@@ -2376,31 +2376,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.18",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -2506,13 +2486,13 @@ dependencies = [
 
 [[package]]
 name = "tracing-forest"
-version = "0.1.6"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee40835db14ddd1e3ba414292272eddde9dad04d3d4b65509656414d1c42592f"
+checksum = "f09cb459317a3811f76644334473239d696cd8efc606963ae7d1c308cead3b74"
 dependencies = [
  "ansi_term",
  "smallvec",
- "thiserror 1.0.69",
+ "thiserror",
  "tracing",
  "tracing-subscriber",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ chacha20poly1305 = { default-features = false, version = "0.10" }
 curve25519-dalek = { default-features = false, version = "4" }
 der              = { default-features = false, version = "0.7" }
 ed25519-dalek    = { default-features = false, version = "2" }
-flume            = { default-features = false, version = "0.11.1" }
+flume            = { default-features = false, version = "0.12.0" }
 hex              = { default-features = false, version = "0.4" }
 hkdf             = { default-features = false, version = "0.12" }
 itertools        = "0.14"
@@ -95,7 +95,7 @@ rand               = { default-features = false, version = "0.10" }
 serde              = { default-features = false, features = ["alloc", "derive"], version = "1.0" }
 thiserror          = { default-features = false, version = "2.0" }
 tracing            = { default-features = false, features = ["attributes"], version = "0.1.37" }
-tracing-forest     = "0.1.6"
+tracing-forest     = "0.3.1"
 tracing-subscriber = { features = ["env-filter", "fmt", "std"], version = "0.3.17" }
 
 [workspace.lints.rust]

--- a/deny.toml
+++ b/deny.toml
@@ -39,9 +39,6 @@ multiple-versions = "deny"
 skip = [
   # Allow duplicate spin versions - transitively pulled by p3-dft and flume
   { name = "spin" },
-  # tracing-forest in miden-bench still depends on thiserror 1.x
-  { name = "thiserror" },
-  { name = "thiserror-impl" },
 ]
 skip-tree = [
   # Stable crypto crates still depend on rand_core 0.6 and chacha20 0.9.

--- a/miden-crypto-fuzz/Cargo.lock
+++ b/miden-crypto-fuzz/Cargo.lock
@@ -380,9 +380,9 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "flume"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+checksum = "5e139bc46ca777eb5efaf62df0ab8cc5fd400866427e56c68b22e414e53bd3be"
 dependencies = [
  "spin 0.9.8",
 ]


### PR DESCRIPTION
Actually closes #1035. Obviates and troubleshoots #1039.

This updates the dependency bumps from #1035 that are ready now: flume to 0.12.0 and tracing-forest to 0.3.1.

- tracing-forest now matches the version line already used by miden-node.

- der, hkdf, sha2, and sha3 stay on their current major lines. Their newer versions pull in a larger RustCrypto change.

- deny.toml no longer allows duplicate thiserror versions, since the tracing-forest update removes the old thiserror 1.x dependency.

Dependabot now opens smaller update PRs: Cargo updates are grouped by dependency across the workspace, GitHub Actions updates stay separate, and both use cooldowns with a one-PR limit.