### PR TITLE
fix: validate SMT leaf advice index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - [BREAKING] Rename miden-lifted-stark `parallel` feature to `concurrent` and make it a default one ([#1073](https://github.com/0xMiden/crypto/issues/1073)).
 - Added a zeroizing read helper for deserializing sensitive material, fixing secret-key read buffers that were not wiped on error paths (ECDSA) or at all (Falcon, Poseidon2 AEAD) ([#1057](https://github.com/0xMiden/crypto/pull/1057)).
 - Parallelize aux trace building for faster proving ([#1074](https://github.com/0xMiden/crypto/issues/1074)).
+- Fixed SMT leaf advice decoding by rebuilding decoded entries through `SmtLeaf::new`, so decoded entries must match the supplied leaf index ([#1076](https://github.com/0xMiden/crypto/pull/1076)).
 
 ## 0.27.0 (2026-06-19)
 

--- a/miden-crypto/src/merkle/smt/full/leaf.rs
+++ b/miden-crypto/src/merkle/smt/full/leaf.rs
@@ -249,36 +249,14 @@ impl SmtLeaf {
             ));
         }
 
-        let num_entries = elements.len() / DOUBLE_WORD_LEN;
-
-        if num_entries == 1 {
-            // Single entry.
-            let key = Word::new([elements[0], elements[1], elements[2], elements[3]]);
-            let value = Word::new([elements[4], elements[5], elements[6], elements[7]]);
-            Ok(SmtLeaf::new_single(key, value))
-        } else {
-            // Multiple entries.
-            let mut entries = Vec::with_capacity(num_entries);
-            // Read k/v pairs from each entry.
-            for i in 0..num_entries {
-                let base_idx = i * DOUBLE_WORD_LEN;
-                let key = Word::new([
-                    elements[base_idx],
-                    elements[base_idx + 1],
-                    elements[base_idx + 2],
-                    elements[base_idx + 3],
-                ]);
-                let value = Word::new([
-                    elements[base_idx + 4],
-                    elements[base_idx + 5],
-                    elements[base_idx + 6],
-                    elements[base_idx + 7],
-                ]);
-                entries.push((key, value));
-            }
-            let leaf = SmtLeaf::new_multiple(entries)?;
-            Ok(leaf)
+        let mut entries = Vec::with_capacity(elements.len() / DOUBLE_WORD_LEN);
+        for entry in elements.chunks_exact(DOUBLE_WORD_LEN) {
+            let key = Word::new([entry[0], entry[1], entry[2], entry[3]]);
+            let value = Word::new([entry[4], entry[5], entry[6], entry[7]]);
+            entries.push((key, value));
         }
+
+        SmtLeaf::new(entries, leaf_index)
     }
 
     // HELPERS

--- a/miden-crypto/src/merkle/smt/full/tests.rs
+++ b/miden-crypto/src/merkle/smt/full/tests.rs
@@ -1081,6 +1081,45 @@ fn test_smt_leaf_try_from_elements_invalid_length() {
     assert_matches!(result, Err(SmtLeafError::DecodingError(_)));
 }
 
+/// Tests that `try_from_elements()` rejects a single-entry leaf whose key maps to a different
+/// index than the supplied leaf index.
+#[test]
+fn test_smt_leaf_try_from_elements_rejects_single_entry_index_mismatch() {
+    let leaf = SmtLeaf::new_single(
+        Word::from([10_u32, 11_u32, 12_u32, 13_u32]),
+        Word::from([1_u32, 2_u32, 3_u32, 4_u32]),
+    );
+    let elements: Vec<Felt> = leaf.to_elements().collect();
+    let wrong_leaf_index = LeafIndex::new_max_depth(14);
+
+    let result = SmtLeaf::try_from_elements(&elements, wrong_leaf_index);
+
+    assert_matches!(result, Err(SmtLeafError::InconsistentSingleLeafIndices { .. }));
+}
+
+/// Tests that `try_from_elements()` rejects a multiple-entry leaf whose keys map to a different
+/// index than the supplied leaf index.
+#[test]
+fn test_smt_leaf_try_from_elements_rejects_multiple_entry_index_mismatch() {
+    let leaf = SmtLeaf::new_multiple(vec![
+        (
+            Word::from([10_u32, 11_u32, 12_u32, 13_u32]),
+            Word::from([1_u32, 2_u32, 3_u32, 4_u32]),
+        ),
+        (
+            Word::from([100_u32, 101_u32, 102_u32, 13_u32]),
+            Word::from([11_u32, 12_u32, 13_u32, 14_u32]),
+        ),
+    ])
+    .unwrap();
+    let elements: Vec<Felt> = leaf.to_elements().collect();
+    let wrong_leaf_index = LeafIndex::new_max_depth(14);
+
+    let result = SmtLeaf::try_from_elements(&elements, wrong_leaf_index);
+
+    assert_matches!(result, Err(SmtLeafError::InconsistentMultipleLeafIndices { .. }));
+}
+
 // DUPLICATE KEY DETECTION
 // --------------------------------------------------------------------------------------------
 

--- a/tests/wycheproof/Cargo.toml
+++ b/tests/wycheproof/Cargo.toml
@@ -7,6 +7,9 @@ repository.workspace   = true
 rust-version.workspace = true
 version.workspace      = true
 
+[lib]
+doctest = false
+
 [dev-dependencies]
 ed25519-dalek       = { workspace = true }
 hex                 = { features = ["alloc"], workspace = true }


### PR DESCRIPTION
  This changes `SmtLeaf::try_from_elements` so it rebuilds the leaf through `SmtLeaf::new`. That path checks that every decoded key belongs to the supplied leaf index.
  
Crypto prelude towards fixing 0xmiden/security-issues#25