### PR TITLE
ci: support selected package releases

### DIFF
--- a/.github/workflows/workspace-dry-run.yml
+++ b/.github/workflows/workspace-dry-run.yml
@@ -5,6 +5,18 @@ on:
     branches:
       - main
       - next
+  workflow_dispatch:
+    inputs:
+      packages:
+        description: "Comma, space, or newline separated packages to dry-run. Empty uses packages_file."
+        required: false
+        default: ""
+        type: string
+      packages_file:
+        description: "Package list file used when packages is empty."
+        required: false
+        default: "release-packages.txt"
+        type: string
 
 permissions:
   contents: read
@@ -17,7 +29,70 @@ concurrency:
 jobs:
   release-dry-run:
     if: ${{ github.repository_owner == '0xMiden' }}
-    uses: 0xMiden/.github/.github/workflows/workspace-release.yml@d34ae3cd29234c5aa4d3ab57635b30563471c3c3
-    with:
-      mode: dry-run
-      msrv_script_path: scripts/check-msrv.sh
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # pin@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Install Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # pin@v1
+        with:
+          cache: false
+          rustflags: ""
+
+      - name: Cache cargo registry and git index
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # pin@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Cleanup large tools for build space
+        uses: ./.github/actions/cleanup-runner
+
+      - name: Install cargo-binstall
+        uses: taiki-e/install-action@b8be7f5e140177087325943c4a8e169d01c59b3d # pin@v2
+        with:
+          tool: cargo-binstall
+
+      - name: Install cargo-msrv
+        shell: bash
+        run: cargo binstall --no-confirm --force cargo-msrv
+
+      - name: Check MSRV
+        shell: bash
+        run: |
+          export PATH="$HOME/.cargo/bin:$PATH"
+          bash scripts/check-msrv.sh
+
+      - name: Clean packaging directory
+        shell: bash
+        run: rm -rf target/package
+
+      - name: Check public API semver compatibility
+        uses: obi1kenobi/cargo-semver-checks-action@6b69fcf40e9b5fb17adeb57e4b6ecd020649a239 # pin@v2
+        with:
+          rust-toolchain: manual
+
+      # Workaround for cargo#14283 and cargo#14789.
+      - name: Clear cargo registry
+        shell: bash
+        run: rm -rf ~/.cargo/registry/{cache,index,src}
+
+      - name: Dry-run selected package publish
+        shell: bash
+        env:
+          RELEASE_PACKAGES: ${{ github.event.inputs.packages || '' }}
+          RELEASE_PACKAGES_FILE: ${{ github.event.inputs.packages_file || 'release-packages.txt' }}
+        run: |
+          scripts/release-selected.sh \
+            --mode dry-run \
+            --packages "$RELEASE_PACKAGES" \
+            --packages-file "$RELEASE_PACKAGES_FILE"

--- a/.github/workflows/workspace-publish.yml
+++ b/.github/workflows/workspace-publish.yml
@@ -1,8 +1,25 @@
-name: Publish workspace to crates.io
+name: Publish selected crates to crates.io
 
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git ref to publish. Usually main."
+        required: true
+        default: "main"
+        type: string
+      packages:
+        description: "Comma, space, or newline separated packages to publish. Empty uses packages_file."
+        required: false
+        default: ""
+        type: string
+      packages_file:
+        description: "Package list file used when packages is empty."
+        required: false
+        default: "release-packages.txt"
+        type: string
 
 permissions:
   contents: read
@@ -11,9 +28,91 @@ permissions:
 jobs:
   publish:
     if: ${{ github.repository_owner == '0xMiden' }}
