### PR TITLE
feat: add Display for DSA public keys and signatures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.27.0 (TBD)
 
 - [BREAKING] Upgraded the RustCrypto and dalek stack: `der`, `hkdf`, `sha2`, `sha3`, `k256`, `curve25519-dalek`, `ed25519-dalek`, and `x25519-dalek` ([#1045](https://github.com/0xMiden/crypto/pull/1045)).
+- Added `Display` (`0x`-prefixed lowercase hex) for the public key and signature types of all DSA schemes ([#1040](https://github.com/0xMiden/crypto/issues/1040)).
 
 ## 0.26.0 (06-02-2026)
 

--- a/miden-crypto/src/dsa/ecdsa_k256_keccak/mod.rs
+++ b/miden-crypto/src/dsa/ecdsa_k256_keccak/mod.rs
@@ -461,7 +461,7 @@ impl Deserializable for PublicKey {
 
 impl fmt::Display for PublicKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        super::write_hex(f, &self.to_bytes())
+        crate::utils::write_hex(f, &self.to_bytes())
     }
 }
 
@@ -491,7 +491,7 @@ impl Deserializable for Signature {
 
 impl fmt::Display for Signature {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        super::write_hex(f, &self.to_bytes())
+        crate::utils::write_hex(f, &self.to_bytes())
     }
 }
 

--- a/miden-crypto/src/dsa/ecdsa_k256_keccak/mod.rs
+++ b/miden-crypto/src/dsa/ecdsa_k256_keccak/mod.rs
@@ -2,6 +2,7 @@
 //! curve using Keccak to hash the messages when signing.
 
 use alloc::{string::ToString, vec::Vec};
+use core::fmt;
 
 use k256::{
     ecdh::diffie_hellman,
@@ -458,6 +459,12 @@ impl Deserializable for PublicKey {
     }
 }
 
+impl fmt::Display for PublicKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        super::write_hex(f, &self.to_bytes())
+    }
+}
+
 impl Serializable for Signature {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
         let mut bytes = [0u8; SIGNATURE_BYTES];
@@ -479,6 +486,12 @@ impl Deserializable for Signature {
         } else {
             Ok(Signature { r, s, v })
         }
+    }
+}
+
+impl fmt::Display for Signature {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        super::write_hex(f, &self.to_bytes())
     }
 }
 

--- a/miden-crypto/src/dsa/ecdsa_k256_keccak/tests.rs
+++ b/miden-crypto/src/dsa/ecdsa_k256_keccak/tests.rs
@@ -1,5 +1,7 @@
 #![cfg(test)]
 mod signing_key {
+    use alloc::string::{String, ToString};
+
     use miden_field::Felt;
     #[cfg(feature = "std")]
     use miden_field::Word;
@@ -158,6 +160,37 @@ mod signing_key {
         // Verify Display impl also elides
         let display_output = format!("{secret_key}");
         assert_eq!(display_output, "<elided secret for SigningKey>");
+    }
+
+    #[test]
+    fn test_public_key_and_signature_display_hex() {
+        let mut rng = seeded_rng([6u8; 32]);
+        let secret_key = SigningKey::with_rng(&mut rng);
+        let public_key = secret_key.public_key();
+        let message = [
+            Felt::new_unchecked(1),
+            Felt::new_unchecked(2),
+            Felt::new_unchecked(3),
+            Felt::new_unchecked(4),
+        ]
+        .into();
+        let signature = secret_key.sign(message);
+
+        // `Display` must render the canonical serialized bytes as `0x`-prefixed lowercase hex.
+        assert_eq!(public_key.to_string(), canonical_hex(&public_key.to_bytes()));
+        assert_eq!(signature.to_string(), canonical_hex(&signature.to_bytes()));
+        assert!(public_key.to_string().starts_with("0x"));
+        assert!(signature.to_string().starts_with("0x"));
+    }
+
+    /// Renders `bytes` as a `0x`-prefixed lowercase hex string, mirroring the expected `Display`
+    /// output.
+    fn canonical_hex(bytes: &[u8]) -> String {
+        let mut s = String::from("0x");
+        for byte in bytes {
+            s.push_str(&format!("{byte:02x}"));
+        }
+        s
     }
 
     #[cfg(feature = "std")]

--- a/miden-crypto/src/dsa/eddsa_25519_sha512/mod.rs
+++ b/miden-crypto/src/dsa/eddsa_25519_sha512/mod.rs
@@ -2,6 +2,7 @@
 //! the messages when signing.
 
 use alloc::{string::ToString, vec::Vec};
+use core::fmt;
 
 use der::{Decode, asn1::BitStringRef};
 use ed25519_dalek::{Signer, Verifier};
@@ -538,6 +539,12 @@ impl Deserializable for PublicKey {
     }
 }
 
