### PR TITLE
refactor(stark): rename parallel -> concurrent feature and add it to default set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## 0.28.0 (TBD)
+- [BREAKING] Rename miden-lifted-stark `parallel` feature to `concurrent` and make it a default one ([#1073](https://github.com/0xMiden/crypto/issues/1073)).
 
 ## 0.27.0 (2026-06-19)
 

--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ test-docs:
 
 .PHONY: test-p3-parallel
 test-p3-parallel: ## Run Miden STARK crate tests with the parallel feature enabled
-	cargo test $(MIDEN_STARK_TEST_PACKAGES) -F miden-lifted-stark/parallel
+	cargo test $(MIDEN_STARK_TEST_PACKAGES) -F miden-lifted-stark/concurrent
 
 .PHONY: test-large-smt
 test-large-smt: ## Run large SMT unit tests and RocksDB integration tests

--- a/miden-bench/Cargo.toml
+++ b/miden-bench/Cargo.toml
@@ -42,8 +42,8 @@ tracing-forest               = { features = ["ansi", "smallvec"], workspace = tr
 tracing-subscriber.workspace = true
 
 [features]
-default  = []
-parallel = ["miden-lifted-stark/parallel"]
+concurrent = ["miden-lifted-stark/concurrent"]
+default    = []
 
 [lints]
 workspace = true

--- a/miden-bench/src/main.rs
+++ b/miden-bench/src/main.rs
@@ -10,22 +10,22 @@
 //!
 //! ```bash
 //! # Quick run with defaults (blake3:15 keccak:18 poseidon2:19):
-//! cargo run -p miden-bench --features parallel --release
+//! cargo run -p miden-bench --features concurrent --release
 //!
 //! # Custom traces:
-//! cargo run -p miden-bench --features parallel --release -- keccak:15 keccak:18 keccak:19
+//! cargo run -p miden-bench --features concurrent --release -- keccak:15 keccak:18 keccak:19
 //!
 //! # Full tracing tree:
-//! cargo run -p miden-bench --features parallel --release -- -v keccak:15
+//! cargo run -p miden-bench --features concurrent --release -- -v keccak:15
 //!
 //! # Multi-iteration with warm-up (reports min/median/mean/max):
-//! cargo run -p miden-bench --features parallel --release -- -n 5 keccak:15
+//! cargo run -p miden-bench --features concurrent --release -- -n 5 keccak:15
 //!
 //! # Miden-shaped AIR (auto log_blowup=3):
-//! cargo run -p miden-bench --features parallel --release -- miden:18:51 miden:19:20
+//! cargo run -p miden-bench --features concurrent --release -- miden:18:51 miden:19:20
 //!
 //! # Batch-STARK comparison:
-//! cargo run -p miden-bench --features parallel --release -- -m batch keccak:15 keccak:18
+//! cargo run -p miden-bench --features concurrent --release -- -m batch keccak:15 keccak:18
 //! ```
 
 mod batch;

--- a/miden-crypto/Cargo.toml
+++ b/miden-crypto/Cargo.toml
@@ -80,7 +80,7 @@ name              = "transpose"
 required-features = ["std"]
 
 [features]
-concurrent        = ["dep:rayon", "miden-lifted-stark/parallel", "p3-maybe-rayon/parallel", "p3-util/parallel", "std"]
+concurrent        = ["dep:rayon", "miden-lifted-stark/concurrent", "p3-maybe-rayon/parallel", "p3-util/parallel", "std"]
 default           = ["concurrent", "std"]
 executable        = ["concurrent", "dep:clap"]
 fuzzing           = []

--- a/scripts/check-features.sh
+++ b/scripts/check-features.sh
@@ -21,7 +21,7 @@ echo ""
 echo "Checking targeted multi-feature combinations..."
 
 # `cargo hack --each-feature` does not cover combinations like
-# `miden-lifted-stark/testing,parallel`.
-cargo check -p miden-lifted-stark --all-targets --features testing,parallel
+# `miden-lifted-stark/testing,concurrent`.
+cargo check -p miden-lifted-stark --all-targets --features testing,concurrent
 
 echo "All feature combinations compiled successfully!"

--- a/stark/README.md
+++ b/stark/README.md
@@ -52,7 +52,7 @@ make doc
 ## Run An Example
 
 ```bash
-cargo run -p miden-bench --features parallel --release -- keccak:15
+cargo run -p miden-bench --features concurrent --release -- keccak:15
 ```
 
 ## Security Disclaimer

--- a/stark/miden-lifted-stark/Cargo.toml
+++ b/stark/miden-lifted-stark/Cargo.toml
@@ -57,9 +57,9 @@ criterion.workspace          = true
 tracing-subscriber.workspace = true
 
 [features]
-default  = []
-parallel = ["p3-maybe-rayon/parallel"]
-testing  = ["dep:p3-blake3", "dep:p3-blake3-air", "dep:p3-keccak", "dep:p3-keccak-air", "dep:p3-poseidon2-air"]
+concurrent = ["p3-maybe-rayon/parallel"]
+default    = ["concurrent"]
+testing    = ["dep:p3-blake3", "dep:p3-blake3-air", "dep:p3-keccak", "dep:p3-keccak-air", "dep:p3-poseidon2-air"]
 
 [[bench]]
 harness           = false

--- a/stark/miden-lifted-stark/README.md
+++ b/stark/miden-lifted-stark/README.md
@@ -177,7 +177,7 @@ at `y_j`, and the opened trace values already correspond to `p_j(y_j)`.
 - **Cyclic extension** — Cross-trace accumulation uses bitwise AND for
   modular indexing (power-of-two sizes).
 - **Parallel execution** — Rayon parallelism throughout constraint evaluation
-  and per-AIR quotient division (gated by `parallel` feature).
+  and per-AIR quotient division (gated by `concurrent` feature).
 
 ## Entry Points
 

--- a/stark/miden-lifted-stark/benches/deep_quotient.rs
+++ b/stark/miden-lifted-stark/benches/deep_quotient.rs
@@ -8,7 +8,7 @@
 //! RUSTFLAGS="-Ctarget-cpu=native" cargo bench --bench deep_quotient --features testing
 //!
 //! # With parallelism
-//! RUSTFLAGS="-Ctarget-cpu=native" cargo bench --bench deep_quotient --features testing,parallel
+//! RUSTFLAGS="-Ctarget-cpu=native" cargo bench --bench deep_quotient --features testing,concurrent
 //!
 //! # Filter by field
 //! cargo bench --bench deep_quotient --features testing -- goldilocks

--- a/stark/miden-lifted-stark/benches/fri_fold.rs
+++ b/stark/miden-lifted-stark/benches/fri_fold.rs
@@ -8,7 +8,7 @@
 //! RUSTFLAGS="-Ctarget-cpu=native" cargo bench --bench fri_fold --features testing
 //!
 //! # With parallelism
-//! RUSTFLAGS="-Ctarget-cpu=native" cargo bench --bench fri_fold --features testing,parallel
+//! RUSTFLAGS="-Ctarget-cpu=native" cargo bench --bench fri_fold --features testing,concurrent
 //!
 //! # Filter by field
 //! cargo bench --bench fri_fold --features testing -- goldilocks

--- a/stark/miden-lifted-stark/benches/merkle_commit.rs
+++ b/stark/miden-lifted-stark/benches/merkle_commit.rs
@@ -8,7 +8,7 @@
 //! RUSTFLAGS="-Ctarget-cpu=native" cargo bench --bench merkle_commit --features testing
 //!
 //! # With parallelism
-//! RUSTFLAGS="-Ctarget-cpu=native" cargo bench --bench merkle_commit --features testing,parallel
+//! RUSTFLAGS="-Ctarget-cpu=native" cargo bench --bench merkle_commit --features testing,concurrent
 //!
 //! # Filter by field
 //! cargo bench --bench merkle_commit --features testing -- goldilocks

--- a/stark/miden-lifted-stark/benches/pcs_trace.rs
+++ b/stark/miden-lifted-stark/benches/pcs_trace.rs
@@ -5,7 +5,7 @@
 //!
 //! Run with:
 //! ```bash
-//! RUSTFLAGS="-Ctarget-cpu=native" cargo bench -p miden-lifted-stark --bench pcs_trace --features testing,parallel
+//! RUSTFLAGS="-Ctarget-cpu=native" cargo bench -p miden-lifted-stark --bench pcs_trace --features testing,concurrent
 //! ```
 
 use std::time::Instant;

--- a/stark/miden-lifted-stark/benches/per_air_degree_opt.rs
+++ b/stark/miden-lifted-stark/benches/per_air_degree_opt.rs
@@ -21,7 +21,7 @@
 //! Run:
 //! ```bash
 //! RUSTFLAGS="-Ctarget-cpu=native" cargo bench -p miden-lifted-stark \
-//!     --bench per_air_degree_opt --features testing,parallel
+//!     --bench per_air_degree_opt --features testing,concurrent
 //! ```
 
 use std::time::Instant;

--- a/stark/miden-lifted-stark/src/prover/constraints/mod.rs
+++ b/stark/miden-lifted-stark/src/prover/constraints/mod.rs
@@ -18,7 +18,7 @@ use p3_field::{
     TwoAdicField,
 };
 use p3_matrix::{Matrix, bitrev::BitReversedMatrixView, dense::RowMajorMatrixView};
-#[cfg(feature = "parallel")]
+#[cfg(feature = "concurrent")]
 use p3_maybe_rayon::prelude::*;
 use packed_row_bitrev::collect_vertically_packed_row_pair_bitrev_into;
 
@@ -243,7 +243,7 @@ pub(super) fn evaluate_constraints_into<F, EF, A>(
         }
     };
 
-    #[cfg(feature = "parallel")]
+    #[cfg(feature = "concurrent")]
     output.par_chunks_mut(points_per_task).enumerate().for_each_init(
         || {
             (
@@ -258,7 +258,7 @@ pub(super) fn evaluate_constraints_into<F, EF, A>(
         },
     );
 
-    #[cfg(not(feature = "parallel"))]
+    #[cfg(not(feature = "concurrent"))]
     {
         let mut main_buf = Vec::<P<F>>::new();
         let mut preproc_buf = Vec::<P<F>>::new();

--- a/stark/miden-lifted-stark/src/testing/params.rs
+++ b/stark/miden-lifted-stark/src/testing/params.rs
@@ -45,7 +45,7 @@ pub const RELATIVE_SPECS: &[&[(usize, usize)]] =
     &[&[(4, 10), (2, 100), (0, 50)], &[(4, 8), (2, 20), (0, 20)], &[(0, 16)]];
 
 /// Label for benchmark group names indicating parallelism mode.
-pub const PARALLEL_STR: &str = if cfg!(feature = "parallel") {
+pub const PARALLEL_STR: &str = if cfg!(feature = "concurrent") {
     "parallel"
 } else {
     "single"


### PR DESCRIPTION
## Describe your changes

Two things:

- rename the `parallel` feature of `miden-lifted-stark` to concurrent to be consistent across the Miden ecosystem and this repo
- make it a default feature. This is to align it with `miden-crypto` and to make it less obvious to miss for downstream users that would need to pull in both `miden-crypto` and `miden-lifted-stark` as dependencies.

## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
