### PR TITLE
perf: use faster dft for PeriodicPolys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.27.0 (TBD)
 
 - [BREAKING] Upgraded the RustCrypto and dalek stack: `der`, `hkdf`, `sha2`, `sha3`, `k256`, `curve25519-dalek`, `ed25519-dalek`, and `x25519-dalek` ([#1045](https://github.com/0xMiden/crypto/pull/1045)).
+- Use faster DFT algorithm for `PeriodicPolys` ([#1054](https://github.com/0xMiden/crypto/pull/1054)).
 
 ## 0.26.0 (06-02-2026)
 

--- a/stark/miden-lifted-stark/src/verifier/periodic.rs
+++ b/stark/miden-lifted-stark/src/verifier/periodic.rs
@@ -7,7 +7,7 @@ extern crate alloc;
 
 use alloc::vec::Vec;
 
-use p3_dft::{NaiveDft, TwoAdicSubgroupDft};
+use p3_dft::{Radix2DFTSmallBatch, TwoAdicSubgroupDft};
 use p3_field::{ExtensionField, TwoAdicField};
 
 use crate::util::horner::horner_acc;
@@ -33,7 +33,7 @@ impl<F: TwoAdicField> PeriodicPolys<F> {
     /// [`assert_multi_air_valid`](miden_lifted_air::debug::assert_multi_air_valid) for the
     /// debug-only check).
     pub fn new(column_evals: &[Vec<F>]) -> Self {
-        let dft = NaiveDft;
+        let dft = Radix2DFTSmallBatch::<F>::default();
         let mut polys = Vec::with_capacity(column_evals.len());
 
         for (i, column) in column_evals.iter().enumerate() {


### PR DESCRIPTION
## Describe your changes

I noticed we were using `NaiveDft` which may have an impact on performance. Below are some results I got for h=2^12:


- Scaling with AIR count (4 periodic cols, period 128):

```bash
  ┌──────┬───────────────────┬─────────────┬───────┐
  │ AIRs │ NaiveDft (before) │ FFT (after) │ saved │
  ├──────┼───────────────────┼─────────────┼───────┤
  │ 1    │ 770 µs            │ 576 µs      │ 25%   │
  ├──────┼───────────────────┼─────────────┼───────┤
  │ 4    │ 2.56 ms           │ 1.42 ms     │ 44%   │
  ├──────┼───────────────────┼─────────────┼───────┤
  │ 8    │ 4.87 ms           │ 2.69 ms     │ 45%   │
  └──────┴───────────────────┴─────────────┴───────┘
```

- Scaling with periodic period (8 AIRs)
```
  ┌────────┬─────────┬─────────┬─────────────┐
  │ period │ before  │  after  │    saved    │
  ├────────┼─────────┼─────────┼─────────────┤
  │ 8      │ 2.54 ms │ 2.61 ms │   (noise)   │
  ├────────┼─────────┼─────────┼─────────────┤
  │ 64     │ 3.13 ms │ 2.38 ms │ 24%         │
  ├────────┼─────────┼─────────┼─────────────┤
  │ 256    │ 9.73 ms │ 2.91 ms │ 70%         │
  └────────┴─────────┴─────────┴─────────────┘
```

## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