+impl fmt::Display for PublicKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        super::write_hex(f, &self.to_bytes())
+    }
+}
+
 impl Serializable for Signature {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
         target.write_bytes(&self.inner.to_bytes())
@@ -549,5 +556,11 @@ impl Deserializable for Signature {
         let bytes: [u8; SIGNATURE_BYTES] = source.read_array()?;
         let inner = ed25519_dalek::Signature::from_bytes(&bytes);
         Ok(Self { inner })
+    }
+}
+
+impl fmt::Display for Signature {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        super::write_hex(f, &self.to_bytes())
     }
 }

--- a/miden-crypto/src/dsa/eddsa_25519_sha512/mod.rs
+++ b/miden-crypto/src/dsa/eddsa_25519_sha512/mod.rs
@@ -541,7 +541,7 @@ impl Deserializable for PublicKey {
 
 impl fmt::Display for PublicKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        super::write_hex(f, &self.to_bytes())
+        crate::utils::write_hex(f, &self.to_bytes())
     }
 }
 
@@ -561,6 +561,6 @@ impl Deserializable for Signature {
 
 impl fmt::Display for Signature {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        super::write_hex(f, &self.to_bytes())
+        crate::utils::write_hex(f, &self.to_bytes())
     }
 }

--- a/miden-crypto/src/dsa/eddsa_25519_sha512/tests.rs
+++ b/miden-crypto/src/dsa/eddsa_25519_sha512/tests.rs
@@ -1,5 +1,7 @@
 #![cfg(test)]
 mod signing_key {
+    use alloc::string::{String, ToString};
+
     use miden_field::{Felt, Word};
     use miden_serde_utils::{Deserializable, Serializable};
 
@@ -52,6 +54,30 @@ mod signing_key {
         // Verify Display impl also elides
         let display_output = format!("{sk}");
         assert_eq!(display_output, "<elided secret for SigningKey>");
+    }
+
+    #[test]
+    fn test_public_key_and_signature_display_hex() {
+        let mut rng = seeded_rng([4u8; 32]);
+        let sk = SigningKey::with_rng(&mut rng);
+        let pk = sk.public_key();
+        let sig = sk.sign(Word::default());
+
+        // `Display` must render the canonical serialized bytes as `0x`-prefixed lowercase hex.
+        assert_eq!(pk.to_string(), canonical_hex(&pk.to_bytes()));
+        assert_eq!(sig.to_string(), canonical_hex(&sig.to_bytes()));
+        assert!(pk.to_string().starts_with("0x"));
+        assert!(sig.to_string().starts_with("0x"));
+    }
+
+    /// Renders `bytes` as a `0x`-prefixed lowercase hex string, mirroring the expected `Display`
+    /// output.
+    fn canonical_hex(bytes: &[u8]) -> String {
+        let mut s = String::from("0x");
+        for byte in bytes {
+            s.push_str(&format!("{byte:02x}"));
+        }
+        s
     }
 
     #[test]

--- a/miden-crypto/src/dsa/falcon512_poseidon2/keys/public_key.rs
+++ b/miden-crypto/src/dsa/falcon512_poseidon2/keys/public_key.rs
@@ -88,7 +88,7 @@ impl Serializable for &PublicKey {
 
 impl fmt::Display for PublicKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        crate::dsa::write_hex(f, &self.to_bytes())
+        crate::utils::write_hex(f, &self.to_bytes())
     }
 }
 

--- a/miden-crypto/src/dsa/falcon512_poseidon2/keys/public_key.rs
+++ b/miden-crypto/src/dsa/falcon512_poseidon2/keys/public_key.rs
@@ -1,7 +1,7 @@
 //! Public key types for the Poseidon2 Falcon 512 digital signature scheme used in Miden VM.
 
 use alloc::{string::ToString, vec::Vec};
-use core::ops::Deref;
+use core::{fmt, ops::Deref};
 
 use num::Zero;
 
