### PR TITLE
feat: make `Felt::from_{u8, u16, u32}` const

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.27.1 (TBD)
+
+- Made `Felt::from_{u8, u16, u32}` const and added `Felt::MAX` ([#1081](https://github.com/0xMiden/crypto/pull/1081)).
+
 ## 0.27.0 (2026-06-19)
 
 - [BREAKING] Upgraded the RustCrypto and dalek stack: `der`, `hkdf`, `sha2`, `sha3`, `k256`, `curve25519-dalek`, `ed25519-dalek`, and `x25519-dalek` ([#1045](https://github.com/0xMiden/crypto/pull/1045)).

--- a/miden-field/src/native/mod.rs
+++ b/miden-field/src/native/mod.rs
@@ -63,6 +63,9 @@ impl Felt {
     pub const ZERO: Self = Self(Goldilocks::ZERO);
     pub const ONE: Self = Self(Goldilocks::ONE);
 
+    /// The largest valid field element, equal to `ORDER - 1`.
+    pub const MAX: Self = Self::new_unchecked(Self::ORDER - 1);
+
     /// The number of bytes which this field element occupies in memory.
     pub const NUM_BYTES: usize = Goldilocks::NUM_BYTES;
 
@@ -84,19 +87,22 @@ impl Felt {
         Self(Goldilocks::new(value))
     }
 
+    /// Constructs a field element from a `u8`.
     #[inline]
-    pub fn from_u8(value: u8) -> Self {
-        <Self as PrimeCharacteristicRing>::from_u8(value)
+    pub const fn from_u8(value: u8) -> Self {
+        Self::new_unchecked(value as u64)
     }
 
+    /// Constructs a field element from a `u16`.
     #[inline]
-    pub fn from_u16(value: u16) -> Self {
-        <Self as PrimeCharacteristicRing>::from_u16(value)
+    pub const fn from_u16(value: u16) -> Self {
+        Self::new_unchecked(value as u64)
     }
 
+    /// Constructs a field element from a `u32`.
     #[inline]
-    pub fn from_u32(value: u32) -> Self {
-        <Self as PrimeCharacteristicRing>::from_u32(value)
+    pub const fn from_u32(value: u32) -> Self {
+        Self::new_unchecked(value as u64)
     }
 
     /// The elementary function `double(a) = 2*a`.

--- a/miden-field/src/native/tests.rs
+++ b/miden-field/src/native/tests.rs
@@ -319,3 +319,28 @@ fn felt_try_from_u64_fails_on_large_inputs() {
     Felt::try_from(u64::MAX).unwrap_err();
     Felt::try_from(Felt::ORDER).unwrap_err();
 }
+
+/// Ensures the `const` integer constructors produce the same element as the
+/// `PrimeCharacteristicRing` trait methods.
+#[test]
+fn const_constructors_match_trait() {
+    for value in [u8::MIN, 1, u8::MAX] {
+        assert_eq!(Felt::from_u8(value), <Felt as PrimeCharacteristicRing>::from_u8(value));
+    }
+
+    for value in [u16::MIN, 1, 12345, u16::MAX] {
+        assert_eq!(Felt::from_u16(value), <Felt as PrimeCharacteristicRing>::from_u16(value));
+    }
+
+    for value in [u32::MIN, 1, 12345, u32::MAX] {
+        assert_eq!(Felt::from_u32(value), <Felt as PrimeCharacteristicRing>::from_u32(value));
+    }
+}
+
+/// Ensures `Felt::MAX` is the largest canonical element, i.e. `ORDER - 1` (equivalently `-1`).
+#[test]
+fn felt_max() {
+    assert_eq!(Felt::MAX.as_canonical_u64(), Felt::ORDER - 1);
+    // The maximum element is `-1`, so adding one wraps around to zero.
+    assert_eq!(Felt::MAX + Felt::ONE, Felt::ZERO);
+}


### PR DESCRIPTION
## Describe your changes

Makes `Felt::from_{u8, u16, u32}` const so one doesn't (always) need to use `new_unchecked` in `const` contexts, which is the only alternative. This helps with https://github.com/0xMiden/protocol/issues/2934.

Also adds `Felt::MAX` for consistency with primitive number types, e.g. `u16::MAX`.

Targets `main` since the changes are non-breaking.

## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