-    uses: 0xMiden/.github/.github/workflows/workspace-release.yml@d34ae3cd29234c5aa4d3ab57635b30563471c3c3
-    with:
-      mode: publish
-      msrv_script_path: scripts/check-msrv.sh
-      verify_target_ref_head: true
-      environment_name: release
+    runs-on: ubuntu-latest
+    environment: release
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # pin@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ github.event.inputs.ref || github.ref }}
+
+      - name: Verify checked out commit matches target ref HEAD
+        shell: bash
+        env:
+          TARGET_REF: main
+        run: |
+          git fetch origin "$TARGET_REF" --depth=1
+          target_sha="$(git rev-parse FETCH_HEAD)"
+          checkout_sha="$(git rev-parse HEAD)"
+
+          echo "target_ref=$TARGET_REF"
+          echo "target_sha=$target_sha"
+          echo "checkout_sha=$checkout_sha"
+
+          if [ "$target_sha" != "$checkout_sha" ]; then
+            echo "::error::The checked out commit does not match origin/$TARGET_REF HEAD. Aborting."
+            exit 1
+          fi
+
+      - name: Install Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # pin@v1
+        with:
+          cache: false
+          rustflags: ""
+
+      - name: Cache cargo registry and git index
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # pin@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Cleanup large tools for build space
+        uses: ./.github/actions/cleanup-runner
+
+      - name: Install cargo-binstall
+        uses: taiki-e/install-action@b8be7f5e140177087325943c4a8e169d01c59b3d # pin@v2
+        with:
+          tool: cargo-binstall
+
+      - name: Install cargo-msrv
+        shell: bash
+        run: cargo binstall --no-confirm --force cargo-msrv
+
+      - name: Check MSRV
+        shell: bash
+        run: |
+          export PATH="$HOME/.cargo/bin:$PATH"
+          bash scripts/check-msrv.sh
+
+      - name: Clean packaging directory
+        shell: bash
+        run: rm -rf target/package
+
+      - name: Check public API semver compatibility
+        id: semver_checks
+        uses: obi1kenobi/cargo-semver-checks-action@6b69fcf40e9b5fb17adeb57e4b6ecd020649a239 # pin@v2
+        with:
+          rust-toolchain: manual
+
+      - name: Authenticate with crates.io
+        id: crates-io-auth
+        uses: rust-lang/crates-io-auth-action@b7e9a28eded4986ec6b1fa40eeee8f8f165559ec # pin@v1
+
+      - name: Publish selected packages
+        shell: bash
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.crates-io-auth.outputs.token }}
+          RELEASE_PACKAGES: ${{ github.event.inputs.packages || '' }}
+          RELEASE_PACKAGES_FILE: ${{ github.event.inputs.packages_file || 'release-packages.txt' }}
+        run: |
+          scripts/release-selected.sh \
+            --mode publish \
+            --packages "$RELEASE_PACKAGES" \
+            --packages-file "$RELEASE_PACKAGES_FILE"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Improved LargeSmt RocksDB defaults, added per-DB memory-budget controls, and exposed durability mode selection ([#1056](https://github.com/0xMiden/crypto/pull/1056)).
 - [BREAKING] Make `Felt::Packing` resolve to the SIMD-packed `PackedFelt` from Plonky3 ([#1060](https://github.com/0xMiden/crypto/pull/1060)).
 - perf: factor the DEEP barycentric inner loop to drop the per-row `xᵢ · qᵢ` base×extension multiplication ([#1064](https://github.com/0xMiden/crypto/issues/1064)).
+- Added release tooling for publishing an explicit package list instead of always publishing the full workspace.
 
 ## 0.26.0 (06-02-2026)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -546,9 +546,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1436,9 +1436,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c863e9ab5e7bf9c99ba75e1050f1e4d624ae87ed3532d6238ffbdc7b585dbbe6"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
 dependencies = [
  "num-integer",
  "num-traits",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,9 @@ keywords     = ["crypto", "hash", "merkle", "miden"]
 license      = "MIT OR Apache-2.0"
 repository   = "https://github.com/0xMiden/crypto"
 rust-version = "1.93"
-version      = "0.29.0"
+# Private workspace members inherit this version. Publishable crates keep their own
+# package versions so release tooling can publish only the crates selected for a release.
+version = "0.29.0"
 
 [workspace.dependencies]
 miden-crypto-derive    = { path = "miden-crypto-derive", version = "0.29" }

--- a/miden-crypto-derive/Cargo.toml
+++ b/miden-crypto-derive/Cargo.toml
@@ -9,7 +9,7 @@ name                   = "miden-crypto-derive"
 readme                 = "README.md"
 repository.workspace   = true
 rust-version.workspace = true
-version.workspace      = true
+version                = "0.29.0"
 
 [lib]
 doctest    = false

--- a/miden-crypto/Cargo.toml
+++ b/miden-crypto/Cargo.toml
@@ -10,7 +10,7 @@ name                   = "miden-crypto"
 readme                 = "../README.md"
 repository.workspace   = true
 rust-version.workspace = true
-version.workspace      = true
+version                = "0.29.0"
 
 [[bin]]
 bench             = false

--- a/miden-field/Cargo.toml
+++ b/miden-field/Cargo.toml
@@ -10,7 +10,7 @@ name                   = "miden-field"
 readme                 = "README.md"
 repository.workspace   = true
 rust-version.workspace = true
-version.workspace      = true
+version                = "0.29.0"
 
 [lib]
 crate-type = ["rlib"]

--- a/miden-serde-utils/Cargo.toml
+++ b/miden-serde-utils/Cargo.toml
@@ -10,7 +10,7 @@ name                   = "miden-serde-utils"
 readme                 = "README.md"
 repository.workspace   = true
 rust-version.workspace = true
-version.workspace      = true
+version                = "0.29.0"
 
 [features]
 default = ["std"]

--- a/release-packages.txt
+++ b/release-packages.txt
@@ -1,0 +1,12 @@
+# Publish order for the next miden-crypto release.
+#
+# Keep this list in dependency order. Remove crates that are not part of a given
+# release; the workflow_dispatch `packages` input can also override this file.
+miden-serde-utils
+miden-field
+miden-crypto-derive
+miden-lifted-air
+miden-stark-transcript
+miden-stateful-hasher
+miden-lifted-stark
+miden-crypto

--- a/scripts/release-selected.sh
+++ b/scripts/release-selected.sh
@@ -1,0 +1,231 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+mode=""
+packages_arg=""
+packages_file="release-packages.txt"
+allow_dirty="false"
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/release-selected.sh --mode <dry-run|publish> [--packages <list>] [--packages-file <path>] [--allow-dirty]
+
+Publishes or dry-runs a selected set of publishable workspace crates.
+
+Package lists may be comma, space, or newline separated. Lines in package files
+may contain comments after '#'. Packages are processed in the order provided.
+--allow-dirty is accepted only with --mode dry-run.
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --mode)
+      mode="${2:-}"
+      shift 2
+      ;;
+    --packages)
+      packages_arg="${2:-}"
+      shift 2
+      ;;
+    --packages-file)
+      packages_file="${2:-}"
+      shift 2
+      ;;
+    --allow-dirty)
+      allow_dirty="true"
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown argument '$1'" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+case "$mode" in
+  dry-run|publish) ;;
+  "")
+    echo "error: --mode is required" >&2
+    usage >&2
+    exit 2
+    ;;
+  *)
+    echo "error: unsupported mode '$mode'; expected dry-run or publish" >&2
+    exit 2
+    ;;
+esac
+
+if [[ "$allow_dirty" == "true" && "$mode" != "dry-run" ]]; then
+  echo "error: --allow-dirty is only supported in dry-run mode" >&2
+  exit 2
+fi
+
+for cmd in cargo jq; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "error: required command '$cmd' is not installed or not in PATH" >&2
+    exit 1
+  fi
+done
+
+packages=()
+
+add_packages() {
+  local line word
+  while IFS= read -r line; do
+    line="${line%%#*}"
+    line="${line//,/ }"
+    for word in $line; do
+      packages+=("$word")
+    done
+  done
+}
+
+if [[ -n "$packages_arg" ]]; then
+  add_packages <<< "$packages_arg"
+else
+  if [[ ! -f "$packages_file" ]]; then
+    echo "error: packages file '$packages_file' does not exist" >&2
+    exit 1
+  fi
+  add_packages < "$packages_file"
+fi
+
+if [[ ${#packages[@]} -eq 0 ]]; then
+  echo "error: no packages selected" >&2
+  exit 1
+fi
+
+metadata_json="$(cargo metadata --locked --no-deps --format-version 1)"
+
+package_version() {
+  local package="$1"
+  printf '%s' "$metadata_json" \
+    | jq -er --arg package "$package" '
+        . as $m
+        | $m.packages[]
+        | select(.name == $package and (.id as $id | $m.workspace_members | index($id)))
+        | select(.publish != [])
+        | .version
+      '
+}
+
+all_publishable_packages() {
+  printf '%s' "$metadata_json" \
+    | jq -r '
+        . as $m
+        | $m.packages[]
+        | select((.id as $id | $m.workspace_members | index($id)) and .publish != [])
+        | .name
+      '
+}
+
+is_selected_package() {
+  local package="$1"
+  local selected
+
+  for selected in "${packages[@]}"; do
+    if [[ "$selected" == "$package" ]]; then
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+for package in "${packages[@]}"; do
+  if ! package_version "$package" >/dev/null; then
+    echo "error: '$package' is not a publishable workspace package" >&2
+    echo "publishable packages:" >&2
+    all_publishable_packages | sed 's/^/  - /' >&2
+    exit 1
+  fi
+done
+
+crate_version_exists() {
+  local package="$1"
+  local version="$2"
+
+  if ! command -v curl >/dev/null 2>&1; then
+    return 1
+  fi
+
+  curl --fail --silent --show-error --output /dev/null \
+    --user-agent "miden-crypto-release-selected" \
+    "https://crates.io/api/v1/crates/${package}/${version}"
+}
+
+publish_package() {
+  local package="$1"
+  local version="$2"
+  local attempt=1
+  local max_attempts=1
+  local retry_seconds="${RELEASE_PUBLISH_RETRY_SECONDS:-30}"
+
+  if [[ "$mode" == "publish" ]]; then
+    max_attempts="${RELEASE_PUBLISH_ATTEMPTS:-5}"
+  fi
+
+  while true; do
+    if [[ "$mode" == "dry-run" ]]; then
+      cargo publish -p "$package" --dry-run
+      return
+    fi
+
+    if crate_version_exists "$package" "$version"; then
+      echo "Skipping $package v$version; it already exists on crates.io."
+      return
+    fi
+
+    if cargo publish -p "$package"; then
+      return
+    fi
+
+    if [[ "$attempt" -ge "$max_attempts" ]]; then
+      echo "error: failed to publish $package v$version after $attempt attempt(s)" >&2
+      return 1
+    fi
+
+    attempt=$((attempt + 1))
+    echo "Retrying $package v$version in ${retry_seconds}s (attempt $attempt/$max_attempts)..."
+    sleep "$retry_seconds"
+  done
+}
+
+dry_run_selected_packages() {
+  local package
+  local cmd=(cargo publish --workspace --dry-run)
+
+  if [[ "$allow_dirty" == "true" ]]; then
+    cmd+=(--allow-dirty)
+  fi
+
+  while IFS= read -r package; do
+    if ! is_selected_package "$package"; then
+      cmd+=(--exclude "$package")
+    fi
+  done < <(all_publishable_packages)
+
+  "${cmd[@]}"
+}
+
+echo "Release mode: $mode"
+echo "Selected packages:"
+for package in "${packages[@]}"; do
+  version="$(package_version "$package")"
+  echo "  - $package v$version"
+done
+
+if [[ "$mode" == "dry-run" ]]; then
+  dry_run_selected_packages
+else
+  for package in "${packages[@]}"; do
+    version="$(package_version "$package")"
+    publish_package "$package" "$version"
+  done
+fi

--- a/stark/miden-lifted-air/Cargo.toml
+++ b/stark/miden-lifted-air/Cargo.toml
@@ -7,7 +7,7 @@ name                   = "miden-lifted-air"
 readme                 = "../README.md"
 repository             = "https://github.com/0xMiden/crypto"
 rust-version.workspace = true
-version.workspace      = true
+version                = "0.29.0"
 
 [lib]
 doctest = true

--- a/stark/miden-lifted-stark/Cargo.toml
+++ b/stark/miden-lifted-stark/Cargo.toml
@@ -7,7 +7,7 @@ name                   = "miden-lifted-stark"
 readme                 = "../README.md"
 repository             = "https://github.com/0xMiden/crypto"
 rust-version.workspace = true
-version.workspace      = true
+version                = "0.29.0"
 
 [lib]
 doctest = false

--- a/stark/miden-stark-transcript/Cargo.toml
+++ b/stark/miden-stark-transcript/Cargo.toml
@@ -7,7 +7,7 @@ name                   = "miden-stark-transcript"
 readme                 = "../README.md"
 repository             = "https://github.com/0xMiden/crypto"
 rust-version.workspace = true
-version.workspace      = true
+version                = "0.29.0"
 
 [lib]
 doctest = false

--- a/stark/miden-stateful-hasher/Cargo.toml
+++ b/stark/miden-stateful-hasher/Cargo.toml
@@ -7,7 +7,7 @@ name                   = "miden-stateful-hasher"
 readme                 = "../README.md"
 repository             = "https://github.com/0xMiden/crypto"
 rust-version.workspace = true
-version.workspace      = true
+version                = "0.29.0"
 
 [lib]
 doctest = false


### PR DESCRIPTION
This PR changes the release flow so we can publish only the crates we choose for a release.
The publishable crates now have their own package versions instead of inheriting the workspace version. Private workspace packages still use the workspace version.
The release workflows now use `scripts/release-selected.sh`. The script reads `release-packages.txt` by default. Manual `workflow_dispatch` runs can pass a package list or another package file.
The dry run path uses Cargo workspace publishing with exclusions. This lets Cargo test selected crates against other selected crates that are not on crates.io yet. The publish path publishes the selected crates in order.