### PR TITLE
Expose Arbitrary impls behind feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.29.0 (TBD)
 
+- Added `arbitrary` features to expose proptest `Arbitrary` implementations without enabling broader testing features ([#1091](https://github.com/0xMiden/crypto/pull/1091)).
 - Updated `miden-bench` Keccak trace summaries to report padded trace rows separately from active Keccak rows ([#1065](https://github.com/0xMiden/crypto/pull/1065)).
 
 ## 0.28.0 (2026-07-03)

--- a/miden-crypto/Cargo.toml
+++ b/miden-crypto/Cargo.toml
@@ -80,6 +80,7 @@ name              = "transpose"
 required-features = ["std"]
 
 [features]
+arbitrary         = ["dep:proptest", "miden-field/arbitrary"]
 concurrent        = ["dep:rayon", "miden-lifted-stark/concurrent", "p3-maybe-rayon/parallel", "p3-util/parallel", "std"]
 default           = ["concurrent", "std"]
 executable        = ["concurrent", "dep:clap"]
@@ -89,7 +90,7 @@ persistent-forest = ["rocksdb", "serde"]
 rocksdb           = ["concurrent", "dep:rocksdb"]
 serde             = ["dep:serde", "serde?/alloc"]
 std               = ["blake3/std", "dep:cc", "miden-serde-utils/std", "once_cell/std", "rand/std", "rand/thread_rng", "serde?/std"]
-testing           = ["dep:proptest", "miden-field/testing"]
+testing           = ["arbitrary"]
 
 [dependencies]
 # Miden dependencies

--- a/miden-crypto/src/merkle/sparse_path.rs
+++ b/miden-crypto/src/merkle/sparse_path.rs
@@ -448,6 +448,58 @@ fn path_depth_iter(tree_depth: u8) -> impl ExactSizeIterator<Item = NonZero<u8>>
     top_down_iter.rev()
 }
 
+// ARBITRARY (proptest)
+// ================================================================================================
+
+#[cfg(any(test, feature = "arbitrary"))]
+mod arbitrary {
+    use proptest::prelude::*;
+
+    use super::{MerklePath, SparseMerklePath};
+    use crate::{Word, merkle::smt::SMT_MAX_DEPTH};
+
+    impl Arbitrary for MerklePath {
+        type Parameters = ();
+        type Strategy = BoxedStrategy<Self>;
+
+        fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
+            prop::collection::vec(any::<Word>(), 0..=SMT_MAX_DEPTH as usize)
+                .prop_map(MerklePath::new)
+                .boxed()
+        }
+    }
+
+    impl Arbitrary for SparseMerklePath {
+        type Parameters = ();
+        type Strategy = BoxedStrategy<Self>;
+
+        fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
+            (0..=SMT_MAX_DEPTH as usize)
+                .prop_flat_map(|depth| {
+                    let max_mask = if depth > 0 && depth < 64 {
+                        (1u64 << depth) - 1
+                    } else if depth == 64 {
+                        u64::MAX
+                    } else {
+                        0
+                    };
+                    let empty_nodes_mask =
+                        prop::num::u64::ANY.prop_map(move |mask| mask & max_mask);
+
+                    empty_nodes_mask.prop_flat_map(move |mask| {
+                        let empty_count = mask.count_ones() as usize;
+                        let non_empty_count = depth.saturating_sub(empty_count);
+
+                        prop::collection::vec(any::<Word>(), non_empty_count).prop_map(
+                            move |nodes| SparseMerklePath::from_parts(mask, nodes).unwrap(),
+                        )
+                    })
+                })
+                .boxed()
+        }
+    }
+}
+
 // TESTS
 // ================================================================================================
 #[cfg(test)]
@@ -634,51 +686,6 @@ mod tests {
     }
 
     use proptest::prelude::*;
-
-    // Arbitrary instance for MerklePath
-    impl Arbitrary for MerklePath {
-        type Parameters = ();
-        type Strategy = BoxedStrategy<Self>;
-
-        fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
-            prop::collection::vec(any::<Word>(), 0..=SMT_MAX_DEPTH as usize)
-                .prop_map(MerklePath::new)
-                .boxed()
-        }
-    }
-
-    // Arbitrary instance for SparseMerklePath
-    impl Arbitrary for SparseMerklePath {
-        type Parameters = ();
-        type Strategy = BoxedStrategy<Self>;
-
-        fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
-            (0..=SMT_MAX_DEPTH as usize)
-                .prop_flat_map(|depth| {
-                    // Generate a bitmask for empty nodes - avoid overflow
-                    let max_mask = if depth > 0 && depth < 64 {
-                        (1u64 << depth) - 1
-                    } else if depth == 64 {
-                        u64::MAX
-                    } else {
-                        0
-                    };
-                    let empty_nodes_mask =
-                        prop::num::u64::ANY.prop_map(move |mask| mask & max_mask);
-
-                    // Generate non-empty nodes based on the mask
-                    empty_nodes_mask.prop_flat_map(move |mask| {
-                        let empty_count = mask.count_ones() as usize;
-                        let non_empty_count = depth.saturating_sub(empty_count);
-
-                        prop::collection::vec(any::<Word>(), non_empty_count).prop_map(
-                            move |nodes| SparseMerklePath::from_parts(mask, nodes).unwrap(),
-                        )
-                    })
-                })
-                .boxed()
-        }
-    }
 
     proptest! {
         #[test]

--- a/miden-field/Cargo.toml
+++ b/miden-field/Cargo.toml
@@ -34,8 +34,9 @@ serde                   = { default-features = false, features = ["derive"], ver
 subtle                  = { default-features = false, version = "2.6" }
 
 [features]
-default = []
-testing = ["dep:proptest"]
+arbitrary = ["dep:proptest"]
+default   = []
+testing   = ["arbitrary"]
 
 [dev-dependencies]
 proptest = { features = ["alloc", "std"], workspace = true }

--- a/miden-field/src/native/mod.rs
+++ b/miden-field/src/native/mod.rs
@@ -699,7 +699,7 @@ impl Deserializable for Felt {
 // ARBITRARY (proptest)
 // ================================================================================================
 
-#[cfg(all(any(test, feature = "testing"), not(all(target_family = "wasm", miden))))]
+#[cfg(all(any(test, feature = "arbitrary"), not(all(target_family = "wasm", miden))))]
 mod arbitrary {
     use proptest::prelude::*;
 

--- a/miden-field/src/word/mod.rs
+++ b/miden-field/src/word/mod.rs
@@ -774,7 +774,7 @@ macro_rules! word {
 // ARBITRARY (proptest)
 // ================================================================================================
 
-#[cfg(all(any(test, feature = "testing"), not(all(target_family = "wasm", miden))))]
+#[cfg(all(any(test, feature = "arbitrary"), not(all(target_family = "wasm", miden))))]
 mod arbitrary {
     use proptest::prelude::*;
 


### PR DESCRIPTION
Closes #1071 #1072 — allows dependent crates to better use arbitrary impls (without bringing in other testing stuff).