@@ -83,6 +83,12 @@ impl Serializable for &PublicKey {
         }
 
         target.write(buf);
+    }
+}
+
+impl fmt::Display for PublicKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        crate::dsa::write_hex(f, &self.to_bytes())
     }
 }
 

--- a/miden-crypto/src/dsa/falcon512_poseidon2/signature.rs
+++ b/miden-crypto/src/dsa/falcon512_poseidon2/signature.rs
@@ -141,7 +141,7 @@ impl Deserializable for Signature {
 
 impl fmt::Display for Signature {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        crate::dsa::write_hex(f, &self.to_bytes())
+        crate::utils::write_hex(f, &self.to_bytes())
     }
 }
 

--- a/miden-crypto/src/dsa/falcon512_poseidon2/signature.rs
+++ b/miden-crypto/src/dsa/falcon512_poseidon2/signature.rs
@@ -1,5 +1,5 @@
 use alloc::string::ToString;
-use core::ops::Deref;
+use core::{fmt, ops::Deref};
 
 use num::Zero;
 
@@ -136,6 +136,12 @@ impl Deserializable for Signature {
         let h = source.read()?;
 
         Ok(Self { header, nonce, s2, h })
+    }
+}
+
+impl fmt::Display for Signature {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        crate::dsa::write_hex(f, &self.to_bytes())
     }
 }
 

