### PR TITLE
Use stable k256 on next

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1057,9 +1057,9 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.14.0-rc.15"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ce7f1aa9a24c53c6572d8017c8c1ceb5d44c6071ff68c9912860fa4d262101"
+checksum = "93f50113171a713f4a4231ef82eb26703607139b35dcb56241f0ceab2ae1f7d8"
 dependencies = [
  "cpubits",
  "ecdsa",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,7 @@ flume               = { default-features = false, version = "0.12.0" }
 hex                 = { default-features = false, version = "0.4" }
 hkdf                = { default-features = false, version = "0.13" }
 itertools           = "0.15"
-k256                = { default-features = false, version = "0.14.0-rc.15" }
+k256                = { default-features = false, version = "0.14" }
 num                 = { default-features = false, version = "0.4" }
 num-complex         = { default-features = false, version = "0.4" }
 once_cell           = { default-features = false, version = "1.21" }

--- a/miden-crypto-fuzz/Cargo.lock
+++ b/miden-crypto-fuzz/Cargo.lock
@@ -470,9 +470,9 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.14.0-rc.15"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ce7f1aa9a24c53c6572d8017c8c1ceb5d44c6071ff68c9912860fa4d262101"
+checksum = "93f50113171a713f4a4231ef82eb26703607139b35dcb56241f0ceab2ae1f7d8"
 dependencies = [
  "cpubits",
  "ecdsa",


### PR DESCRIPTION
Cleans up the rc versions away.