### PR TITLE
test: add doctests for documented contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [BREAKING] Bumped Plonky3 upstream dependencies to v0.6.0 ([#1053](https://github.com/0xMiden/crypto/pull/1053)).
 - [BREAKING] Make `Felt::Packing` resolve to the SIMD-packed `PackedFelt` from Plonky3 ([#1060](https://github.com/0xMiden/crypto/pull/1060)).
 - Improved LargeSmt RocksDB defaults, added per-DB memory-budget controls, and exposed durability mode selection ([#1056](https://github.com/0xMiden/crypto/pull/1056)).
+- Added doctests for ECDSA signature serialization, sponge state sizing, SMT sorted entries, and lifted AIR Fiat-Shamir docs ([#1049](https://github.com/0xMiden/crypto/pull/1049)).
 
 ## 0.26.0 (06-02-2026)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1336,6 +1336,7 @@ dependencies = [
 name = "miden-lifted-air"
 version = "0.27.0"
 dependencies = [
+ "miden-field",
  "p3-air",
  "p3-challenger",
  "p3-field",

--- a/miden-crypto/src/dsa/ecdsa_k256_keccak/mod.rs
+++ b/miden-crypto/src/dsa/ecdsa_k256_keccak/mod.rs
@@ -311,7 +311,7 @@ pub enum PublicKeyError {
 ///
 /// This implementation supports 2 serialization formats:
 ///
-/// ### Custom Format (66 bytes):
+/// ### Custom Format (65 bytes):
 /// - Bytes 0-31: r component (32 bytes, big-endian)
 /// - Bytes 32-63: s component (32 bytes, big-endian)
 /// - Byte 64: recovery ID (v) - values 0-3
@@ -320,6 +320,32 @@ pub enum PublicKeyError {
 /// - Bytes 0-31: r component (32 bytes, big-endian)
 /// - Bytes 32-63: s component (32 bytes, big-endian)
 /// - Note: Recovery ID
+///
+/// # Examples
+///
+/// ```
+/// use miden_crypto::{
+///     Felt, Word,
+///     dsa::ecdsa_k256_keccak::{Signature, SigningKey},
+///     rand::test_utils::seeded_rng,
+/// };
+/// use miden_serde_utils::{Deserializable, Serializable};
+///
+/// let mut rng = seeded_rng([7; 32]);
+/// let signing_key = SigningKey::with_rng(&mut rng);
+/// let message = Word::new([
+///     Felt::new_unchecked(1),
+///     Felt::new_unchecked(2),
+///     Felt::new_unchecked(3),
+///     Felt::new_unchecked(4),
+/// ]);
+///
+/// let signature = signing_key.sign(message);
+/// let encoded = signature.to_bytes();
+///
+/// assert_eq!(encoded.len(), 65);
+/// assert_eq!(Signature::read_from_bytes(&encoded).unwrap(), signature);
+/// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Signature {
     r: [u8; SCALARS_SIZE_BYTES],

--- a/miden-crypto/src/hash/algebraic_sponge/poseidon2/mod.rs
+++ b/miden-crypto/src/hash/algebraic_sponge/poseidon2/mod.rs
@@ -130,8 +130,20 @@ impl Poseidon2 {
     /// Number of internal rounds.
     pub const NUM_INTERNAL_ROUNDS: usize = NUM_INTERNAL_ROUNDS;
 
-    /// Sponge state is set to 12 field elements or 768 bytes; 8 elements are reserved for the
-    /// rate and the remaining 4 elements are reserved for the capacity.
+    /// Sponge state is set to 12 field elements, or 96 bytes / 768 bits; 8 elements are
+    /// reserved for the rate and the remaining 4 elements are reserved for the capacity.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use miden_crypto::{Word, hash::poseidon2::Poseidon2};
+    ///
+    /// const FELT_SERIALIZED_SIZE: usize = Word::SERIALIZED_SIZE / Word::NUM_ELEMENTS;
+    ///
+    /// assert_eq!(Poseidon2::STATE_WIDTH * FELT_SERIALIZED_SIZE, 96);
+    /// assert_eq!(Poseidon2::RATE_RANGE.len(), 8);
+    /// assert_eq!(Poseidon2::CAPACITY_RANGE.len(), 4);
+    /// ```
     pub const STATE_WIDTH: usize = STATE_WIDTH;
 
     /// The rate portion of the state is located in elements 0 through 7 (inclusive).
@@ -336,8 +348,8 @@ impl Poseidon2Permutation256 {
     /// Number of internal rounds.
     pub const NUM_INTERNAL_ROUNDS: usize = Poseidon2::NUM_INTERNAL_ROUNDS;
 
-    /// Sponge state is set to 12 field elements or 768 bytes; 8 elements are reserved for rate and
-    /// the remaining 4 elements are reserved for capacity.
+    /// Sponge state is set to 12 field elements, or 96 bytes / 768 bits; 8 elements are
+    /// reserved for rate and the remaining 4 elements are reserved for capacity.
     pub const STATE_WIDTH: usize = STATE_WIDTH;
 
     /// The rate portion of the state is located in elements 0 through 7 (inclusive).

--- a/miden-crypto/src/hash/algebraic_sponge/rescue/rpo/mod.rs
+++ b/miden-crypto/src/hash/algebraic_sponge/rescue/rpo/mod.rs
@@ -92,8 +92,20 @@ impl Rpo256 {
     /// The number of rounds is set to 7 to target 128-bit security level.
     pub const NUM_ROUNDS: usize = NUM_ROUNDS;
 
-    /// Sponge state is set to 12 field elements or 768 bytes; 8 elements are reserved for the
-    /// rate and the remaining 4 elements are reserved for the capacity.
+    /// Sponge state is set to 12 field elements, or 96 bytes / 768 bits; 8 elements are
+    /// reserved for the rate and the remaining 4 elements are reserved for the capacity.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use miden_crypto::{Word, hash::rpo::Rpo256};
+    ///
+    /// const FELT_SERIALIZED_SIZE: usize = Word::SERIALIZED_SIZE / Word::NUM_ELEMENTS;
+    ///
+    /// assert_eq!(Rpo256::STATE_WIDTH * FELT_SERIALIZED_SIZE, 96);
+    /// assert_eq!(Rpo256::RATE_RANGE.len(), 8);
+    /// assert_eq!(Rpo256::CAPACITY_RANGE.len(), 4);
+    /// ```
     pub const STATE_WIDTH: usize = STATE_WIDTH;
 
     /// The rate portion of the state is located in elements 0 through 7 (inclusive).
@@ -233,8 +245,8 @@ impl RpoPermutation256 {
     /// The number of rounds is set to 7 to target 128-bit security level.
     pub const NUM_ROUNDS: usize = Rpo256::NUM_ROUNDS;
 
-    /// Sponge state is set to 12 field elements or 768 bytes; 8 elements are reserved for rate and
-    /// the remaining 4 elements are reserved for capacity.
+    /// Sponge state is set to 12 field elements, or 96 bytes / 768 bits; 8 elements are
+    /// reserved for rate and the remaining 4 elements are reserved for capacity.
     pub const STATE_WIDTH: usize = STATE_WIDTH;
 
     /// The rate portion of the state is located in elements 0 through 7 (inclusive).

--- a/miden-crypto/src/hash/algebraic_sponge/rescue/rpx/mod.rs
+++ b/miden-crypto/src/hash/algebraic_sponge/rescue/rpx/mod.rs
@@ -93,8 +93,20 @@ impl Rpx256 {
     /// Target collision resistance level in bits.
     pub const COLLISION_RESISTANCE: u32 = 128;
 
-    /// Sponge state is set to 12 field elements or 768 bytes; 8 elements are reserved for the
-    /// rate and the remaining 4 elements are reserved for the capacity.
+    /// Sponge state is set to 12 field elements, or 96 bytes / 768 bits; 8 elements are
+    /// reserved for the rate and the remaining 4 elements are reserved for the capacity.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use miden_crypto::{Word, hash::rpx::Rpx256};
+    ///
+    /// const FELT_SERIALIZED_SIZE: usize = Word::SERIALIZED_SIZE / Word::NUM_ELEMENTS;
+    ///
+    /// assert_eq!(Rpx256::STATE_WIDTH * FELT_SERIALIZED_SIZE, 96);
+    /// assert_eq!(Rpx256::RATE_RANGE.len(), 8);
+    /// assert_eq!(Rpx256::CAPACITY_RANGE.len(), 4);
+    /// ```
     pub const STATE_WIDTH: usize = STATE_WIDTH;
 
     /// The rate portion of the state is located in elements 0 through 7 (inclusive).
@@ -356,8 +368,8 @@ impl RpxPermutation256 {
     // CONSTANTS
     // --------------------------------------------------------------------------------------------
 
-    /// Sponge state is set to 12 field elements or 768 bytes; 8 elements are reserved for rate and
-    /// the remaining 4 elements are reserved for capacity.
+    /// Sponge state is set to 12 field elements, or 96 bytes / 768 bits; 8 elements are
+    /// reserved for rate and the remaining 4 elements are reserved for capacity.
     pub const STATE_WIDTH: usize = STATE_WIDTH;
 
     /// The rate portion of the state is located in elements 0 through 7 (inclusive).

--- a/miden-crypto/src/merkle/smt/full/mod.rs
+++ b/miden-crypto/src/merkle/smt/full/mod.rs
@@ -152,11 +152,44 @@ impl Smt {
         }
     }
 
-    /// Similar to `with_entries` but avoids the overhead of sorting if the entries are already
-    /// sorted.
+    /// Similar to [`Self::with_entries`] but avoids the overhead of sorting if the entries are
+    /// already sorted by leaf index.
     ///
     /// This only applies if the "concurrent" feature is enabled. Without the feature, the behavior
-    /// is equivalent to `with_entiries`.
+    /// is equivalent to [`Self::with_entries`].
+    ///
+    /// When the "concurrent" feature is enabled, entries must be sorted by
+    /// `LeafIndex::<SMT_DEPTH>::from(key).position()`, not by key.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use miden_crypto::{
+    ///     Felt, Word,
+    ///     merkle::smt::{LeafIndex, SMT_DEPTH, Smt},
+    /// };
+    ///
+    /// fn word(a: u64, b: u64, c: u64, d: u64) -> Word {
+    ///     Word::new([
+    ///         Felt::new_unchecked(a),
+    ///         Felt::new_unchecked(b),
+    ///         Felt::new_unchecked(c),
+    ///         Felt::new_unchecked(d),
+    ///     ])
+    /// }
+    ///
+    /// let mut entries = vec![
+    ///     (word(1, 0, 0, 3), word(10, 0, 0, 0)),
+    ///     (word(0, 0, 0, 1), word(20, 0, 0, 0)),
+    ///     (word(0, 1, 0, 2), word(30, 0, 0, 0)),
+    /// ];
+    ///
+    /// let expected = Smt::with_entries(entries.clone()).unwrap();
+    /// entries.sort_by_key(|(key, _)| LeafIndex::<SMT_DEPTH>::from(*key).position());
+    /// let actual = Smt::with_sorted_entries(entries).unwrap();
+    ///
+    /// assert_eq!(actual, expected);
+    /// ```
     ///
     /// # Errors
     /// Returns an error if inserting a key-value pair would exceed [`MAX_LEAF_ENTRIES`] (1024

--- a/stark/SECURITY.md
+++ b/stark/SECURITY.md
@@ -59,8 +59,8 @@ These are requirements on *applications* composing these crates.
   metadata, and any other statement metadata not owned by `Statement::observe`
   into the Fiat-Shamir challenger state, identically on both prover and verifier.
 - If you override `MultiAir::observe`, you MUST preserve equivalent binding of
-  `air_inputs`, `max_aux_inputs`, `aux_inputs.len()`, and `aux_inputs` before
-  challenges are derived.
+  `air_inputs`, `air_inputs.len()`, `max_aux_inputs`, `aux_inputs.len()`, and
+  `aux_inputs` before challenges are derived.
 - You MUST enforce transcript boundaries / canonicality at the protocol boundary.
   The lifted STARK verifier rejects trailing data; if you compose the PCS
   separately, use `verify_strict` or check `channel.is_empty()` at

--- a/stark/SECURITY.md
+++ b/stark/SECURITY.md
@@ -41,19 +41,26 @@ Assume:
 - Hash/compression primitives are collision-resistant.
 - Fiat-Shamir is modeled as a random oracle (or an appropriate heuristic).
 
-Caller-provided "statement data" is *not* consistently observed into the
-challenger by these libraries. In particular, **public inputs** are passed
-out-of-band to prover/verifier APIs. If an input can vary per statement, the
-application must bind it into Fiat-Shamir on *both* prover and verifier.
+With the default `MultiAir::observe` implementation, statement-owned inputs
+(`air_inputs` and `aux_inputs`) are observed into the challenger by
+`Statement::observe` before the prover/verifier derives challenges. The runnable
+Rustdoc example on `Statement::observe` asserts that default binding sequence.
+Custom `MultiAir::observe` implementations can extend or replace that sequence.
+
+The remaining caller-owned binding gap is the trusted AIR identity and
+configuration: the default binding does not canonically bind the `MultiAir` AIR
+collection, AIR versions/configuration, or `eval_external` logic.
 
 ## Normative Requirements (MUST)
 
 These are requirements on *applications* composing these crates.
 
-- You MUST bind all per-statement out-of-band inputs (notably `public_values`,
-  AIR identity/version tags, commitment roots, widths/heights metadata, and any
-  statement metadata) into the Fiat-Shamir challenger state, identically on both
-  prover and verifier.
+- You MUST bind AIR identity/version tags, commitment roots, widths/heights
+  metadata, and any other statement metadata not owned by `Statement::observe`
+  into the Fiat-Shamir challenger state, identically on both prover and verifier.
+- If you override `MultiAir::observe`, you MUST preserve equivalent binding of
+  `air_inputs`, `max_aux_inputs`, `aux_inputs.len()`, and `aux_inputs` before
+  challenges are derived.
 - You MUST enforce transcript boundaries / canonicality at the protocol boundary.
   The lifted STARK verifier rejects trailing data; if you compose the PCS
   separately, use `verify_strict` or check `channel.is_empty()` at
@@ -69,7 +76,7 @@ These are requirements on *applications* composing these crates.
 
 Concrete examples of statement data that the application must treat explicitly:
 
-- `public_values`
+- Extra application public data not passed through `Statement::air_inputs`
 - AIR identity / version tags (if multiple AIRs exist)
 - configuration choices not already committed inside the transcript
 

--- a/stark/miden-lifted-air/Cargo.toml
+++ b/stark/miden-lifted-air/Cargo.toml
@@ -10,7 +10,7 @@ rust-version.workspace = true
 version.workspace      = true
 
 [lib]
-doctest = false
+doctest = true
 test    = false
 
 [dependencies]
@@ -21,6 +21,9 @@ p3-matrix.workspace     = true
 p3-util.workspace       = true
 
 thiserror.workspace = true
+
+[dev-dependencies]
+miden-field.workspace = true
 
 [lints]
 workspace = true

--- a/stark/miden-lifted-air/src/air.rs
+++ b/stark/miden-lifted-air/src/air.rs
@@ -293,6 +293,8 @@ where
     /// observes the instance count and `log_trace_heights` separately after this
     /// hook, but passes the heights here so custom bindings can include AIR
     /// metadata that depends on the prover-chosen trace ordering or heights.
+    /// See [`Statement::observe`](crate::Statement::observe) for a runnable
+    /// example of the default binding sequence.
     ///
     /// # Soundness gap (TODO)
     ///

--- a/stark/miden-lifted-air/src/statement.rs
+++ b/stark/miden-lifted-air/src/statement.rs
@@ -113,6 +113,106 @@ where
     /// `log_trace_heights` in instance order after this call. Heights are passed
     /// here only so custom `MultiAir` bindings can include height-dependent
     /// statement data.
+    ///
+    /// The default [`MultiAir::observe`] implementation absorbs, in order, the
+    /// `air_inputs` length, `air_inputs`, [`MultiAir::max_aux_inputs`], the
+    /// `aux_inputs` length, and `aux_inputs`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use miden_field::Felt;
+    /// use miden_lifted_air::{BaseAir, LiftedAir, LiftedAirBuilder, MultiAir, Statement};
+    /// use p3_challenger::CanObserve;
+    /// use p3_matrix::{Matrix, dense::RowMajorMatrix};
+    ///
+    /// #[derive(Clone)]
+    /// struct ExampleAir;
+    ///
+    /// impl BaseAir<Felt> for ExampleAir {
+    ///     fn width(&self) -> usize {
+    ///         1
+    ///     }
+    ///
+    ///     fn num_public_values(&self) -> usize {
+    ///         2
+    ///     }
+    /// }
+    ///
+    /// impl LiftedAir<Felt, Felt> for ExampleAir {
+    ///     fn num_randomness(&self) -> usize {
+    ///         0
+    ///     }
+    ///
+    ///     fn aux_width(&self) -> usize {
+    ///         1
+    ///     }
+    ///
+    ///     fn num_aux_values(&self) -> usize {
+    ///         0
+    ///     }
+    ///
+    ///     fn build_aux_trace(
+    ///         &self,
+    ///         main: &RowMajorMatrix<Felt>,
+    ///         _air_inputs: &[Felt],
+    ///         _aux_inputs: &[Felt],
+    ///         _challenges: &[Felt],
+    ///     ) -> (RowMajorMatrix<Felt>, Vec<Felt>) {
+    ///         (RowMajorMatrix::new(vec![Felt::ZERO; main.height()], 1), Vec::new())
+    ///     }
+    ///
+    ///     fn eval<AB: LiftedAirBuilder<F = Felt>>(&self, _builder: &mut AB) {}
+    /// }
+    ///
+    /// struct ExampleMultiAir {
+    ///     airs: [ExampleAir; 1],
+    /// }
+    ///
+    /// impl MultiAir<Felt, Felt> for ExampleMultiAir {
+    ///     type Air = ExampleAir;
+    ///
+    ///     fn airs(&self) -> &[Self::Air] {
+    ///         &self.airs
+    ///     }
+    ///
+    ///     fn max_aux_inputs(&self) -> usize {
+    ///         3
+    ///     }
+    /// }
+    ///
+    /// #[derive(Default)]
+    /// struct RecordingChallenger(Vec<Felt>);
+    ///
+    /// impl CanObserve<Felt> for RecordingChallenger {
+    ///     fn observe(&mut self, value: Felt) {
+    ///         self.0.push(value);
+    ///     }
+    /// }
+    ///
+    /// let statement = Statement::<Felt, Felt, _>::new(
+    ///     ExampleMultiAir { airs: [ExampleAir] },
+    ///     vec![Felt::new_unchecked(10), Felt::new_unchecked(11)],
+    ///     vec![Felt::new_unchecked(20), Felt::new_unchecked(21)],
+    /// )
+    /// .unwrap();
+    ///
+    /// let mut challenger = RecordingChallenger::default();
+    /// statement.observe(&mut challenger, &[3]);
+    ///
+    /// assert_eq!(
+    ///     challenger.0,
+    ///     vec![
+    ///         Felt::new_unchecked(2),
+    ///         Felt::new_unchecked(10),
+    ///         Felt::new_unchecked(11),
+    ///         Felt::new_unchecked(3),
+    ///         Felt::new_unchecked(2),
+    ///         Felt::new_unchecked(20),
+    ///         Felt::new_unchecked(21),
+    ///     ],
+    /// );
+    /// ```
     pub fn observe<C: CanObserve<F>>(&self, challenger: &mut C, log_trace_heights: &[u8]) {
         self.multi_air
             .observe(challenger, &self.air_inputs, &self.aux_inputs, log_trace_heights);


### PR DESCRIPTION
This can be seen as a bare bones version of the approach suggested in 0xMiden/miden-vm#2221, but using regular runnable Rust doc tests to cover for documentation--code drift.

-  ECDSA k256 Keccak signatures now document the custom format as 65 bytes, with a deterministic sign, serialize, length check, and deserialize round trip.
-  Poseidon2, RPO, and RPX now describe the sponge state as 96 bytes / 768 bits, and check state width, rate, and capacity constants.
-  `Smt::with_sorted_entries` now documents sorting by `LeafIndex::<SMT_DEPTH>::from(key).position()` and checks it against `Smt::with_entries`.
- Lifted AIR docs now show the default Fiat-Shamir binding order for `Statement::observe` / `MultiAir::observe`. stark/SECURITY.md names the remaining caller duties, including custom `MultiAir::observe` overrides.