--- a/miden-crypto/src/dsa/falcon512_poseidon2/tests/mod.rs
+++ b/miden-crypto/src/dsa/falcon512_poseidon2/tests/mod.rs
@@ -1,3 +1,5 @@
+use alloc::string::{String, ToString};
+
 use data::{
     DETERMINISTIC_SIGNATURE, EXPECTED_SIG, EXPECTED_SIG_POLYS, NUM_TEST_VECTORS, SK_POLYS,
     SYNC_DATA_FOR_TEST_VECTOR,
@@ -110,6 +112,33 @@ fn test_signature_determinism() {
     let serialized_signature = signature.to_bytes();
 
     assert_eq!(serialized_signature, DETERMINISTIC_SIGNATURE);
+}
+
+#[test]
+fn test_public_key_and_signature_display_hex() {
+    let seed = [0_u8; 32];
+    let mut rng = ChaCha20Rng::from_seed(seed);
+
+    let sk = SecretKey::with_rng(&mut rng);
+    let pk = sk.public_key();
+    let signature = sk.sign(b"data".into());
+
+    // `Display` must render the canonical serialized bytes as `0x`-prefixed lowercase hex.
+    // `Serializable` is implemented for `&PublicKey`, so the borrow is required here.
+    assert_eq!(pk.to_string(), canonical_hex(&(&pk).to_bytes()));
+    assert_eq!(signature.to_string(), canonical_hex(&signature.to_bytes()));
+    assert!(pk.to_string().starts_with("0x"));
+    assert!(signature.to_string().starts_with("0x"));
+}
+
+/// Renders `bytes` as a `0x`-prefixed lowercase hex string, mirroring the expected `Display`
+/// output.
+fn canonical_hex(bytes: &[u8]) -> String {
+    let mut s = String::from("0x");
+    for byte in bytes {
+        s.push_str(&format!("{byte:02x}"));
+    }
+    s
 }
 
 #[test]

--- a/miden-crypto/src/dsa/mod.rs
+++ b/miden-crypto/src/dsa/mod.rs
@@ -1,21 +1,5 @@
 //! Digital signature schemes supported by default in the Miden VM.
 
-use core::fmt;
-
 pub mod ecdsa_k256_keccak;
 pub mod eddsa_25519_sha512;
 pub mod falcon512_poseidon2;
-
-/// Writes `bytes` into the formatter as a `0x`-prefixed, lowercase hexadecimal string.
-///
-/// Shared by the `Display` implementations of the public key and signature types across the
-/// supported signature schemes, so that `%`-formatting (e.g. in `tracing` logs) produces compact,
-/// canonical output that is easy to compare across nodes. This mirrors the format produced by
-/// [`crate::utils::bytes_to_hex_string`], which only accepts fixed-size arrays.
-pub(crate) fn write_hex(f: &mut fmt::Formatter<'_>, bytes: &[u8]) -> fmt::Result {
-    write!(f, "0x")?;
-    for byte in bytes {
-        write!(f, "{byte:02x}")?;
-    }
-    Ok(())
-}

--- a/miden-crypto/src/dsa/mod.rs
+++ b/miden-crypto/src/dsa/mod.rs
@@ -1,5 +1,21 @@
 //! Digital signature schemes supported by default in the Miden VM.
 
+use core::fmt;
+
 pub mod ecdsa_k256_keccak;
 pub mod eddsa_25519_sha512;
 pub mod falcon512_poseidon2;
+
+/// Writes `bytes` into the formatter as a `0x`-prefixed, lowercase hexadecimal string.
+///
+/// Shared by the `Display` implementations of the public key and signature types across the
+/// supported signature schemes, so that `%`-formatting (e.g. in `tracing` logs) produces compact,
+/// canonical output that is easy to compare across nodes. This mirrors the format produced by
+/// [`crate::utils::bytes_to_hex_string`], which only accepts fixed-size arrays.
+pub(crate) fn write_hex(f: &mut fmt::Formatter<'_>, bytes: &[u8]) -> fmt::Result {
+    write!(f, "0x")?;
+    for byte in bytes {
+        write!(f, "{byte:02x}")?;
+    }
+    Ok(())
+}

--- a/miden-crypto/src/utils/mod.rs
+++ b/miden-crypto/src/utils/mod.rs
@@ -42,6 +42,19 @@ pub fn word_to_hex(w: &Word) -> Result<String, fmt::Error> {
     Ok(s)
 }
 
+/// Writes `bytes` into the formatter as a `0x`-prefixed, lowercase hexadecimal string.
+///
+/// Useful for `Display` implementations that want compact, canonical hex output (e.g. in `tracing`
+/// logs) without allocating an intermediate `String`. This mirrors the format produced by
+/// [`bytes_to_hex_string`], which only accepts fixed-size arrays.
+pub fn write_hex(f: &mut fmt::Formatter<'_>, bytes: &[u8]) -> fmt::Result {
+    write!(f, "0x")?;
+    for byte in bytes {
+        write!(f, "{byte:02x}")?;
+    }
+    Ok(())
+}
+
 pub use miden_field::utils::{HexParseError, bytes_to_hex_string, hex_to_bytes};
 
 // CONVERSIONS BETWEEN BYTES AND ELEMENTS


### PR DESCRIPTION
Closes #1040.

### Why

These types only have Debug today. When signature verification fails and we log the key and signature, the output is rough: ECDSA prints the public key as nested k256 internals and the signature as decimal byte arrays. It's hard to read, and basically impossible to compare across nodes when you're tracking down a bad signature.

### What changed

Display is now implemented for the public key and signature types in all three schemes:

- `ecdsa_k256_keccak::{PublicKey, Signature}`
- `eddsa_25519_sha512::{PublicKey, Signature}`
- `falcon512_poseidon2::{PublicKey, Signature}`

Each prints the canonical serialized bytes as 0x-prefixed lowercase hex, so logs can move from `?` to `%`:

```rust
validator_key = %header.validator_key(),
signature = %signature,
```

Debug is left exactly as it was.

### How

I added a small `pub(crate)` helper, `dsa::write_hex`, that writes a byte slice as 0x lowercase hex into a Formatter. It produces the same format as the existing `utils::bytes_to_hex_string`, which I couldn't reuse directly since it only takes fixed-size arrays and `to_bytes()` returns a Vec. Each Display impl just calls `write_hex(f, &self.to_bytes())`.

### Secret keys stay elided

The secret types are already safe. `SecretKey`, `SigningKey`, and `KeyExchangeKey` derive `SilentDebug`/`SilentDisplay` (they print `<elided secret for TypeName>`), and the existing redaction tests cover that. Nothing here gives a secret type a Display that leaks bytes.

### Tests

Added `test_public_key_and_signature_display_hex` to each scheme. It checks the Display output starts with 0x and matches the hex of the canonical serialization.

### Checks run locally

- `cargo +nightly fmt --all --check`
- `cargo xclippy` (curated lint set, `-Dwarnings`)
- `cargo test -p miden-crypto` (647 unit + 28 doctests pass)

One small judgment call: for the ECDSA signature I used the canonical `Serializable` bytes (r, s, v), matching "canonical serialized bytes" in the issue. Happy to switch it to the 64-byte SEC1 form if you'd prefer.