### PR TITLE
ci: Fix Codspeed toolchain install

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -34,7 +34,8 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          rustup toolchain install --profile minimal
+          toolchain="$(awk -F '"' '/^channel[[:space:]]*=/{ print $2; exit }' rust-toolchain.toml)"
+          rustup toolchain install --profile minimal "${toolchain}"
 
       - name: Install LLVM/Clang
         uses: ./.github/actions/install-llvm


### PR DESCRIPTION
The Codspeed job failed while installing Rust because rustup toolchain install --profile minimal did not
  receive a toolchain name.

  This reads the pinned Rust channel from rust-toolchain.toml and passes it to rustup explicitly. This keeps
  Codspeed using the repo’s toolchain while avoiding runner-specific rustup behavior.