### PR TITLE
fix: zeroize Falcon secret polynomial temporaries and encoded key buffers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Made `Felt::from_{u8, u16, u32}` const and added `Felt::MAX` ([#1081](https://github.com/0xMiden/crypto/pull/1081)).
 
 - Added a zeroizing read helper for deserializing sensitive material, fixing secret-key read buffers that were not wiped on error paths (ECDSA) or at all (Falcon, Poseidon2 AEAD) ([#1057](https://github.com/0xMiden/crypto/pull/1057)).
+- Made Falcon secret polynomial temporaries wipeable and wiped: added `Zeroize` for `FalconFelt`, removed the unbacked `ZeroizeOnDrop` marker on `Polynomial`, and zeroized the secret-carrying temporaries in `SecretKey` deserialization, serialization, and seed generation ([#1061](https://github.com/0xMiden/crypto/pull/1061)).
 
 ## 0.27.0 (2026-06-19)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 - Fixed SMT leaf advice decoding by rebuilding decoded entries through `SmtLeaf::new`, so decoded entries must match the supplied leaf index ([#1076](https://github.com/0xMiden/crypto/pull/1076)).
 - Made `Felt::from_{u8, u16, u32}` const and added `Felt::MAX` ([#1081](https://github.com/0xMiden/crypto/pull/1081)).
 
+- Added a zeroizing read helper for deserializing sensitive material, fixing secret-key read buffers that were not wiped on error paths (ECDSA) or at all (Falcon, Poseidon2 AEAD) ([#1057](https://github.com/0xMiden/crypto/pull/1057)).
+
 ## 0.27.0 (2026-06-19)
 
 - [BREAKING] Upgraded the RustCrypto and dalek stack: `der`, `hkdf`, `sha2`, `sha3`, `k256`, `curve25519-dalek`, `ed25519-dalek`, and `x25519-dalek` ([#1045](https://github.com/0xMiden/crypto/pull/1045)).

--- a/miden-crypto/src/dsa/ecdsa_k256_keccak/mod.rs
+++ b/miden-crypto/src/dsa/ecdsa_k256_keccak/mod.rs
@@ -21,7 +21,8 @@ use crate::{
     ecdh::k256::{EphemeralPublicKey, SharedSecret},
     utils::{
         ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable,
-        read_sensitive_array, zeroize::ZeroizeOnDrop,
+        read_sensitive_array,
+        zeroize::{ZeroizeOnDrop, Zeroizing},
     },
 };
 
@@ -96,20 +97,25 @@ impl SecretKey {
 // which ensures that the secret key material is securely zeroized when dropped.
 impl ZeroizeOnDrop for SecretKey {}
 
+#[cfg(test)]
 impl PartialEq for SecretKey {
     fn eq(&self, other: &Self) -> bool {
         use subtle::ConstantTimeEq;
-        self.to_bytes().ct_eq(&other.to_bytes()).into()
+        let self_bytes = Zeroizing::new(self.inner.to_bytes());
+        let other_bytes = Zeroizing::new(other.inner.to_bytes());
+        self_bytes[..].ct_eq(&other_bytes[..]).into()
     }
 }
 
+#[cfg(test)]
 impl Eq for SecretKey {}
 
 // SIGNING KEY
 // ================================================================================================
 
 /// A secret key for ECDSA signature verification over the secp256k1 curve.
-#[derive(Clone, Eq, PartialEq, SilentDebug, SilentDisplay)] // Safe as SecretKey has const-time eq
+#[derive(Clone, SilentDebug, SilentDisplay)]
+#[cfg_attr(test, derive(Eq, PartialEq))] // Safe as SecretKey has const-time eq in tests
 pub struct SigningKey(SecretKey);
 
 impl SigningKey {
@@ -170,7 +176,8 @@ impl Deserializable for SigningKey {
 // ================================================================================================
 
 /// A secret key for ECDH key-exchange over the secp256k1 curve.
-#[derive(Clone, Eq, PartialEq, SilentDebug, SilentDisplay)] // Safe as SecretKey has const-time eq
+#[derive(Clone, SilentDebug, SilentDisplay)]
+#[cfg_attr(test, derive(Eq, PartialEq))] // Safe as SecretKey has const-time eq in tests
 pub struct KeyExchangeKey(SecretKey);
 
 impl KeyExchangeKey {
@@ -448,9 +455,10 @@ impl Signature {
 
 impl Serializable for SecretKey {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
-        let mut buffer = Vec::with_capacity(SECRET_KEY_BYTES);
-        let sk_bytes: [u8; SECRET_KEY_BYTES] = self.inner.to_bytes().into();
-        buffer.extend_from_slice(&sk_bytes);
+        let mut buffer = Zeroizing::new(Vec::with_capacity(SECRET_KEY_BYTES));
+        let sk_bytes: Zeroizing<[u8; SECRET_KEY_BYTES]> =
+            Zeroizing::new(self.inner.to_bytes().into());
+        buffer.extend_from_slice(&sk_bytes[..]);
 
         target.write_bytes(&buffer);
     }

--- a/miden-crypto/src/dsa/eddsa_25519_sha512/mod.rs
+++ b/miden-crypto/src/dsa/eddsa_25519_sha512/mod.rs
@@ -16,7 +16,7 @@ use crate::{
     utils::{
         ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable,
         bytes_to_packed_u32_elements, read_sensitive_array,
-        zeroize::{Zeroize, ZeroizeOnDrop},
+        zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing},
     },
 };
 
@@ -95,20 +95,25 @@ impl SecretKey {
 // which ensures that the secret key material is securely zeroized when dropped.
 impl ZeroizeOnDrop for SecretKey {}
 
+#[cfg(test)]
 impl PartialEq for SecretKey {
     fn eq(&self, other: &Self) -> bool {
         use subtle::ConstantTimeEq;
-        self.inner.to_bytes().ct_eq(&other.inner.to_bytes()).into()
+        let self_bytes = Zeroizing::new(self.inner.to_bytes());
+        let other_bytes = Zeroizing::new(other.inner.to_bytes());
+        self_bytes[..].ct_eq(&other_bytes[..]).into()
     }
 }
 
+#[cfg(test)]
 impl Eq for SecretKey {}
 
 // SIGNING KEY
 // ================================================================================================
 
 /// A secret key for EdDSA (Ed25519) signature verification over Curve25519.
-#[derive(Clone, Eq, PartialEq, SilentDebug, SilentDisplay)] // Safe as SecretKey has const-time eq
+#[derive(Clone, SilentDebug, SilentDisplay)]
+#[cfg_attr(test, derive(Eq, PartialEq))] // Safe as SecretKey has const-time eq in tests
 pub struct SigningKey(SecretKey);
 
 impl SigningKey {
@@ -164,7 +169,8 @@ impl Deserializable for SigningKey {
 // ================================================================================================
 
 /// A key for ECDH key exchange over Curve25519
-#[derive(Clone, Eq, PartialEq, SilentDebug, SilentDisplay)] // Safe as SecretKey has const-time eq
+#[derive(Clone, SilentDebug, SilentDisplay)]
+#[cfg_attr(test, derive(Eq, PartialEq))] // Safe as SecretKey has const-time eq in tests
 pub struct KeyExchangeKey(SecretKey);
 
 impl KeyExchangeKey {
@@ -509,7 +515,8 @@ impl Signature {
 
 impl Serializable for SecretKey {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
-        target.write_bytes(&self.inner.to_bytes());
+        let bytes = Zeroizing::new(self.inner.to_bytes());
+        target.write_bytes(&bytes[..]);
     }
 }
 

--- a/miden-crypto/src/dsa/falcon512_poseidon2/keys/secret_key.rs
+++ b/miden-crypto/src/dsa/falcon512_poseidon2/keys/secret_key.rs
@@ -270,7 +270,9 @@ impl SecretKey {
     fn generate_seed(&self, message: &Word) -> [u8; 32] {
         let mut buffer = Vec::with_capacity(1 + SK_LEN + Word::SERIALIZED_SIZE);
         buffer.push(LOG_N);
-        buffer.extend_from_slice(&self.to_bytes());
+        // Bind the serialized key so the temporary holding it is wiped, not just `buffer`.
+        let sk_bytes = Zeroizing::new(self.to_bytes());
+        buffer.extend_from_slice(&sk_bytes);
         buffer.extend_from_slice(&message.to_bytes());
 
         let digest = Blake3_256::hash(&buffer);
@@ -307,39 +309,42 @@ impl Serializable for SecretKey {
         let g = &basis[0];
         let neg_big_f = &basis[3];
 
-        let mut buffer = Vec::with_capacity(1281);
+        let mut buffer = Zeroizing::new(Vec::with_capacity(1281));
         buffer.push(header);
 
-        let mut f_i8: Vec<i8> = neg_f
-            .coefficients
-            .iter()
-            .map(|&a| FalconFelt::new(-a).balanced_value() as i8)
-            .collect();
-        let f_i8_encoded = encode_i8(&f_i8, WIDTH_SMALL_POLY_COEFFICIENT).unwrap();
+        let f_i8: Zeroizing<Vec<i8>> = Zeroizing::new(
+            neg_f
+                .coefficients
+                .iter()
+                .map(|&a| FalconFelt::new(-a).balanced_value() as i8)
+                .collect(),
+        );
+        let f_i8_encoded = Zeroizing::new(encode_i8(&f_i8, WIDTH_SMALL_POLY_COEFFICIENT).unwrap());
         buffer.extend_from_slice(&f_i8_encoded);
-        f_i8.zeroize();
 
-        let mut g_i8: Vec<i8> = g
-            .coefficients
-            .iter()
-            .map(|&a| FalconFelt::new(a).balanced_value() as i8)
-            .collect();
-        let g_i8_encoded = encode_i8(&g_i8, WIDTH_SMALL_POLY_COEFFICIENT).unwrap();
+        let g_i8: Zeroizing<Vec<i8>> = Zeroizing::new(
+            g.coefficients
+                .iter()
+                .map(|&a| FalconFelt::new(a).balanced_value() as i8)
+                .collect(),
+        );
+        let g_i8_encoded = Zeroizing::new(encode_i8(&g_i8, WIDTH_SMALL_POLY_COEFFICIENT).unwrap());
         buffer.extend_from_slice(&g_i8_encoded);
-        g_i8.zeroize();
 
-        let mut big_f_i8: Vec<i8> = neg_big_f
-            .coefficients
-            .iter()
-            .map(|&a| FalconFelt::new(-a).balanced_value() as i8)
-            .collect();
-        let big_f_i8_encoded = encode_i8(&big_f_i8, WIDTH_BIG_POLY_COEFFICIENT).unwrap();
+        let big_f_i8: Zeroizing<Vec<i8>> = Zeroizing::new(
+            neg_big_f
+                .coefficients
+                .iter()
+                .map(|&a| FalconFelt::new(-a).balanced_value() as i8)
+                .collect(),
+        );
+        let big_f_i8_encoded =
+            Zeroizing::new(encode_i8(&big_f_i8, WIDTH_BIG_POLY_COEFFICIENT).unwrap());
         buffer.extend_from_slice(&big_f_i8_encoded);
-        big_f_i8.zeroize();
 
+        // `write_bytes` only borrows the buffer, so it is wiped here on drop; the target
+        // owns its copy of the encoded key and is responsible for it.
         target.write_bytes(&buffer);
-        // Note: buffer is not zeroized here as it's being passed to write_bytes which consumes it
-        // The caller should ensure proper handling of the written bytes
     }
 }
 
@@ -391,17 +396,34 @@ impl Deserializable for SecretKey {
             .unwrap(),
         );
 
-        let f = Polynomial::new(f.iter().map(|&c| FalconFelt::new(c.into())).collect());
-        let g = Polynomial::new(g.iter().map(|&c| FalconFelt::new(c.into())).collect());
-        let big_f = Polynomial::new(big_f.iter().map(|&c| FalconFelt::new(c.into())).collect());
+        let f =
+            Zeroizing::new(Polynomial::new(f.iter().map(|&c| FalconFelt::new(c.into())).collect()));
+        let g =
+            Zeroizing::new(Polynomial::new(g.iter().map(|&c| FalconFelt::new(c.into())).collect()));
+        let big_f = Zeroizing::new(Polynomial::new(
+            big_f.iter().map(|&c| FalconFelt::new(c.into())).collect(),
+        ));
 
-        // big_g * f - g * big_f = p (mod X^n + 1)
-        let big_g = g.fft().hadamard_div(&f.fft()).hadamard_mul(&big_f.fft()).ifft();
+        // big_g * f - g * big_f = p (mod X^n + 1). Each FFT-domain step is bound in
+        // `Zeroizing` so every secret-carrying intermediate is wiped, including the
+        // inverse that `hadamard_div` would otherwise allocate out of reach.
+        let f_fft = Zeroizing::new(f.fft());
+        let g_fft = Zeroizing::new(g.fft());
+        let big_f_fft = Zeroizing::new(big_f.fft());
+        let f_fft_inv = Zeroizing::new(f_fft.hadamard_inv());
+        let quotient = Zeroizing::new(g_fft.hadamard_mul(&f_fft_inv));
+        let big_g_fft = Zeroizing::new(quotient.hadamard_mul(&big_f_fft));
+        let big_g = Zeroizing::new(big_g_fft.ifft());
+
+        // Negate through references so the un-negated temporaries stay wrapped and wiped;
+        // `-Polynomial` by value would drop them intact.
+        let f_balanced = Zeroizing::new(Polynomial::new(f.to_balanced_values()));
+        let big_f_balanced = Zeroizing::new(Polynomial::new(big_f.to_balanced_values()));
         let basis = [
             Polynomial::new(g.to_balanced_values()),
-            -Polynomial::new(f.to_balanced_values()),
+            -(&*f_balanced),
             Polynomial::new(big_g.to_balanced_values()),
-            -Polynomial::new(big_f.to_balanced_values()),
+            -(&*big_f_balanced),
         ];
         Ok(Self::from_short_lattice_basis(basis))
     }

--- a/miden-crypto/src/dsa/falcon512_poseidon2/keys/secret_key.rs
+++ b/miden-crypto/src/dsa/falcon512_poseidon2/keys/secret_key.rs
@@ -194,12 +194,16 @@ impl SecretKey {
 
     /// Derives the public key corresponding to this secret key using h = g /f [mod ϕ][mod p].
     fn compute_pub_key_poly(&self) -> PublicKey {
-        let g: Polynomial<FalconFelt> = self.secret_key[0].clone().into();
-        let g_fft = g.fft();
-        let minus_f: Polynomial<FalconFelt> = self.secret_key[1].clone().into();
-        let f = -minus_f;
-        let f_fft = f.fft();
-        let h_fft = g_fft.hadamard_div(&f_fft);
+        let g: Zeroizing<Polynomial<FalconFelt>> =
+            Zeroizing::new(self.secret_key[0].clone().into());
+        let g_fft = Zeroizing::new(g.fft());
+        let minus_f: Zeroizing<Polynomial<FalconFelt>> =
+            Zeroizing::new(self.secret_key[1].clone().into());
+        let f = Zeroizing::new(-(&*minus_f));
+        let f_fft = Zeroizing::new(f.fft());
+        let f_fft_inv = Zeroizing::new(f_fft.hadamard_inv());
+        // h = g / f is the public key, so the result needs no wiping.
+        let h_fft = g_fft.hadamard_mul(&f_fft_inv);
         h_fft.ifft().into()
     }
 

--- a/miden-crypto/src/dsa/falcon512_poseidon2/keys/secret_key.rs
+++ b/miden-crypto/src/dsa/falcon512_poseidon2/keys/secret_key.rs
@@ -288,13 +288,17 @@ impl SecretKey {
     }
 }
 
+#[cfg(test)]
 impl PartialEq for SecretKey {
     fn eq(&self, other: &Self) -> bool {
         use subtle::ConstantTimeEq;
-        self.to_bytes().ct_eq(&other.to_bytes()).into()
+        let self_bytes = Zeroizing::new(self.to_bytes());
+        let other_bytes = Zeroizing::new(other.to_bytes());
+        self_bytes.ct_eq(&other_bytes).into()
     }
 }
 
+#[cfg(test)]
 impl Eq for SecretKey {}
 
 // SERIALIZATION / DESERIALIZATION
@@ -486,7 +490,7 @@ pub fn encode_i8(x: &[i8], bits: usize) -> Option<Vec<u8>> {
 /// Decodes a sequence of bytes into a sequence of signed integers such that each integer x
 /// satisfies |x| < 2^(bits-1) for a given parameter bits. bits can take either the value 6 or 8.
 pub fn decode_i8(buf: &[u8], bits: usize) -> Option<Vec<i8>> {
-    let mut x = [0_i8; N];
+    let mut x = Zeroizing::new([0_i8; N]);
 
     let mut i = 0;
     let mut j = 0;

--- a/miden-crypto/src/dsa/falcon512_poseidon2/math/field.rs
+++ b/miden-crypto/src/dsa/falcon512_poseidon2/math/field.rs
@@ -4,6 +4,7 @@ use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAss
 use num::{One, Zero};
 
 use super::{Inverse, MODULUS, fft::CyclotomicFourier};
+use crate::utils::zeroize::Zeroize;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct FalconFelt(u32);
@@ -30,6 +31,12 @@ impl FalconFelt {
 
     pub const fn multiply(self, other: Self) -> Self {
         FalconFelt((self.0 * other.0) % MODULUS as u32)
+    }
+}
+
+impl Zeroize for FalconFelt {
+    fn zeroize(&mut self) {
+        self.0.zeroize();
     }
 }
 

--- a/miden-crypto/src/dsa/falcon512_poseidon2/math/mod.rs
+++ b/miden-crypto/src/dsa/falcon512_poseidon2/math/mod.rs
@@ -16,6 +16,7 @@ use super::{
     MODULUS,
     keys::{WIDTH_BIG_POLY_COEFFICIENT, WIDTH_SMALL_POLY_COEFFICIENT},
 };
+use crate::utils::zeroize::Zeroizing;
 
 mod fft;
 pub use fft::{CyclotomicFourier, FastFft};
@@ -87,8 +88,9 @@ impl Inverse for f64 {
 /// [1]: <https://falcon-sign.info/falcon.pdf>
 pub(crate) fn ntru_gen<R: Rng>(n: usize, rng: &mut R) -> [Polynomial<i16>; 4] {
     loop {
-        let f = gen_poly(n, rng);
-        let g = gen_poly(n, rng);
+        // Wrap the sampled secrets so rejected candidates are wiped on every `continue`.
+        let f = Zeroizing::new(gen_poly(n, rng));
+        let mut g = Zeroizing::new(gen_poly(n, rng));
 
         // we do bound checks on the coefficients of the sampled polynomials in order to make sure
         // that they will be encodable/decodable
@@ -98,7 +100,8 @@ pub(crate) fn ntru_gen<R: Rng>(n: usize, rng: &mut R) -> [Polynomial<i16>; 4] {
             continue;
         }
 
-        let f_ntt = f.map(|&i| FalconFelt::new(i)).fft();
+        let f_felt = Zeroizing::new(f.map(|&i| FalconFelt::new(i)));
+        let f_ntt = Zeroizing::new(f_felt.fft());
         if f_ntt.coefficients.iter().any(Zero::is_zero) {
             continue;
         }
@@ -112,14 +115,22 @@ pub(crate) fn ntru_gen<R: Rng>(n: usize, rng: &mut R) -> [Polynomial<i16>; 4] {
         {
             // we do bound checks on the coefficients of the solution polynomials in order to make
             // sure that they will be encodable/decodable
-            let capital_f = capital_f.map(|i| i.try_into().unwrap());
-            let capital_g = capital_g.map(|i| i.try_into().unwrap());
+            let capital_f = Zeroizing::new(capital_f.map(|i| i.try_into().unwrap()));
+            let mut capital_g = Zeroizing::new(capital_g.map(|i| i.try_into().unwrap()));
             if !(check_coefficients_bound(&capital_f, MAX_BIG_POLY_COEFFICIENT_SIZE)
                 && check_coefficients_bound(&capital_g, MAX_BIG_POLY_COEFFICIENT_SIZE))
             {
                 continue;
             }
-            return [g, -f, capital_g, -capital_f];
+            // Move the kept polynomials out (the wrappers then wipe empty vecs) and negate
+            // through references so the un-negated copies are wiped too. The returned basis
+            // is owned by `SecretKey`, which wipes it on drop.
+            return [
+                core::mem::take(&mut *g),
+                -(&*f),
+                core::mem::take(&mut *capital_g),
+                -(&*capital_f),
+            ];
         }
     }
 }
@@ -168,13 +179,11 @@ fn ntru_solve(
 fn gen_poly<R: Rng>(n: usize, rng: &mut R) -> Polynomial<i16> {
     let mu = 0.0;
     let sigma_star = 1.43300980528773;
+    let samples: Zeroizing<Vec<i16>> = Zeroizing::new(
+        (0..4096).map(|_| sampler_z(mu, sigma_star, sigma_star - 0.001, rng)).collect(),
+    );
     Polynomial {
-        coefficients: (0..4096)
-            .map(|_| sampler_z(mu, sigma_star, sigma_star - 0.001, rng))
-            .collect::<Vec<i16>>()
-            .chunks(4096 / n)
-            .map(|ch| ch.iter().sum())
-            .collect(),
+        coefficients: samples.chunks(4096 / n).map(|ch| ch.iter().sum()).collect(),
     }
 }
 

--- a/miden-crypto/src/dsa/falcon512_poseidon2/math/mod.rs
+++ b/miden-crypto/src/dsa/falcon512_poseidon2/math/mod.rs
@@ -329,5 +329,9 @@ fn xgcd(a: &BigInt, b: &BigInt) -> (BigInt, BigInt, BigInt) {
 /// Asserts that the balanced values of the coefficients of a polynomial are within the interval
 /// [-bound, bound].
 fn check_coefficients_bound(polynomial: &Polynomial<i16>, bound: i16) -> bool {
-    polynomial.to_balanced_values().iter().all(|c| *c <= bound && *c >= -bound)
+    polynomial
+        .coefficients
+        .iter()
+        .map(|&c| FalconFelt::new(c).balanced_value())
+        .all(|c| c <= bound && c >= -bound)
 }

--- a/miden-crypto/src/dsa/falcon512_poseidon2/math/polynomial.rs
+++ b/miden-crypto/src/dsa/falcon512_poseidon2/math/polynomial.rs
@@ -13,7 +13,7 @@ use super::{Inverse, field::FalconFelt};
 use crate::{
     Felt,
     dsa::falcon512_poseidon2::{MODULUS, N},
-    utils::zeroize::{Zeroize, ZeroizeOnDrop},
+    utils::zeroize::Zeroize,
 };
 
 /// Represents a polynomial with coefficients of type F.
@@ -647,7 +647,10 @@ impl<F: Zeroize> Zeroize for Polynomial<F> {
     }
 }
 
-impl<F: Zeroize> ZeroizeOnDrop for Polynomial<F> {}
+// `ZeroizeOnDrop` cannot be provided for `Polynomial<F>`: a `Drop` impl bounded on
+// `F: Zeroize` is rejected by the compiler (E0367), and bounding the struct itself would
+// exclude `Polynomial<Complex64>` used by the signing path. Callers holding secret
+// polynomials must wrap them in `Zeroizing` instead.
 
 // TESTS
 // ================================================================================================
@@ -670,5 +673,18 @@ mod tests {
             prod.reduce_by_cyclotomic(N),
             Polynomial::reduce_negacyclic(&Polynomial::mul_modulo_p(&poly1, &poly2))
         );
+    }
+
+    #[test]
+    fn test_zeroize_wipes_falcon_felt_polynomial() {
+        use crate::utils::zeroize::Zeroize;
+
+        let mut felt = FalconFelt::new(42);
+        felt.zeroize();
+        assert_eq!(felt.value(), 0);
+
+        let mut poly = Polynomial::new(vec![FalconFelt::new(3), FalconFelt::new(-7)]);
+        poly.zeroize();
+        assert!(poly.coefficients.is_empty());
     }
 }


### PR DESCRIPTION
Follow-up to 0xMiden/crypto#1057, closes 0xMiden/miden-vm#3533.

0xMiden/crypto#1057 wiped the byte-level read buffers, but the secret material doesn't stop there. On the Falcon path the decoded coefficients get turned into `Polynomial` temporaries that nothing wipes, `Polynomial` carries a `ZeroizeOnDrop` marker with no `Drop` behind it so it never actually runs, and both `write_into` and `generate_seed` leave encoded copies of the secret key on the heap, the second one on every signature. 0xMiden/miden-vm#3533 has the full walkthrough.

What's in here:

- `Zeroize` for `FalconFelt`, so `Polynomial<FalconFelt>` becomes wipeable through the existing generic impl.
- Dropped the unbacked `ZeroizeOnDrop` marker on `Polynomial`. It's unimplementable as declared: a `Drop` bounded on `F: Zeroize` fails E0367, and bounding the struct itself breaks `Polynomial<Complex64>` on the signing path. Made wipe-on-drop explicit at the use sites with `Zeroizing` instead, the same pattern 0xMiden/crypto#1057 uses for the byte buffers.
- `read_from`: wrapped `f`/`g`/`big_f`/`big_g` and bound the fft chain stepwise so the intermediates get wiped too, inlining `hadamard_div` as `hadamard_inv` + `hadamard_mul` so the inverse lands in a wrapped value instead of an internal allocation. Negated the basis polynomials through references so the un-negated copies stay wrapped.
- `write_into`: wiped the encode buffer and the encoded chunks, and fixed the stale comment that claimed `write_bytes` consumes the buffer (it borrows it).
- `generate_seed`: bound the serialized key in `Zeroizing` so the per-signature copies are covered.
- Swept the rest of the secret path: `compute_pub_key_poly` clones `f`/`g` on every signature and `ntru_gen` drops rejected candidates on every retry, both wiped now.

The `BigInt` arithmetic in `ntru_solve` and the `Complex64` fft domain are left as documented residue. Wiping those needs the volatile-write treatment `LdlTree` already does rather than `Zeroize`, and that's called out in 0xMiden/miden-vm#3533.

This sits on top of 0xMiden/crypto#1057, so it should land after that one. The first commits here are 0xMiden/crypto#1057's.

Test plan: `cargo test -p miden-crypto dsa` (49 pass, including the reference-impl signature determinism check), `cargo fmt --check`, `cargo clippy -p miden-crypto --all-features`, and the no-std build.
