### PR TITLE
Change ECDSA public key commitments to native coordinates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.28.0 (TBD)
 - [BREAKING] Rename miden-lifted-stark `parallel` feature to `concurrent` and make it a default one ([#1073](https://github.com/0xMiden/crypto/issues/1073)).
+- [BREAKING] Changed ECDSA-k256 public-key commitments to hash native affine-coordinate limbs (`qx || qy`, little-endian `u32` limbs) while keeping compressed SEC1 serialization unchanged ([#1075](https://github.com/0xMiden/crypto/issues/1075)).
 - Added a zeroizing read helper for deserializing sensitive material, fixing secret-key read buffers that were not wiped on error paths (ECDSA) or at all (Falcon, Poseidon2 AEAD) ([#1057](https://github.com/0xMiden/crypto/pull/1057)).
 - Parallelize aux trace building for faster proving ([#1074](https://github.com/0xMiden/crypto/issues/1074)).
 - Fixed SMT leaf advice decoding by rebuilding decoded entries through `SmtLeaf::new`, so decoded entries must match the supplied leaf index ([#1076](https://github.com/0xMiden/crypto/pull/1076)).

--- a/miden-crypto/src/dsa/ecdsa_k256_keccak/mod.rs
+++ b/miden-crypto/src/dsa/ecdsa_k256_keccak/mod.rs
@@ -5,10 +5,11 @@ use alloc::{string::ToString, vec::Vec};
 use core::fmt;
 
 use k256::{
+    AffinePoint,
     ecdh::diffie_hellman,
     ecdsa,
     ecdsa::{RecoveryId, VerifyingKey, signature::hazmat::PrehashVerifier},
-    elliptic_curve::{Generate, scalar::IsHigh},
+    elliptic_curve::{Generate, point::AffineCoordinates, scalar::IsHigh},
     pkcs8::DecodePublicKey,
 };
 use miden_crypto_derive::{SilentDebug, SilentDisplay};
@@ -20,7 +21,7 @@ use crate::{
     ecdh::k256::{EphemeralPublicKey, SharedSecret},
     utils::{
         ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable,
-        bytes_to_packed_u32_elements, read_sensitive_array, zeroize::ZeroizeOnDrop,
+        read_sensitive_array, zeroize::ZeroizeOnDrop,
     },
 };
 
@@ -237,10 +238,16 @@ pub struct PublicKey {
 impl PublicKey {
     /// Returns a commitment to the public key using the Poseidon2 hash function.
     ///
-    /// The commitment is computed by first converting the public key to field elements (4 bytes
-    /// per element), and then computing a sequential hash of the elements.
+    /// Public key serialization remains compressed SEC1. The commitment preimage is not the
+    /// compressed SEC1 encoding; it is `qx || qy`, where each secp256k1 affine coordinate is
+    /// represented as eight little-endian numeric `u32` limbs, one limb per [`Felt`].
     pub fn to_commitment(&self) -> Word {
         <Self as SequentialCommit>::to_commitment(self)
+    }
+
+    /// Returns a reference to this public key as an elliptic curve point in affine coordinates.
+    pub fn as_affine(&self) -> &AffinePoint {
+        self.inner.as_affine()
     }
 
     /// Verifies a signature against this public key and message.
@@ -291,7 +298,7 @@ impl SequentialCommit for PublicKey {
     type Commitment = Word;
 
     fn to_elements(&self) -> Vec<Felt> {
-        bytes_to_packed_u32_elements(&self.to_bytes())
+        affine_point_to_elements(self.as_affine()).to_vec()
     }
 }
 
@@ -465,9 +472,7 @@ impl Deserializable for SecretKey {
 
 impl Serializable for PublicKey {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
-        // Compressed format
         let encoded = self.inner.to_sec1_point(true);
-
         target.write_bytes(encoded.as_bytes());
     }
 }
@@ -521,6 +526,27 @@ impl fmt::Display for Signature {
 
 // HELPER
 // ================================================================================================
+
+fn affine_point_to_elements(point: &AffinePoint) -> [Felt; 16] {
+    let qx = be_bytes_to_le_u32_limbs(point.x().as_ref());
+    let qy = be_bytes_to_le_u32_limbs(point.y().as_ref());
+
+    core::array::from_fn(|idx| {
+        if idx < 8 {
+            Felt::from_u32(qx[idx])
+        } else {
+            Felt::from_u32(qy[idx - 8])
+        }
+    })
+}
+
+fn be_bytes_to_le_u32_limbs(bytes: &[u8]) -> [u32; 8] {
+    debug_assert_eq!(bytes.len(), SCALARS_SIZE_BYTES);
+    core::array::from_fn(|idx| {
+        let start = SCALARS_SIZE_BYTES - 4 * (idx + 1);
+        u32::from_be_bytes(bytes[start..start + 4].try_into().expect("chunk is exactly 4 bytes"))
+    })
+}
 
 /// Hashes a word message using Keccak.
 fn hash_message(message: Word) -> [u8; 32] {

--- a/miden-crypto/src/dsa/ecdsa_k256_keccak/tests.rs
+++ b/miden-crypto/src/dsa/ecdsa_k256_keccak/tests.rs
@@ -1,16 +1,17 @@
 #![cfg(test)]
+
 mod signing_key {
     use alloc::string::{String, ToString};
 
-    use miden_field::Felt;
-    #[cfg(feature = "std")]
-    use miden_field::Word;
+    use k256::elliptic_curve::sec1::ToSec1Point;
+    use miden_field::{Felt, Word};
     #[cfg(feature = "std")]
     use miden_serde_utils::ByteReader;
     use miden_serde_utils::{Deserializable, Serializable};
 
     use crate::{
         dsa::ecdsa_k256_keccak::{PublicKey, Signature, SigningKey},
+        hash::poseidon2::Poseidon2,
         rand::test_utils::seeded_rng,
     };
 
@@ -29,6 +30,23 @@ mod signing_key {
         let pk_bytes = public_key.to_bytes();
         let recovered_pk = PublicKey::read_from_bytes(&pk_bytes).unwrap();
         assert_eq!(public_key, recovered_pk);
+    }
+
+    #[test]
+    fn test_public_key_serialization_uses_compressed_sec1() {
+        let mut rng = seeded_rng([14u8; 32]);
+        let public_key = SigningKey::with_rng(&mut rng).public_key();
+
+        let serialized = public_key.to_bytes();
+        let affine_sec1 = public_key.as_affine().to_sec1_point(true);
+
+        assert_eq!(serialized.len(), 33);
+        assert!(matches!(serialized[0], 0x02 | 0x03));
+        assert_eq!(serialized.as_slice(), affine_sec1.as_bytes());
+
+        let recovered_pk = PublicKey::read_from_bytes(&serialized).unwrap();
+        assert_eq!(public_key, recovered_pk);
+        assert_eq!(public_key.to_string(), canonical_hex(&serialized));
     }
 
     #[test]
@@ -202,6 +220,48 @@ mod signing_key {
             s.push_str(&format!("{byte:02x}"));
         }
         s
+    }
+
+    #[test]
+    fn test_public_key_native_commitment_test_vector() {
+        let mut secret_key_bytes = [0u8; 32];
+        secret_key_bytes[31] = 1;
+        let signing_key = SigningKey::read_from_bytes(&secret_key_bytes).unwrap();
+        let public_key = signing_key.public_key();
+
+        const COMPRESSED_SEC1: [u8; 33] = [
+            0x02, 0x79, 0xbe, 0x66, 0x7e, 0xf9, 0xdc, 0xbb, 0xac, 0x55, 0xa0, 0x62, 0x95, 0xce,
+            0x87, 0x0b, 0x07, 0x02, 0x9b, 0xfc, 0xdb, 0x2d, 0xce, 0x28, 0xd9, 0x59, 0xf2, 0x81,
+            0x5b, 0x16, 0xf8, 0x17, 0x98,
+        ];
+        const NATIVE_ELEMENTS: [Felt; 16] = [
+            Felt::new_unchecked(0x16f81798),
+            Felt::new_unchecked(0x59f2815b),
+            Felt::new_unchecked(0x2dce28d9),
+            Felt::new_unchecked(0x029bfcdb),
+            Felt::new_unchecked(0xce870b07),
+            Felt::new_unchecked(0x55a06295),
+            Felt::new_unchecked(0xf9dcbbac),
+            Felt::new_unchecked(0x79be667e),
+            Felt::new_unchecked(0xfb10d4b8),
+            Felt::new_unchecked(0x9c47d08f),
+            Felt::new_unchecked(0xa6855419),
+            Felt::new_unchecked(0xfd17b448),
+            Felt::new_unchecked(0x0e1108a8),
+            Felt::new_unchecked(0x5da4fbfc),
+            Felt::new_unchecked(0x26a3c465),
+            Felt::new_unchecked(0x483ada77),
+        ];
+        const COMMITMENT: Word = Word::new([
+            Felt::new_unchecked(11823917948314246078),
+            Felt::new_unchecked(15960174880805474786),
+            Felt::new_unchecked(15208912687411787098),
+            Felt::new_unchecked(1636772189670681504),
+        ]);
+
+        assert_eq!(public_key.to_bytes(), COMPRESSED_SEC1);
+        assert_eq!(public_key.to_commitment(), Poseidon2::hash_elements(&NATIVE_ELEMENTS));
+        assert_eq!(public_key.to_commitment(), COMMITMENT);
     }
 
     #[cfg(feature = "std")]


### PR DESCRIPTION
## Summary
- Keep compressed SEC1 public key serialization unchanged.
- Change ECDSA public-key commitments to Poseidon2 over native affine qx/qy little-endian u32 limbs.
- Expose PublicKey::as_affine() and add serialization/commitment regression tests, including a concrete generator-point vector.

Addresses #1075.

## Validation
- cargo test -p miden-crypto ecdsa_k256_keccak
- cargo check -p miden-crypto --no-default-features
- cargo fmt --check (stable rustfmt emits warnings for nightly-only config options)
