### PR TITLE
feat: add zeroizing read helper for sensitive deserialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 0.28.0 (TBD)
 
+- Added a zeroizing read helper for deserializing sensitive material, fixing secret-key read buffers that were not wiped on error paths (ECDSA) or at all (Falcon, Poseidon2 AEAD) ([#1057](https://github.com/0xMiden/crypto/pull/1057)).
+
 ## 0.27.0 (2026-06-19)
 
 - [BREAKING] Upgraded the RustCrypto and dalek stack: `der`, `hkdf`, `sha2`, `sha3`, `k256`, `curve25519-dalek`, `ed25519-dalek`, and `x25519-dalek` ([#1045](https://github.com/0xMiden/crypto/pull/1045)).

--- a/miden-crypto/src/aead/aead_poseidon2/mod.rs
+++ b/miden-crypto/src/aead/aead_poseidon2/mod.rs
@@ -25,7 +25,7 @@ use crate::{
     utils::{
         ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable,
         bytes_to_elements_exact, bytes_to_elements_with_padding, elements_to_bytes,
-        padded_elements_to_bytes,
+        padded_elements_to_bytes, read_sensitive_array,
         zeroize::{Zeroize, ZeroizeOnDrop},
     },
 };
@@ -629,9 +629,9 @@ impl Serializable for SecretKey {
 
 impl Deserializable for SecretKey {
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
-        let bytes: [u8; SK_SIZE_BYTES] = source.read_array()?;
+        let bytes = read_sensitive_array::<SK_SIZE_BYTES, _>(source)?;
 
-        match bytes_to_elements_exact(&bytes) {
+        match bytes_to_elements_exact(bytes.as_slice()) {
             Some(inner) => {
                 let inner: [Felt; 4] = inner.try_into().map_err(|_| {
                     DeserializationError::InvalidValue("malformed secret key".to_string())

--- a/miden-crypto/src/dsa/ecdsa_k256_keccak/mod.rs
+++ b/miden-crypto/src/dsa/ecdsa_k256_keccak/mod.rs
@@ -20,8 +20,7 @@ use crate::{
     ecdh::k256::{EphemeralPublicKey, SharedSecret},
     utils::{
         ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable,
-        bytes_to_packed_u32_elements,
-        zeroize::{Zeroize, ZeroizeOnDrop},
+        bytes_to_packed_u32_elements, read_sensitive_array, zeroize::ZeroizeOnDrop,
     },
 };
 
@@ -455,11 +454,10 @@ impl Serializable for SecretKey {
 
 impl Deserializable for SecretKey {
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
-        let mut bytes: [u8; SECRET_KEY_BYTES] = source.read_array()?;
+        let bytes = read_sensitive_array::<SECRET_KEY_BYTES, _>(source)?;
 
-        let signing_key = ecdsa::SigningKey::from_slice(&bytes)
+        let signing_key = ecdsa::SigningKey::from_slice(bytes.as_slice())
             .map_err(|_| DeserializationError::InvalidValue("Invalid secret key".to_string()))?;
-        bytes.zeroize();
 
         Ok(Self { inner: signing_key })
     }

--- a/miden-crypto/src/dsa/ecdsa_k256_keccak/tests.rs
+++ b/miden-crypto/src/dsa/ecdsa_k256_keccak/tests.rs
@@ -32,6 +32,17 @@ mod signing_key {
     }
 
     #[test]
+    fn test_secret_key_deserialization_rejects_invalid_bytes() {
+        // A scalar of all 0xFF is above the secp256k1 curve order, and an all-zero scalar is
+        // also invalid, so both must be rejected with an error rather than a panic. This is the
+        // early-return path that previously skipped zeroizing the read buffer.
+        for invalid in [[0xFFu8; 32], [0u8; 32]] {
+            let result = SigningKey::read_from_bytes(&invalid);
+            assert!(result.is_err(), "invalid secret key bytes must fail to deserialize");
+        }
+    }
+
+    #[test]
     fn test_public_key_recovery() {
         let mut rng = seeded_rng([1u8; 32]);
 

--- a/miden-crypto/src/dsa/ecdsa_k256_keccak/tests.rs
+++ b/miden-crypto/src/dsa/ecdsa_k256_keccak/tests.rs
@@ -36,7 +36,7 @@ mod signing_key {
         // A scalar of all 0xFF is above the secp256k1 curve order, and an all-zero scalar is
         // also invalid, so both must be rejected with an error rather than a panic. This is the
         // early-return path that previously skipped zeroizing the read buffer.
-        for invalid in [[0xFFu8; 32], [0u8; 32]] {
+        for invalid in [[0xffu8; 32], [0u8; 32]] {
             let result = SigningKey::read_from_bytes(&invalid);
             assert!(result.is_err(), "invalid secret key bytes must fail to deserialize");
         }

--- a/miden-crypto/src/dsa/eddsa_25519_sha512/mod.rs
+++ b/miden-crypto/src/dsa/eddsa_25519_sha512/mod.rs
@@ -15,7 +15,7 @@ use crate::{
     ecdh::x25519::{EphemeralPublicKey, SharedSecret},
     utils::{
         ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable,
-        bytes_to_packed_u32_elements,
+        bytes_to_packed_u32_elements, read_sensitive_array,
         zeroize::{Zeroize, ZeroizeOnDrop},
     },
 };
@@ -515,9 +515,8 @@ impl Serializable for SecretKey {
 
 impl Deserializable for SecretKey {
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
-        let mut bytes: [u8; SECRET_KEY_BYTES] = source.read_array()?;
+        let bytes = read_sensitive_array::<SECRET_KEY_BYTES, _>(source)?;
         let inner = ed25519_dalek::SigningKey::from_bytes(&bytes);
-        bytes.zeroize();
 
         Ok(Self { inner })
     }

--- a/miden-crypto/src/dsa/falcon512_poseidon2/keys/secret_key.rs
+++ b/miden-crypto/src/dsa/falcon512_poseidon2/keys/secret_key.rs
@@ -20,7 +20,10 @@ use crate::{
         LOG_N, SK_LEN, hash_to_point::hash_to_point_poseidon2, math::ntru_gen,
     },
     hash::blake::Blake3_256,
-    utils::zeroize::{Zeroize, ZeroizeOnDrop},
+    utils::{
+        read_sensitive_array,
+        zeroize::{Zeroize, ZeroizeOnDrop},
+    },
 };
 
 // CONSTANTS
@@ -342,7 +345,7 @@ impl Serializable for SecretKey {
 
 impl Deserializable for SecretKey {
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
-        let byte_vector: [u8; SK_LEN] = source.read_array()?;
+        let byte_vector = read_sensitive_array::<SK_LEN, _>(source)?;
 
         // read fields
         let header = byte_vector[0];

--- a/miden-crypto/src/dsa/falcon512_poseidon2/keys/secret_key.rs
+++ b/miden-crypto/src/dsa/falcon512_poseidon2/keys/secret_key.rs
@@ -22,7 +22,7 @@ use crate::{
     hash::blake::Blake3_256,
     utils::{
         read_sensitive_array,
-        zeroize::{Zeroize, ZeroizeOnDrop},
+        zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing},
     },
 };
 
@@ -370,20 +370,26 @@ impl Deserializable for SecretKey {
         let chunk_size_g = ((n * WIDTH_SMALL_POLY_COEFFICIENT) + 7) >> 3;
         let chunk_size_big_f = ((n * WIDTH_BIG_POLY_COEFFICIENT) + 7) >> 3;
 
-        let f = decode_i8(&byte_vector[1..chunk_size_f + 1], WIDTH_SMALL_POLY_COEFFICIENT).ok_or(
-            DeserializationError::InvalidValue("Failed to decode f coefficients".to_string()),
-        )?;
-        let g = decode_i8(
-            &byte_vector[chunk_size_f + 1..(chunk_size_f + chunk_size_g + 1)],
-            WIDTH_SMALL_POLY_COEFFICIENT,
-        )
-        .unwrap();
-        let big_f = decode_i8(
-            &byte_vector[(chunk_size_f + chunk_size_g + 1)
-                ..(chunk_size_f + chunk_size_g + chunk_size_big_f + 1)],
-            WIDTH_BIG_POLY_COEFFICIENT,
-        )
-        .unwrap();
+        let f = Zeroizing::new(
+            decode_i8(&byte_vector[1..chunk_size_f + 1], WIDTH_SMALL_POLY_COEFFICIENT).ok_or(
+                DeserializationError::InvalidValue("Failed to decode f coefficients".to_string()),
+            )?,
+        );
+        let g = Zeroizing::new(
+            decode_i8(
+                &byte_vector[chunk_size_f + 1..(chunk_size_f + chunk_size_g + 1)],
+                WIDTH_SMALL_POLY_COEFFICIENT,
+            )
+            .unwrap(),
+        );
+        let big_f = Zeroizing::new(
+            decode_i8(
+                &byte_vector[(chunk_size_f + chunk_size_g + 1)
+                    ..(chunk_size_f + chunk_size_g + chunk_size_big_f + 1)],
+                WIDTH_BIG_POLY_COEFFICIENT,
+            )
+            .unwrap(),
+        );
 
         let f = Polynomial::new(f.iter().map(|&c| FalconFelt::new(c.into())).collect());
         let g = Polynomial::new(g.iter().map(|&c| FalconFelt::new(c.into())).collect());

--- a/miden-crypto/src/utils/mod.rs
+++ b/miden-crypto/src/utils/mod.rs
@@ -57,6 +57,24 @@ pub fn write_hex(f: &mut fmt::Formatter<'_>, bytes: &[u8]) -> fmt::Result {
 
 pub use miden_field::utils::{HexParseError, bytes_to_hex_string, hex_to_bytes};
 
+/// Reads a fixed-size byte array from `source`, wrapped in [`Zeroizing`](zeroize::Zeroizing) so
+/// the buffer is wiped on drop regardless of how the calling function exits, including `?` early
+/// returns on malformed input.
+///
+/// Deserialization of sensitive material (secret keys, seeds) should read its bytes through this
+/// helper instead of calling `read_array` and remembering a manual `zeroize()` before every
+/// return path.
+///
+/// Note: `ByteReader::read_array` returns the array by value, so the single move into the
+/// wrapper is not wiped. This is the same residual a manual `zeroize()` call has; the helper
+/// closes the error-path leak and removes the per-call-site cleanup, but a fully airtight read
+/// would require `ByteReader` to expose reading into a caller-provided `&mut [u8]`.
+pub(crate) fn read_sensitive_array<const N: usize, R: ByteReader>(
+    source: &mut R,
+) -> Result<zeroize::Zeroizing<[u8; N]>, DeserializationError> {
+    Ok(zeroize::Zeroizing::new(source.read_array()?))
+}
+
 // CONVERSIONS BETWEEN BYTES AND ELEMENTS
 // ================================================================================================
 


### PR DESCRIPTION
## Describe your changes

Closes #593. Follows up on my comment there, opening this so the actual diff is easier to judge than a description.

Deserializing a secret key reads its bytes into a stack buffer, and each `read_from` had to remember to call `zeroize()` on that buffer before every return path. Going through the sensitive `read_from` impls, some forgot:

- `ecdsa_k256_keccak::SecretKey::read_from` zeroized on success but leaked the buffer on the early return when `from_slice` rejects the bytes
- `falcon512_poseidon2::SecretKey::read_from` never wiped its `SK_LEN` buffer on any path, success included
- the Poseidon2 AEAD `SecretKey::read_from` never wiped its buffer either
- the eddsa path was correct, but only because `from_bytes` is infallible

This adds `read_sensitive_array` to `utils`, which returns the array wrapped in `Zeroizing` so the buffer is wiped on drop no matter how the calling function exits, and switches the four impls over to it. The manual `zeroize()` calls go away, and a forgotten cleanup in a future `read_from` stops being possible by construction.

One limit I want to be straight about (also documented on the helper): `read_array` returns by value, so the single move into the `Zeroizing` wrapper is not wiped. That residual is the same one the manual calls had. Closing it fully would need a `ByteReader` method that reads into a caller-provided `&mut [u8]`, which felt like a bigger conversation than this fix.

While in there I noticed `falcon512` `read_from` calls `decode_i8(...).unwrap()` for the `g` and `big_F` chunks (only `f` gets a proper error). If those can fail on malformed input that's a panic on attacker-supplied bytes, but I didn't want to widen this PR before asking. Happy to file it separately if you think it's reachable.

## Testing

- Added a test covering the ECDSA error path (out-of-range and zero scalars must return an error), which is the path that previously skipped the cleanup
- Full `miden-crypto` lib suite passes (648 tests), clippy clean
- CHANGELOG entry will follow in a commit once this PR has its number

## Checklist before requesting a review

- [x] Repo forked and branch created from `next` according to naming convention.
- [x] Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- [x] Relevant issues are linked in the PR description.
- [x] Tests added for new functionality.
- [x] Documentation/comments updated according to changes.
